### PR TITLE
Time validation on datasets

### DIFF
--- a/hera_pspec/pspecdata.py
+++ b/hera_pspec/pspecdata.py
@@ -86,9 +86,16 @@ class PSpecData(object):
         assert len(self.dsets) > 1
         assert len(self.dsets) == len(self.wgts)
 
-        # Check if data are all the same shape
+        # Check if data are all the same shape along freq axis
         Nfreqs = [d.Nfreqs for d in self.dsets]
-        assert np.unique(Nfreqs).size == 1
+        if np.unique(Nfreqs).size > 1:
+            raise ValueError("all dsets must have the same Nfreqs")
+
+        # Check shape along time axis
+        Ntimes = [d.Ntimes for d in self.dsets]
+        if np.unique(Ntimes).size > 1:
+            raise ValueError("all dsets must have the same Ntimes")
+
 
     def clear_cov_cache(self, keys=None):
         """

--- a/hera_pspec/tests/test_pspecdata.py
+++ b/hera_pspec/tests/test_pspecdata.py
@@ -80,8 +80,12 @@ taper_selection = ['blackman'] #,'blackman-harris','gaussian0.4','kaiser2',\
 class Test_DataSet(unittest.TestCase):
 
     def setUp(self):
+        # setup empty PSpecData
         self.ds = pspecdata.PSpecData()
-        pass
+
+        # read in miriad file
+        self.uvd = uv.UVData()
+        self.uvd.read_miriad(os.path.join(DATA_PATH, 'zen.2458042.12552.xx.HH.uvXAA'))
 
     def tearDown(self):
         pass
@@ -98,6 +102,16 @@ class Test_DataSet(unittest.TestCase):
 
     def test_add_data(self):
         pass
+
+    def test_validate_datasets(self):
+        # test freq exception
+        uvd2 = self.uvd.select(frequencies=np.unique(self.uvd.freq_array)[:10], inplace=False)
+        ds = pspecdata.PSpecData(dsets=[self.uvd, uvd2], wgts=[None, None])
+        nt.assert_raises(ValueError, ds.validate_datasets)
+        # test time exception
+        uvd2 = self.uvd.select(times=np.unique(self.uvd.time_array)[:10], inplace=False)
+        ds = pspecdata.PSpecData(dsets=[self.uvd, uvd2], wgts=[None, None])
+        nt.assert_raises(ValueError, ds.validate_datasets)
 
     def test_get_Q(self):
         vect_length = 50

--- a/hera_pspec/tests/test_pspecdata.py
+++ b/hera_pspec/tests/test_pspecdata.py
@@ -312,11 +312,11 @@ class Test_DataSet(unittest.TestCase):
         self.assertTrue(np.allclose(f_mat,
                         np.identity(data.Nfreqs).astype(complex),
                         rtol=tolerance,
-                        atol=tolerance)
+                        atol=tolerance))
         self.assertTrue(np.allclose(f_mat_true,
                                     np.identity(data.Nfreqs).astype(complex),
                                     rtol=tolerance,
-                                    atol=tolerance)
+                                    atol=tolerance))
         #TODO: Need a test case for some kind of taper.
 
 


### PR DESCRIPTION
Validation of time axes of input dsets should be checked in `PSpecData.validate_datasets`. otherwise, this leads to a less-informative numpy broadcasting error further downstream..