### PR TITLE
added Jy_to_mK conversion method to pspecbeam

### DIFF
--- a/hera_pspec/conversions.py
+++ b/hera_pspec/conversions.py
@@ -40,6 +40,15 @@ class units:
     w21 = 0.211061140542  # 21cm wavelength in meters
     H0_to_SI = 3.24078e-20 # km s-1 Mpc-1 to s-1
 
+
+class cgs_units:
+    """
+    fundamental constants in ** CGS ** units
+    """
+    c = 2.99702453e10  # cm s-1
+    kb = 1.38064e-16  # erg K-1
+
+
 class Cosmo_Conversions(object):
     """
     Cosmo_Conversions class for mathematical conversion functions,

--- a/hera_pspec/conversions.py
+++ b/hera_pspec/conversions.py
@@ -45,8 +45,8 @@ class cgs_units:
     """
     fundamental constants in ** CGS ** units
     """
-    c = 2.99702453e10  # cm s-1
-    kb = 1.38064e-16  # erg K-1
+    c = 2.99792458e10  # cm s-1
+    kb = 1.38064852e-16  # erg K-1
 
 
 class Cosmo_Conversions(object):

--- a/hera_pspec/pspecbeam.py
+++ b/hera_pspec/pspecbeam.py
@@ -186,8 +186,12 @@ class PSpecBeamBase(object):
         -------
         M : float ndarray, contains Jy -> mK factor at each frequency
         """
-        if isinstance(freqs, (int, np.float, float)):
+        if isinstance(freqs, (np.float, float)):
             freqs = np.array([freqs])
+        elif not isinstance(freqs, np.ndarray):
+            raise TypeError("freqs must be fed as a float ndarray")
+        elif isinstance(freqs, np.ndarray) and freqs.dtype not in (float, np.float, np.float64):
+            raise TypeError("freqs must be fed as a float ndarray")
         if np.min(freqs) < self.beam_freqs.min(): print "Warning: min freq {} < self.beam_freqs.min(), extrapolating...".format(np.min(freqs))
         if np.max(freqs) > self.beam_freqs.max(): print "Warning: max freq {} > self.beam_freqs.max(), extrapolating...".format(np.max(freqs))
 

--- a/hera_pspec/tests/test_conversions.py
+++ b/hera_pspec/tests/test_conversions.py
@@ -12,7 +12,6 @@ class Test_Cosmo(unittest.TestCase):
     def setUp(self):
         self.C = conversions.Cosmo_Conversions(Om_L=0.68440, Om_b=0.04911, Om_c=0.26442, H0=100.0,
                                                Om_M=None, Om_k=None)
-
     def tearDown(self):
         pass
 
@@ -28,6 +27,12 @@ class Test_Cosmo(unittest.TestCase):
         # test parameters get fed to class
         C = conversions.Cosmo_Conversions(H0=25.5)
         self.assertAlmostEqual(C.H0, 25.5)
+
+    def test_units(self):
+        si = conversions.units()
+        cgs = conversions.cgs_units()
+        nt.assert_almost_equal(si.c, 2.99792458e8)
+        nt.assert_almost_equal(cgs.c, 2.99792458e10)
 
     def test_distances(self):
         self.assertAlmostEqual(self.C.f2z(100e6), 13.20405751)

--- a/hera_pspec/tests/test_pspecbeam.py
+++ b/hera_pspec/tests/test_pspecbeam.py
@@ -75,6 +75,12 @@ class Test_DataSet(unittest.TestCase):
         scalar = self.bm.compute_pspec_scalar(lower_freq, upper_freq, num_freqs, num_steps=5000, taper='blackman')
         self.assertAlmostEqual(scalar / 1793248694.8873105, 1.0, delta=1e-8)
 
+        # test Jy_to_mK
+        M = self.bm.Jy_to_mK(np.linspace(100e6, 200e6, 11))
+        nt.assert_equal(len(M), 11)
+        nt.assert_almost_equal(M[0], 41.33552971)
+        M = self.bm.Jy_to_mK(120e6)
+
     def test_Gaussbeam(self):
         Om_p = self.gauss.power_beam_int()
         Om_pp = self.gauss.power_beam_sq_int()

--- a/hera_pspec/tests/test_pspecbeam.py
+++ b/hera_pspec/tests/test_pspecbeam.py
@@ -78,8 +78,9 @@ class Test_DataSet(unittest.TestCase):
         # test Jy_to_mK
         M = self.bm.Jy_to_mK(np.linspace(100e6, 200e6, 11))
         nt.assert_equal(len(M), 11)
-        nt.assert_almost_equal(M[0], 41.33552971)
-        M = self.bm.Jy_to_mK(120e6)
+        nt.assert_almost_equal(M[0], 41.360105524572283)
+        M = self.bm.Jy_to_mK(99e6)
+        M = self.bm.Jy_to_mK(201)
 
     def test_Gaussbeam(self):
         Om_p = self.gauss.power_beam_int()

--- a/hera_pspec/tests/test_pspecbeam.py
+++ b/hera_pspec/tests/test_pspecbeam.py
@@ -80,7 +80,11 @@ class Test_DataSet(unittest.TestCase):
         nt.assert_equal(len(M), 11)
         nt.assert_almost_equal(M[0], 41.360105524572283)
         M = self.bm.Jy_to_mK(99e6)
-        M = self.bm.Jy_to_mK(201)
+        M = self.bm.Jy_to_mK(201e6)
+        # test exception
+        nt.assert_raises(TypeError, self.bm.Jy_to_mK, [1])
+        nt.assert_raises(TypeError, self.bm.Jy_to_mK, np.array([1]))
+
 
     def test_Gaussbeam(self):
         Om_p = self.gauss.power_beam_int()


### PR DESCRIPTION
for converting visibilities on a Jy scale to units of mK. Although ideally this would be done for us in the calibration step, in actuality the analysis team has no plan to give us visibilities on a mK scale, and also we developed the framework for calculating beam scalars in `hera_pspec` (which `hera_cal` does not have), so it makes sense for this conversion factor to go here...