### PR TITLE
Fixed bugs in pspecbeam

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,6 @@ env/
 dist/
 eggs/
 *.eggs/
-
+*egg-info
+*GIT_INFO
 

--- a/hera_pspec/pspecbeam.py
+++ b/hera_pspec/pspecbeam.py
@@ -149,7 +149,7 @@ class PSpecBeamGauss(PSpecBeamBase):
                 in h^-3 Mpc^3 or Mpc^3.
         """
 
-        integration_freqs = np.linspace(lower_freq, upper_freq, num_steps, endpoint=True)
+        integration_freqs = np.linspace(lower_freq, upper_freq, num_steps, endpoint=False)
         integration_freqs_MHz = integration_freqs / 10**6 # The interpolations are generally more stable in MHz
         redshifts = self.conversion.f2z(integration_freqs).flatten()
         X2Y = np.array(map(lambda z: self.conversion.X2Y(z,little_h=little_h),redshifts))
@@ -299,7 +299,7 @@ class PSpecBeamUV(PSpecBeamBase):
                 in h^-3 Mpc^3 or Mpc^3.
         """
 
-        integration_freqs = np.linspace(lower_freq, upper_freq, num_steps, endpoint=True)
+        integration_freqs = np.linspace(lower_freq, upper_freq, num_steps, endpoint=False)
         integration_freqs_MHz = integration_freqs / 10**6 # The interpolations are generally more stable in MHz
         redshifts = self.conversion.f2z(integration_freqs).flatten()
         X2Y = np.array(map(lambda z: self.conversion.X2Y(z,little_h=little_h),redshifts))

--- a/hera_pspec/pspecbeam.py
+++ b/hera_pspec/pspecbeam.py
@@ -7,7 +7,7 @@ from scipy.interpolate import interp1d
 import aipy
 
 
-def _compute_pspec_scalar(cosmo, beam_freqs, omega_ratio, pspec_freqs, num_steps=20000,
+def _compute_pspec_scalar(cosmo, beam_freqs, omega_ratio, pspec_freqs, num_steps=5000,
                           stokes='pseudo_I', taper='none', little_h=True):
     """
     This is not to be used by the novice user to calculate a pspec scalar.

--- a/hera_pspec/pspecdata.py
+++ b/hera_pspec/pspecdata.py
@@ -666,7 +666,7 @@ g
             return delay * 1e9 # convert to ns
     
     
-    def scalar(self, stokes='I', taper='none', little_h=True, num_steps=10000):
+    def scalar(self, stokes='I', taper='none', little_h=True, num_steps=20000):
         """
         Computes the scalar function to convert a power spectrum estimate
         in "telescope units" to cosmological units
@@ -702,9 +702,9 @@ g
                 [\int dnu (\Omega_PP / \Omega_P^2) ( B_PP / B_P^2 ) / (X^2 Y)]^-1
                 in h^-3 Mpc^3 or Mpc^3.
         """
-        scalar = self.primary_beam.compute_pspec_scalar(\
-                self.freqs[0],self.freqs[-1],self.Nfreqs,\
-                stokes,taper,little_h,num_steps)
+        scalar = self.primary_beam.compute_pspec_scalar(self.freqs[0], self.freqs[-1], stokes=stokes,
+                                                        taper=taper, little_h=litle_h, num_steps=num_steps)
+
         return scalar
 
     def pspec(self, bls, beam=None, input_data_weight='identity', norm='I', 

--- a/hera_pspec/pspecdata.py
+++ b/hera_pspec/pspecdata.py
@@ -666,7 +666,7 @@ g
             return delay * 1e9 # convert to ns
     
     
-    def scalar(self, stokes='I', taper='none', little_h=True, num_steps=20000):
+    def scalar(self, stokes='I', taper='none', little_h=True, num_steps=2000):
         """
         Computes the scalar function to convert a power spectrum estimate
         in "telescope units" to cosmological units
@@ -702,7 +702,7 @@ g
                 [\int dnu (\Omega_PP / \Omega_P^2) ( B_PP / B_P^2 ) / (X^2 Y)]^-1
                 in h^-3 Mpc^3 or Mpc^3.
         """
-        scalar = self.primary_beam.compute_pspec_scalar(self.freqs[0], self.freqs[-1], stokes=stokes,
+        scalar = self.primary_beam.compute_pspec_scalar(self.freqs[0], self.freqs[-1], len(self.freqs), stokes=stokes,
                                                         taper=taper, little_h=little_h, num_steps=num_steps)
 
         return scalar

--- a/hera_pspec/pspecdata.py
+++ b/hera_pspec/pspecdata.py
@@ -703,7 +703,7 @@ g
                 in h^-3 Mpc^3 or Mpc^3.
         """
         scalar = self.primary_beam.compute_pspec_scalar(self.freqs[0], self.freqs[-1], stokes=stokes,
-                                                        taper=taper, little_h=litle_h, num_steps=num_steps)
+                                                        taper=taper, little_h=little_h, num_steps=num_steps)
 
         return scalar
 

--- a/hera_pspec/tests/test_pspecbeam.py
+++ b/hera_pspec/tests/test_pspecbeam.py
@@ -3,18 +3,28 @@ import nose.tools as nt
 import numpy as np
 import pyuvdata as uv
 from hera_pspec import pspecbeam
+from hera_pspec.data import DATA_PATH
 
-# Get absolute path to data directory
-DATADIR = os.path.dirname( os.path.realpath(__file__) ) + "/../data/"
+
+class Example(unittest.TestCase):
+    """
+    when running tests in this file by-hand in an interactive interpreter, 
+    instantiate this example class as
+
+    self = Example()
+
+    and you can copy-paste self.assert* calls interactively.
+    """
+    def runTest(self):
+        pass
 
 
 class Test_DataSet(unittest.TestCase):
 
     def setUp(self):
-        beamfile = DATADIR + 'NF_HERA_Beams.beamfits'
+        beamfile = os.path.join(DATA_PATH, 'NF_HERA_Beams.beamfits')
         self.bm = pspecbeam.PSpecBeamUV(beamfile)
-        self.gauss = pspecbeam.PSpecBeamGauss(0.8, np.linspace(120e6, 128e6, 50))
-        pass
+        self.gauss = pspecbeam.PSpecBeamGauss(0.8, np.linspace(115e6, 130e6, 50, endpoint=False))
 
     def tearDown(self):
         pass
@@ -23,9 +33,8 @@ class Test_DataSet(unittest.TestCase):
         pass
 
     def test_init(self):
-        beamfile = DATADIR + 'NF_HERA_Beams.beamfits'
+        beamfile = os.path.join(DATA_PATH, 'NF_HERA_Beams.beamfits')
         bm = pspecbeam.PSpecBeamUV(beamfile)
-        pass
 
     def test_UVbeam(self):
         # Precomputed results in the following tests were done "by hand" using 
@@ -34,9 +43,7 @@ class Test_DataSet(unittest.TestCase):
         Om_pp = self.bm.power_beam_sq_int()
         lower_freq = 120.*10**6
         upper_freq = 128.*10**6
-        num_freqs = 50
-        scalar = self.bm.compute_pspec_scalar(lower_freq, upper_freq, 
-                                              num_freqs, stokes='pseudo_I')
+        scalar = self.bm.compute_pspec_scalar(lower_freq, upper_freq, stokes='pseudo_I', num_steps=50000)
 
         # Check array dimensionality
         self.assertEqual(Om_p.ndim, 1)
@@ -44,12 +51,10 @@ class Test_DataSet(unittest.TestCase):
 
         # Check that errors are raised for other Stokes parameters
         for stokes in ['Q', 'U', 'V', 'Z']:
-            nt.assert_raises(NotImplementedError, self.bm.power_beam_int, 
-                             stokes=stokes)
-            nt.assert_raises(NotImplementedError, self.bm.power_beam_sq_int, 
-                             stokes=stokes)
+            nt.assert_raises(NotImplementedError, self.bm.power_beam_int, stokes=stokes)
+            nt.assert_raises(NotImplementedError, self.bm.power_beam_sq_int, stokes=stokes)
             nt.assert_raises(NotImplementedError, self.bm.compute_pspec_scalar, 
-                             lower_freq, upper_freq, num_freqs, stokes=stokes)
+                             lower_freq, upper_freq, stokes=stokes)
 
         self.assertAlmostEqual(Om_p[0], 0.078694909518866998)
         self.assertAlmostEqual(Om_p[18], 0.065472512282419112)
@@ -59,26 +64,22 @@ class Test_DataSet(unittest.TestCase):
         self.assertAlmostEqual(Om_pp[24], 0.024137903003171767)
         self.assertAlmostEqual(Om_pp[-1], 0.013178952686690554)
 
-        self.assertAlmostEqual(scalar/10**5, 567834117.162/10**5)
+        self.assertAlmostEqual(scalar/567862539.59197414, 1.0, delta=1e-4)
         
         # convergence of integral
-        scalar_double_steps = self.bm.compute_pspec_scalar(lower_freq, 
-                                        upper_freq, num_freqs, num_steps=20000) 
-        
-        # assertAlmostEqual does absolute comparisons, so we want to put things 
-        # on a sensible scale
-        scalar /= 10**9
-        scalar_double_steps /= 10**9
-        self.assertAlmostEqual(scalar, scalar_double_steps)
+        scalar_large_Nsteps = self.bm.compute_pspec_scalar(lower_freq, upper_freq, stokes='pseudo_I', num_steps=100000) 
+        self.assertAlmostEqual(scalar / scalar_large_Nsteps, 1.0, delta=1e-5)
+
+        # test taper execution
+        scalar = self.bm.compute_pspec_scalar(lower_freq, upper_freq, taper='blackman')
 
     def test_Gaussbeam(self):
         Om_p = self.gauss.power_beam_int()
         Om_pp = self.gauss.power_beam_sq_int()
         lower_freq = 120.*10**6
         upper_freq = 128.*10**6
-        num_freqs = 50
-        scalar = self.gauss.compute_pspec_scalar(lower_freq, upper_freq, 
-                                                 num_freqs, stokes='pseudo_I')
+        scalar = self.gauss.compute_pspec_scalar(lower_freq, upper_freq, stokes='pseudo_I', num_steps=50000)
+
         # Check array dimensionality
         self.assertEqual(Om_p.ndim,1)
         self.assertEqual(Om_pp.ndim,1)
@@ -91,7 +92,7 @@ class Test_DataSet(unittest.TestCase):
                              self.gauss.power_beam_sq_int, stokes=stokes)
             nt.assert_raises(NotImplementedError, 
                              self.gauss.compute_pspec_scalar, 
-                             lower_freq, upper_freq, num_freqs, stokes=stokes)
+                             lower_freq, upper_freq, stokes=stokes)
 
         self.assertAlmostEqual(Om_p[4], 0.7251776226923511)
         self.assertAlmostEqual(Om_p[4], Om_p[0])
@@ -99,14 +100,12 @@ class Test_DataSet(unittest.TestCase):
         self.assertAlmostEqual(Om_pp[4], 0.36258881134617554)
         self.assertAlmostEqual(Om_pp[4], Om_pp[0])
 
-        self.assertAlmostEqual(scalar/10**5, 6392750121.05/10**5)
+        self.assertAlmostEqual(scalar/6392626346.1433468, 1.0, delta=1e-4)
         
         # convergence of integral
-        scalar_double_steps = self.gauss.compute_pspec_scalar(lower_freq, 
-                                        upper_freq, num_freqs, num_steps=20000) 
-        # assertAlmostEqual does absolute comparisons, so we want to put things 
-        # on a sensible scale
-        scalar /= 10**9
-        scalar_double_steps /= 10**9
-        self.assertAlmostEqual(scalar, scalar_double_steps)
+        scalar_large_Nsteps = self.gauss.compute_pspec_scalar(lower_freq, upper_freq, num_steps=100000)
+        self.assertAlmostEqual(scalar / scalar_large_Nsteps, 1.0, delta=1e-5)
+
+        # test taper execution
+        scalar = self.bm.compute_pspec_scalar(lower_freq, upper_freq, taper='blackman')
 

--- a/hera_pspec/tests/test_pspecbeam.py
+++ b/hera_pspec/tests/test_pspecbeam.py
@@ -73,6 +73,7 @@ class Test_DataSet(unittest.TestCase):
 
         # test taper execution
         scalar = self.bm.compute_pspec_scalar(lower_freq, upper_freq, num_freqs, num_steps=5000, taper='blackman')
+        self.assertAlmostEqual(scalar / 1793248694.8873105, 1.0, delta=1e-8)
 
     def test_Gaussbeam(self):
         Om_p = self.gauss.power_beam_int()
@@ -109,5 +110,6 @@ class Test_DataSet(unittest.TestCase):
         self.assertAlmostEqual(scalar / scalar_large_Nsteps, 1.0, delta=1e-5)
 
         # test taper execution
-        scalar = self.bm.compute_pspec_scalar(lower_freq, upper_freq, num_freqs, num_steps=2000, taper='blackman')
+        scalar = self.gauss.compute_pspec_scalar(lower_freq, upper_freq, num_freqs, num_steps=5000, taper='blackman')
+        self.assertAlmostEqual(scalar / 19974901797.178055, 1.0, delta=1e-8)
 

--- a/hera_pspec/tests/test_pspecbeam.py
+++ b/hera_pspec/tests/test_pspecbeam.py
@@ -43,7 +43,8 @@ class Test_DataSet(unittest.TestCase):
         Om_pp = self.bm.power_beam_sq_int()
         lower_freq = 120.*10**6
         upper_freq = 128.*10**6
-        scalar = self.bm.compute_pspec_scalar(lower_freq, upper_freq, stokes='pseudo_I', num_steps=50000)
+        num_freqs = 20
+        scalar = self.bm.compute_pspec_scalar(lower_freq, upper_freq, num_freqs, stokes='pseudo_I', num_steps=2000)
 
         # Check array dimensionality
         self.assertEqual(Om_p.ndim, 1)
@@ -54,7 +55,7 @@ class Test_DataSet(unittest.TestCase):
             nt.assert_raises(NotImplementedError, self.bm.power_beam_int, stokes=stokes)
             nt.assert_raises(NotImplementedError, self.bm.power_beam_sq_int, stokes=stokes)
             nt.assert_raises(NotImplementedError, self.bm.compute_pspec_scalar, 
-                             lower_freq, upper_freq, stokes=stokes)
+                             lower_freq, upper_freq, num_freqs, stokes=stokes)
 
         self.assertAlmostEqual(Om_p[0], 0.078694909518866998)
         self.assertAlmostEqual(Om_p[18], 0.065472512282419112)
@@ -64,21 +65,22 @@ class Test_DataSet(unittest.TestCase):
         self.assertAlmostEqual(Om_pp[24], 0.024137903003171767)
         self.assertAlmostEqual(Om_pp[-1], 0.013178952686690554)
 
-        self.assertAlmostEqual(scalar/567862539.59197414, 1.0, delta=1e-4)
+        self.assertAlmostEqual(scalar/544745630.76776004, 1.0, delta=1e-4)
         
         # convergence of integral
-        scalar_large_Nsteps = self.bm.compute_pspec_scalar(lower_freq, upper_freq, stokes='pseudo_I', num_steps=100000) 
+        scalar_large_Nsteps = self.bm.compute_pspec_scalar(lower_freq, upper_freq, num_freqs, stokes='pseudo_I', num_steps=10000) 
         self.assertAlmostEqual(scalar / scalar_large_Nsteps, 1.0, delta=1e-5)
 
         # test taper execution
-        scalar = self.bm.compute_pspec_scalar(lower_freq, upper_freq, taper='blackman')
+        scalar = self.bm.compute_pspec_scalar(lower_freq, upper_freq, num_freqs, num_steps=5000, taper='blackman')
 
     def test_Gaussbeam(self):
         Om_p = self.gauss.power_beam_int()
         Om_pp = self.gauss.power_beam_sq_int()
         lower_freq = 120.*10**6
         upper_freq = 128.*10**6
-        scalar = self.gauss.compute_pspec_scalar(lower_freq, upper_freq, stokes='pseudo_I', num_steps=50000)
+        num_freqs = 20
+        scalar = self.gauss.compute_pspec_scalar(lower_freq, upper_freq, num_freqs, stokes='pseudo_I', num_steps=2000)
 
         # Check array dimensionality
         self.assertEqual(Om_p.ndim,1)
@@ -92,7 +94,7 @@ class Test_DataSet(unittest.TestCase):
                              self.gauss.power_beam_sq_int, stokes=stokes)
             nt.assert_raises(NotImplementedError, 
                              self.gauss.compute_pspec_scalar, 
-                             lower_freq, upper_freq, stokes=stokes)
+                             lower_freq, upper_freq, num_freqs, stokes=stokes)
 
         self.assertAlmostEqual(Om_p[4], 0.7251776226923511)
         self.assertAlmostEqual(Om_p[4], Om_p[0])
@@ -100,12 +102,12 @@ class Test_DataSet(unittest.TestCase):
         self.assertAlmostEqual(Om_pp[4], 0.36258881134617554)
         self.assertAlmostEqual(Om_pp[4], Om_pp[0])
 
-        self.assertAlmostEqual(scalar/6392626346.1433468, 1.0, delta=1e-4)
+        self.assertAlmostEqual(scalar/6082814757.7556648, 1.0, delta=1e-4)
         
         # convergence of integral
-        scalar_large_Nsteps = self.gauss.compute_pspec_scalar(lower_freq, upper_freq, num_steps=100000)
+        scalar_large_Nsteps = self.gauss.compute_pspec_scalar(lower_freq, upper_freq, num_freqs, num_steps=5000)
         self.assertAlmostEqual(scalar / scalar_large_Nsteps, 1.0, delta=1e-5)
 
         # test taper execution
-        scalar = self.bm.compute_pspec_scalar(lower_freq, upper_freq, taper='blackman')
+        scalar = self.bm.compute_pspec_scalar(lower_freq, upper_freq, num_freqs, num_steps=2000, taper='blackman')
 


### PR DESCRIPTION
There are a few bugs in `pspecbeam` I found while fixing one particular bug. These include

1. All `np.linspace()` calls should have `endpoint=False`, which is actually my fault for the confusion from the previous PR where I said the opposite.

2. `aipy` is not loaded in the module even though there is an `aipy` dependence when using a `taper` kwarg that is non-default.

3. `num_freqs` directly clashes with `num_steps`, which causes a broadcasting error when specifying a non-default `taper`. `num_freqs` is otherwise not used, so it is eliminated from the module.

4. With the above updates, the pspec scalar convergence test does not actually converge at only 20000 num_steps for some reason, not even close, even though this test was passing before. Not sure why this is the case, but I did a benchmark and the calculation accuracy is hindered by the `interp1d` call, which defaults to linear interpolation. Simply changing this to quadratic interpolation improved the accuracy of the scalar calculation and sped it up slightly, such that it now converges to an error of 1e-5 at 50000 steps, which is the new default.

5. `compute_pspec_scalar()` is duplicated in both `PSpecBeamGauss` and `PSpecBeamUV`. I understand why this was probably done, because the beam integrals are different for the two objects, but code duplication should be avoided at all costs. A nice way we get around this in `hera_cal` is to outsource the core functionality to a more agnostic, module-level function, which is then called by each class in a way that suits them. I did this here for `compute_pspec_scalar`. This is also nice b/c you may want to use this core functionality on your own without having to instantiate one of these objects.. say you have a beam that isn't gaussian or a pyuvdata object.

6. in general there were some pep8 issues, although not technically bugs. also I added some more comments to the code where I thought necessary.

7. lastly, I updated some of the testing for the module