### PR TITLE
Fix extra taper fnc get q

### DIFF
--- a/hera_pspec/pspecdata.py
+++ b/hera_pspec/pspecdata.py
@@ -479,14 +479,14 @@ class PSpecData(object):
             # Slow method, used to explicitly cross-check FFT code
             q = []
             for i in xrange(self.spw_Nfreqs):
-                Q = self.get_Q(i, self.spw_Nfreqs, taper=taper)
+                Q = self.get_Q(i, self.spw_Nfreqs)
                 RQR = np.einsum('ab,bc,cd',
                                 self.R(key1).T.conj(), Q, self.R(key2))
                 qi = np.sum(self.x(key1).conj()*np.dot(RQR, self.x(key2)), axis=0)
                 q.append(qi)
             return 0.5 * np.array(q)
 
-    def get_G(self, key1, key2, taper='none'):
+    def get_G(self, key1, key2):
         """
         Calculates the response matrix G of the unnormalized band powers q
         to the true band powers p, i.e.,
@@ -509,10 +509,6 @@ class PSpecData(object):
             input datavectors. If a list of tuples is provided, the baselines 
             in the list will be combined with inverse noise weights.
 
-        taper : str, optional
-            Tapering (window) function used when calculating Q. Takes the same
-            arguments as aipy.dsp.gen_window(). Default: 'none'.
-
         Returns
         -------
         G : array_like, complex
@@ -524,7 +520,7 @@ class PSpecData(object):
 
         iR1Q, iR2Q = {}, {}
         for ch in xrange(self.spw_Nfreqs): # this loop is nchan^3
-            Q = self.get_Q(ch, self.spw_Nfreqs, taper=taper)
+            Q = self.get_Q(ch, self.spw_Nfreqs)
             iR1Q[ch] = np.dot(R1, Q) # R_1 Q
             iR2Q[ch] = np.dot(R2, Q) # R_2 Q
 
@@ -653,7 +649,7 @@ class PSpecData(object):
         M /= norm; W = np.dot(M, G)
         return M, W
 
-    def get_Q(self, mode, n_k, taper='none'):
+    def get_Q(self, mode, n_k):
         """
         Response of the covariance to a given bandpower, dC / dp_alpha.
 
@@ -673,10 +669,6 @@ class PSpecData(object):
         n_k : int
             Number of k bins that will be .
 
-        taper : str, optional
-            Type of tapering (window) function to use. Valid options are any
-            window function supported by aipy.dsp.gen_window(). Default: 'none'.
-
         Returns
         -------
         Q : array_like
@@ -685,8 +677,8 @@ class PSpecData(object):
         _m = np.zeros((n_k,), dtype=np.complex)
         _m[mode] = 1. # delta function at specific delay mode
 
-        # FFT to transform to frequency space, and apply window function
-        m = np.fft.fft(np.fft.ifftshift(_m)) * aipy.dsp.gen_window(n_k, taper)
+        # FFT to transform to frequency space
+        m = np.fft.fft(np.fft.ifftshift(_m))
         Q = np.einsum('i,j', m, m.conj()) # dot it with its conjugate
         return Q
 

--- a/hera_pspec/pspecdata.py
+++ b/hera_pspec/pspecdata.py
@@ -799,13 +799,15 @@ class PSpecData(object):
         """
         # set spw_range and get freqs
         freqs = self.freqs[self.spw_range[0]:self.spw_range[1]]
+        start = freqs[0]
+        end = freqs[0] + np.median(np.diff(freqs)) * len(freqs)
 
         # calculate scalar
         if beam is None:
-            scalar = self.primary_beam.compute_pspec_scalar(freqs[0], freqs[-1], len(freqs), stokes=stokes,
+            scalar = self.primary_beam.compute_pspec_scalar(start, end, len(freqs), stokes=stokes,
                                                             taper=taper, little_h=little_h, num_steps=num_steps)
         else:
-            scalar = beam.compute_pspec_scalar(freqs[0], freqs[-1], len(freqs), stokes=stokes,
+            scalar = beam.compute_pspec_scalar(start, end, len(freqs), stokes=stokes,
                                                             taper=taper, little_h=little_h, num_steps=num_steps)
 
         return scalar

--- a/hera_pspec/pspecdata.py
+++ b/hera_pspec/pspecdata.py
@@ -476,13 +476,22 @@ class PSpecData(object):
             return 0.5 * np.conj(  np.fft.fftshift(_Rx1, axes=0).conj() 
                                  * np.fft.fftshift(_Rx2, axes=0) )
         else:
+            # get taper if provided
+            if taper != 'none':
+                tapering_fct = aipy.dsp.gen_window(self.spw_Nfreqs, taper)
+
             # Slow method, used to explicitly cross-check FFT code
             q = []
             for i in xrange(self.spw_Nfreqs):
                 Q = self.get_Q(i, self.spw_Nfreqs)
                 RQR = np.einsum('ab,bc,cd',
                                 self.R(key1).T.conj(), Q, self.R(key2))
-                qi = np.sum(self.x(key1).conj()*np.dot(RQR, self.x(key2)), axis=0)
+                x1 = self.x(key1).conj()
+                x2 = self.x(key2)
+                if taper != 'none':
+                    x1 *= tapering_fct
+                    x2 *= tapering_fct
+                qi = np.sum(x1*np.dot(RQR, x2), axis=0)
                 q.append(qi)
             return 0.5 * np.array(q)
 

--- a/hera_pspec/pspecdata.py
+++ b/hera_pspec/pspecdata.py
@@ -1069,7 +1069,7 @@ class PSpecData(object):
                         pass
                     else:
                         if verbose: print("  Building G...")
-                        Gv = self.get_G(key1, key2, taper=taper)
+                        Gv = self.get_G(key1, key2)
                         built_G = True
 
                     # Calculate unnormalized bandpowers

--- a/hera_pspec/pspecdata.py
+++ b/hera_pspec/pspecdata.py
@@ -489,8 +489,8 @@ class PSpecData(object):
                 x1 = self.x(key1).conj()
                 x2 = self.x(key2)
                 if taper != 'none':
-                    x1 *= tapering_fct
-                    x2 *= tapering_fct
+                    x1 = x1 * tapering_fct[:, None]
+                    x2 = x2 * tapering_fct[:, None]
                 qi = np.sum(x1*np.dot(RQR, x2), axis=0)
                 q.append(qi)
             return 0.5 * np.array(q)

--- a/hera_pspec/tests/test_pspecbeam.py
+++ b/hera_pspec/tests/test_pspecbeam.py
@@ -114,7 +114,7 @@ class Test_DataSet(unittest.TestCase):
         self.assertAlmostEqual(Om_pp[4], 0.36258881134617554)
         self.assertAlmostEqual(Om_pp[4], Om_pp[0])
 
-        self.assertAlmostEqual(scalar/6082814757.7556648, 1.0, delta=1e-4)
+        self.assertAlmostEqual(scalar/6392750120.8657961, 1.0, delta=1e-4)
         
         # convergence of integral
         scalar_large_Nsteps = self.gauss.compute_pspec_scalar(lower_freq, upper_freq, num_freqs, num_steps=5000)
@@ -122,5 +122,5 @@ class Test_DataSet(unittest.TestCase):
 
         # test taper execution
         scalar = self.gauss.compute_pspec_scalar(lower_freq, upper_freq, num_freqs, num_steps=5000, taper='blackman')
-        self.assertAlmostEqual(scalar / 19974901797.178055, 1.0, delta=1e-8)
+        self.assertAlmostEqual(scalar / 22123832163.072491, 1.0, delta=1e-8)
 

--- a/hera_pspec/tests/test_pspecbeam.py
+++ b/hera_pspec/tests/test_pspecbeam.py
@@ -65,7 +65,7 @@ class Test_DataSet(unittest.TestCase):
         self.assertAlmostEqual(Om_pp[24], 0.024137903003171767)
         self.assertAlmostEqual(Om_pp[-1], 0.013178952686690554)
 
-        self.assertAlmostEqual(scalar/544745630.76776004, 1.0, delta=1e-4)
+        self.assertAlmostEqual(scalar/567871703.75268996, 1.0, delta=1e-4)
         
         # convergence of integral
         scalar_large_Nsteps = self.bm.compute_pspec_scalar(lower_freq, upper_freq, num_freqs, stokes='pseudo_I', num_steps=10000) 
@@ -73,7 +73,7 @@ class Test_DataSet(unittest.TestCase):
 
         # test taper execution
         scalar = self.bm.compute_pspec_scalar(lower_freq, upper_freq, num_freqs, num_steps=5000, taper='blackman')
-        self.assertAlmostEqual(scalar / 1793248694.8873105, 1.0, delta=1e-8)
+        self.assertAlmostEqual(scalar / 1986172241.1760113, 1.0, delta=1e-8)
 
         # test Jy_to_mK
         M = self.bm.Jy_to_mK(np.linspace(100e6, 200e6, 11))

--- a/hera_pspec/tests/test_pspecdata.py
+++ b/hera_pspec/tests/test_pspecdata.py
@@ -219,7 +219,7 @@ class Test_PSpecData(unittest.TestCase):
                 self.assertEqual(q_hat_a.shape, (Nfreq, Ntime))
                 
                 # Check that swapping x_1 <-> x_2 results in complex conj. only
-                q_hat_b = self.ds.q_hat(key2, key1)
+                q_hat_b = self.ds.q_hat(key2, key1, taper=taper)
                 q_hat_diff = np.conjugate(q_hat_a) - q_hat_b
                 for i in range(Nfreq):
                     for j in range(Ntime):
@@ -229,9 +229,9 @@ class Test_PSpecData(unittest.TestCase):
                                                q_hat_diff[i,j].imag)
                 
                 # Check that lists of keys are handled properly
-                q_hat_aa = self.ds.q_hat(key1, key4) # q_hat(k1, k2+k2)
-                q_hat_bb = self.ds.q_hat(key4, key1) # q_hat(k2+k2, k1)
-                q_hat_cc = self.ds.q_hat(key3, key4) # q_hat(k1+k1, k2+k2)
+                q_hat_aa = self.ds.q_hat(key1, key4, taper=taper) # q_hat(k1, k2+k2)
+                q_hat_bb = self.ds.q_hat(key4, key1, taper=taper) # q_hat(k2+k2, k1)
+                q_hat_cc = self.ds.q_hat(key3, key4, taper=taper) # q_hat(k1+k1, k2+k2)
                 
                 # Effectively checks that q_hat(2*k1, 2*k2) = 4*q_hat(k1, k2)
                 for i in range(Nfreq):
@@ -243,16 +243,8 @@ class Test_PSpecData(unittest.TestCase):
                 
                 # Check that the slow method is the same as the FFT method
                 q_hat_a_slow = self.ds.q_hat(key1, key2, use_fft=False, taper=taper)
-                vector_scale = np.min([ np.min(np.abs(q_hat_a_slow.real)), 
-                                        np.min(np.abs(q_hat_a_slow.imag)) ])
-                for i in range(Nfreq):
-                    for j in range(Ntime):
-                        self.assertLessEqual(
-                                np.abs((q_hat_a[i,j] - q_hat_a_slow[i,j]).real), 
-                                vector_scale*1e-6 )
-                        self.assertLessEqual(
-                                np.abs((q_hat_a[i,j] - q_hat_a_slow[i,j]).imag), 
-                                vector_scale*1e-6 )
+                self.assertTrue(np.isclose(np.real(q_hat_a/q_hat_a_slow), 1).all())
+                self.assertTrue(np.isclose(np.imag(q_hat_a/q_hat_a_slow), 0, atol=1e-6).all())
 
     def test_get_G(self):
         """

--- a/hera_pspec/tests/test_pspecdata.py
+++ b/hera_pspec/tests/test_pspecdata.py
@@ -264,12 +264,12 @@ class Test_PSpecData(unittest.TestCase):
 
         for input_data_weight in ['identity','iC']:
             for taper in taper_selection:
-                print 'input_data_weight', input_data_weight, 'taper', taper
+                print 'input_data_weight', input_data_weight
                 self.ds.set_R(input_data_weight)
                 key1 = (0, 24, 38)
                 key2 = (1, 25, 38)
 
-                G = self.ds.get_G(key1, key2, taper=taper)
+                G = self.ds.get_G(key1, key2)
                 self.assertEqual(G.shape, (Nfreq,Nfreq)) # Test shape
                 print np.min(np.abs(G)), np.min(np.abs(np.linalg.eigvalsh(G)))
                 matrix_scale = np.min(np.abs(np.linalg.eigvalsh(G)))
@@ -292,7 +292,7 @@ class Test_PSpecData(unittest.TestCase):
                     # same test as the symmetry test, but perhaps there are
                     # creative ways to break the code to break one test but not
                     # the other.
-                    G_swapped = self.ds.get_G(key2, key1, taper=taper)
+                    G_swapped = self.ds.get_G(key2, key1)
                     G_diff_norm = np.linalg.norm(G - G_swapped)
                     self.assertLessEqual(G_diff_norm, 
                                         matrix_scale * multiplicative_tolerance)
@@ -309,7 +309,7 @@ class Test_PSpecData(unittest.TestCase):
                     # In general, when R_1 != R_2, there is a more restricted 
                     # symmetry where swapping R_1 and R_2 *and* taking the 
                     # transpose gives the same result
-                    G_swapped = self.ds.get_G(key2, key1, taper=taper)
+                    G_swapped = self.ds.get_G(key2, key1)
                     G_diff_norm = np.linalg.norm(G - G_swapped.T)
                     self.assertLessEqual(G_diff_norm, 
                                          matrix_scale * multiplicative_tolerance)

--- a/hera_pspec/tests/test_pspecdata.py
+++ b/hera_pspec/tests/test_pspecdata.py
@@ -16,7 +16,7 @@ dfiles = [
 ]
 
 # List of tapering function to use in tests
-taper_selection = ['blackman',]
+taper_selection = ['none', 'blackman',]
 #taper_selection = ['blackman', 'blackman-harris', 'gaussian0.4', 'kaiser2',
 #                   'kaiser3', 'hamming', 'hanning', 'parzen']
 
@@ -215,7 +215,7 @@ class Test_PSpecData(unittest.TestCase):
             for taper in taper_selection:
                 
                 # Calculate q_hat for a pair of baselines and test output shape
-                q_hat_a = self.ds.q_hat(key1, key2)
+                q_hat_a = self.ds.q_hat(key1, key2, taper=taper)
                 self.assertEqual(q_hat_a.shape, (Nfreq, Ntime))
                 
                 # Check that swapping x_1 <-> x_2 results in complex conj. only
@@ -242,7 +242,7 @@ class Test_PSpecData(unittest.TestCase):
                                                0.25 * q_hat_cc[i,j].imag)
                 
                 # Check that the slow method is the same as the FFT method
-                q_hat_a_slow = self.ds.q_hat(key1, key2, use_fft=False)
+                q_hat_a_slow = self.ds.q_hat(key1, key2, use_fft=False, taper=taper)
                 vector_scale = np.min([ np.min(np.abs(q_hat_a_slow.real)), 
                                         np.min(np.abs(q_hat_a_slow.imag)) ])
                 for i in range(Nfreq):


### PR DESCRIPTION
there were two calls to a tapering function in `pspecdata`, one in `get_Q` which is applied to the `Q` FT matrix, and another in `q_hat` which is applied directly to the data. Eliminating the one in `get_Q` makes OQE match the results Aaron P and I cooked up a few weeks ago, meaning that with these pushes I think OQE is properly normalized! 

Comparison with w/o tapering function (before fix)
![oqe_comp_notaper](https://user-images.githubusercontent.com/4307358/38463045-b3399932-3aa5-11e8-9f1e-dc6199c7d143.png)

Comparison with tapering function (before fix)
![oqe_comp_taper](https://user-images.githubusercontent.com/4307358/38463053-d47753fa-3aa5-11e8-812f-1674b7fc82fd.png)

Comparison with tapering function (after fix, title should read `fix_extra_taper_fnc_get_Q`, not `master`)
![oqe_comp_taper_noq](https://user-images.githubusercontent.com/4307358/38463049-c36142d8-3aa5-11e8-9172-0a6caa499411.png)
