### PR TITLE
Add ability to name datasets in PSpecData

### DIFF
--- a/hera_pspec/pspecdata.py
+++ b/hera_pspec/pspecdata.py
@@ -1357,15 +1357,18 @@ class PSpecData(object):
         uvp.taper = taper
         uvp.norm = norm
         uvp.git_hash = version.git_hash
+        
         if self.primary_beam is not None:
             uvp.cosmo_params = str(self.primary_beam.cosmo.get_params())
         if self.primary_beam is not None and hasattr(self.primary_beam, 'filename'): 
             uvp.beamfile = self.primary_beam.filename
-        if hasattr(dset1.extra_keywords, 'filename'): uvp.filename1 = dset1.extra_keywords['filename']
-        if hasattr(dset2.extra_keywords, 'filename'): uvp.filename2 = dset2.extra_keywords['filename']
-        if hasattr(dset1.extra_keywords, 'tag'): uvp.tag1 = dset1.extra_keywords['tag']
-        if hasattr(dset2.extra_keywords, 'tag'): uvp.tag2 = dset2.extra_keywords['tag']
-
+        if hasattr(dset1.extra_keywords, 'filename'):
+            uvp.filename1 = dset1.extra_keywords['filename']
+        if hasattr(dset2.extra_keywords, 'filename'): 
+            uvp.filename2 = dset2.extra_keywords['filename']
+        uvp.label1 = self.labels[dset1]
+        uvp.label2 = self.labels[dset2]
+        
         # fill data arrays
         uvp.data_array = data_array
         uvp.integration_array = integration_array

--- a/hera_pspec/pspecdata.py
+++ b/hera_pspec/pspecdata.py
@@ -13,27 +13,34 @@ import operator
 
 class PSpecData(object):
 
-    def __init__(self, dsets=[], wgts=[], beam=None):
+    def __init__(self, dsets=[], wgts=[], labels=None, beam=None):
         """
         Object to store multiple sets of UVData visibilities and perform
         operations such as power spectrum estimation on them.
 
         Parameters
         ----------
-        dsets : List of UVData objects, optional
-            List of UVData objects containing the data that will be used to
-            compute the power spectrum. Default: Empty list.
+        dsets : list or dict of UVData objects, optional
+            Set of UVData objects containing the data that will be used to
+            compute the power spectrum. If specified as a dict, the key names 
+            will be used to tag each dataset. Default: Empty list.
 
-        wgts : List of UVData objects, optional
-            List of UVData objects containing weights for the input data.
+        wgts : list or dict of UVData objects, optional
+            Set of UVData objects containing weights for the input data.
             Default: Empty list.
-
+        
+        labels : list of str, optional
+            An ordered list of names/labels for each dataset, if dsets was 
+            specified as a list. If None, names will not be assigned to the 
+            datasets. If dsets was specified as a dict, the keys 
+            of that dict will be used instead of this. Default: None.
+        
         beam : PspecBeam object, optional
             PspecBeam object containing information about the primary beam
             Default: None.
         """
         self.clear_cov_cache()  # Covariance matrix cache
-        self.dsets = []; self.wgts = []
+        self.dsets = []; self.wgts = []; self.labels = []
         self.Nfreqs = None
         self.spw_range = None
         self.spw_Nfreqs = None
@@ -43,29 +50,53 @@ class PSpecData(object):
 
         # Store the input UVData objects if specified
         if len(dsets) > 0:
-            self.add(dsets, wgts)
+            self.add(dsets, wgts, labels=labels)
 
         # Store a primary beam
         self.primary_beam = beam
 
-    def add(self, dsets, wgts):
+    def add(self, dsets, wgts, labels=None):
         """
         Add a dataset to the collection in this PSpecData object.
 
         Parameters
         ----------
-        dsets : UVData or list
+        dsets : UVData or list or dict
             UVData object or list of UVData objects containing data to add to
             the collection.
 
-        wgts : UVData or list
+        wgts : UVData or list or dict
             UVData object or list of UVData objects containing weights to add
             to the collection. Must be the same length as dsets. If a weight is
             set to None, the flags of the corresponding
+        
+        labels : list of str
+            An ordered list of names/labels for each dataset, if dsets was 
+            specified as a list. If dsets was specified as a dict, the keys 
+            of that dict will be used instead.
         """
+        # Check for dicts and unpack into an ordered list if found
+        if isinstance(dsets, dict):
+            # Disallow labels kwarg if a dict was passed
+            if labels is not None:
+                raise ValueError("If 'dsets' is a dict, 'labels' cannot be "
+                                 "specified.")
+            
+            if not isinstance(wgts, dict):
+                raise TypeError("If 'dsets' is a dict, 'wgts' must also be "
+                                "a dict")
+            
+            # Unpack dsets and wgts dicts
+            labels = dsets.keys()
+            _dsets = [dsets[key] for key in labels]
+            _wgts = [wgts[key] for key in labels]
+            dsets = _dsets
+            wgts = _wgts
+            
         # Convert input args to lists if possible
         if isinstance(dsets, pyuvdata.UVData): dsets = [dsets,]
         if isinstance(wgts, pyuvdata.UVData): wgts = [wgts,]
+        if isinstance(labels, str): labels = [labels,]
         if wgts is None: wgts = [wgts,]
         if isinstance(dsets, tuple): dsets = list(dsets)
         if isinstance(wgts, tuple): wgts = list(wgts)
@@ -76,6 +107,7 @@ class PSpecData(object):
 
         # Make sure enough weights were specified
         assert(len(dsets) == len(wgts))
+        if labels is not None: assert(len(dsets) == len(labels))
 
         # Check that everything is a UVData object
         for d, w in zip(dsets, wgts):
@@ -88,6 +120,12 @@ class PSpecData(object):
         # Append to list
         self.dsets += dsets
         self.wgts += wgts
+        
+        # Store labels (if they were set)
+        if labels is None:
+            self.labels = [None for d in dsets]
+        else:
+            self.labels += labels
 
         # Store no. frequencies and no. times
         self.Nfreqs = self.dsets[0].Nfreqs
@@ -97,6 +135,27 @@ class PSpecData(object):
         self.freqs = self.dsets[0].freq_array[0]
         self.spw_range = (0, self.Nfreqs)
         self.spw_Nfreqs = self.Nfreqs
+    
+    
+    def __str__(self):
+        """
+        Print basic info about this PSpecData object.
+        """
+        # Basic info
+        s = "PSpecData object\n"
+        s += "  %d datasets" % len(self.dsets)
+        if len(self.dsets) == 0: return s
+        
+        # Dataset summary
+        for i, d in enumerate(self.dsets):
+            if self.labels[i] is None:
+                s += "  dset (%d): %d bls (freqs=%d, times=%d, pols=%d)\n" \
+                      % (i, d.Nbls, d.Nfreqs, d.Ntimes, d.Npols)
+            else:
+                s += "  dset '%s' (%d): %d bls (freqs=%d, times=%d, pols=%d)\n" \
+                      % (self.labels[i], i, d.Nbls, d.Nfreqs, d.Ntimes, d.Npols)
+        return s
+        
         
     def validate_datasets(self, verbose=True):
         """
@@ -149,7 +208,8 @@ class PSpecData(object):
             max_diff_dec = np.max(map(lambda d: np.diff(d), itertools.combinations(phase_dec, 2)))
             max_diff = np.sqrt(max_diff_ra**2 + max_diff_dec**2)
             if max_diff > 0.15: raise_warning("Warning: maximum phase-center difference between datasets is > 10 arcmin", verbose=verbose)
-
+    
+    
     def check_key_in_dset(self, key, dset_ind):
         """
         Check 'key' exists in the UVData object self.dsets[dset_ind]
@@ -168,6 +228,9 @@ class PSpecData(object):
         exists : bool
             True if the key exists, False otherwise
         """
+        #FIXME: Fix this to enable label keys
+        
+        
         # get iterable
         key = pyuvdata.utils.get_iterable(key)
         if isinstance(key, str):
@@ -206,7 +269,75 @@ class PSpecData(object):
                 except(KeyError): pass
                 try: del(self._iC[k])
                 except(KeyError): pass
-
+    
+    def dset_idx(self, dset):
+        """
+        Return the index of a dataset, regardless of whether it was specified 
+        as an integer of a string.
+        
+        Parameters
+        ----------
+        dset : int or str
+            Index or name of a dataset belonging to this PSpecData object.
+        
+        Returns
+        -------
+        dset_idx : int
+            Index of dataset.
+        """
+        # Look up dset label if it's a string
+        if isinstance(dset, str):
+            if dset in self.labels:
+                return self.labels.index(dset)
+            else:
+                raise KeyError("dset '%s' not found." % dset)
+        elif isinstance(dset, int):
+            return dset
+        else:
+            raise TypeError("dset must be either an int or string")
+    
+    
+    def blkey(self, dset, bl=None, pol=None):
+        """
+        Return a key specifying a particular dataset, baseline, and 
+        (optionally) polarization, in the tuple format used by other methods 
+        of PSpecData.
+        
+        Parameters
+        ----------
+        dset : int or str
+            Index or name of a dataset belonging to this PSpecData object.
+        
+        bl : tuple, optional
+            Baseline ID, specified as a tuple of antenna pairs, e.g. (10, 11). 
+            Default: None.
+        
+        pol : str, optional
+            Polarization of the visibility, in linear (e.g. 'xx') or Stokes 
+            (e.g. 'I') notation, whatever is supported by the input UVData 
+            objects. Default: None (polarization will not be included).
+        
+        Returns
+        -------
+        key : tuple
+            Tuple containing dataset ID, baseline index (if specified), and 
+            polarization (if specified).
+        """
+        key = ()
+        
+        # Look up dset label if it's a string
+        dset_idx = self.dset_idx(dset)
+        key += (dset_idx,)
+                
+        # Add the baseline tuple if it was specified
+        if bl is None: return key
+        key += (bl,)
+        
+        # Polarization
+        if pol is not None: key += (pol,)
+        return key
+        
+    
     def x(self, key):
         """
         Get data for a given dataset and baseline, as specified in a standard
@@ -216,8 +347,8 @@ class PSpecData(object):
         ----------
         key : tuple
             Tuple containing dataset ID and baseline index. The first element
-            of the tuple is the dataset index, and the subsequent elements are
-            the baseline ID.
+            of the tuple is the dataset index (or label), and the subsequent 
+            elements are the baseline ID.
 
         Returns
         -------
@@ -225,8 +356,9 @@ class PSpecData(object):
             Array of data from the requested UVData dataset and baseline.
         """
         assert isinstance(key, tuple)
-        dset = key[0]; bl = key[1:]
-        return self.dsets[dset].get_data(bl).T[self.spw_range[0]:self.spw_range[1], :] # FIXME: Transpose?
+        dset, bl = self.blkey(dset=key[0], bl=key[1:])
+        spwmin, spwmax = self.spw_range[0], self.spw_range[1]
+        return self.dsets[dset].get_data(bl).T[spwmin:spwmax, :]
 
     def w(self, key):
         """
@@ -246,13 +378,15 @@ class PSpecData(object):
             Array of weights for the requested UVData dataset and baseline.
         """
         assert isinstance(key, tuple)
-        dset = key[0]; bl = key[1:]
+        spwrange = self.spw_range
+        dset, bl = self.blkey(dset=key[0], bl=key[1:])
+        
         if self.wgts[dset] is not None:
-            return self.wgts[dset].get_data(bl).T[self.spw_range[0]:self.spw_range[1], :] # FIXME: Transpose?
+            return self.wgts[dset].get_data(bl).T[spwrange[0]:spwrange[1], :]
         else:
             # If weights were not specified, use the flags built in to the
             # UVData dataset object
-            flags = self.dsets[dset].get_flags(bl).astype(float).T[self.spw_range[0]:self.spw_range[1], :]
+            flags = self.dsets[dset].get_flags(bl).astype(float).T[spwrange[0]:spwrange[1], :]
             return 1. - flags # Flag=1 => weight=0
 
     def C(self, key):
@@ -272,6 +406,8 @@ class PSpecData(object):
             (Weighted) empirical covariance of data for baseline 'bl'.
         """
         assert isinstance(key, tuple)
+        key = (self.dset_idx(key[0]),) + key[1:]  # Sanitize dataset name
+        
         # Set covariance if it's not in the cache
         if not self._C.has_key(key):
             self.set_C( {key : utils.cov(self.x(key), self.w(key))} )
@@ -313,6 +449,8 @@ class PSpecData(object):
             Empirical covariance for the specified key.
         """
         assert isinstance(key, tuple)
+        key = (self.dset_idx(key[0]),) + key[1:]  # Sanitize dataset name
+        
         # Check cache for empirical covariance
         if not self._Cempirical.has_key(key):
             self._Cempirical[key] = utils.cov(self.x(key), self.w(key))
@@ -335,6 +473,7 @@ class PSpecData(object):
             Identity covariance matrix, dimension (Nfreqs, Nfreqs).
         """
         assert isinstance(key, tuple)
+        key = (self.dset_idx(key[0]),) + key[1:]  # Sanitize dataset name
 
         if not self._I.has_key(key):
             self._I[key] = np.identity(self.spw_Nfreqs)
@@ -357,6 +496,8 @@ class PSpecData(object):
             Inverse covariance matrix for specified dataset and baseline.
         """
         assert isinstance(key, tuple)
+        key = (self.dset_idx(key[0]),) + key[1:]  # Sanitize dataset name
+        
         # Calculate inverse covariance if not in cache
         if not self._iC.has_key(key):
             C = self.C(key)
@@ -396,14 +537,13 @@ class PSpecData(object):
             If set to "iC", sets R = C^-1
             Otherwise, accepts a user inputted dictionary
         """
-
         if R_matrix == "identity":
             self.R = self.I
         elif R_matrix == "iC":
             self.R = self.iC
         else:
             self.R = R_matrix
-
+    
     def set_spw(self, spw_range):
         """
         Set the spectral window range
@@ -413,8 +553,10 @@ class PSpecData(object):
         spw_range : tuple, contains start and end of spw in channel indices
             used to slice the frequency array
         """
-        assert isinstance(spw_range, tuple), "spw_range must be fed as a len-2 integer tuple"
-        assert isinstance(spw_range[0], (int, np.int)), "spw_range must be fed as len-2 integer tuple"
+        assert isinstance(spw_range, tuple), \
+            "spw_range must be fed as a len-2 integer tuple"
+        assert isinstance(spw_range[0], (int, np.int)), \
+            "spw_range must be fed as len-2 integer tuple"
         self.spw_range = spw_range
         self.spw_Nfreqs = spw_range[1] - spw_range[0]
 
@@ -744,7 +886,8 @@ class PSpecData(object):
     def delays(self):
         """
         Return an array of delays, tau, corresponding to the bins of the delay 
-        power spectrum output by pspec() using self.spw_range to specify the spectral window.
+        power spectrum output by pspec() using self.spw_range to specify the 
+        spectral window.
         
         Returns
         -------
@@ -757,12 +900,13 @@ class PSpecData(object):
                              "calculate delays.")
         else:
             return utils.get_delays(self.freqs[self.spw_range[0]:self.spw_range[1]]) * 1e9 # convert to ns    
-    
-    
-    def scalar(self, pol='I', taper='none', little_h=True, num_steps=2000, beam=None):
+        
+    def scalar(self, pol='I', taper='none', little_h=True, 
+               num_steps=2000, beam=None):
         """
         Computes the scalar function to convert a power spectrum estimate
-        in "telescope units" to cosmological units, using self.spw_range to set spectral window.
+        in "telescope units" to cosmological units, using self.spw_range to set 
+        spectral window.
 
         See arxiv:1304.4991 and HERA memo #27 for details.
 
@@ -788,7 +932,8 @@ class PSpecData(object):
                 Default: 10000
 
         beam : PSpecBeam object
-            Option to use a manually-fed PSpecBeam object instead of using self.primary_beam.
+            Option to use a manually-fed PSpecBeam object instead of using 
+            self.primary_beam.
 
         Returns
         -------
@@ -804,9 +949,9 @@ class PSpecData(object):
         # calculate scalar
         if beam is None:
             scalar = self.primary_beam.compute_pspec_scalar(
-                                    start, end, len(freqs), pol=pol,
-                                    taper=taper, little_h=little_h, 
-                                    num_steps=num_steps)
+                                        start, end, len(freqs), pol=pol,
+                                        taper=taper, little_h=little_h, 
+                                        num_steps=num_steps)
         else:
             scalar = beam.compute_pspec_scalar(start, end, len(freqs), 
                                                pol=pol, taper=taper, 
@@ -945,8 +1090,8 @@ class PSpecData(object):
         assert isinstance(dsets, (list, tuple)), "dsets must be fed as length-2 tuple of integers"
         assert len(dsets) == 2, "len(dsets) must be 2"
         assert isinstance(dsets[0], (int, np.int)) and isinstance(dsets[1], (int, np.int)), "dsets must contain integer indices"
-        dset1 = self.dsets[dsets[0]]
-        dset2 = self.dsets[dsets[1]]
+        dset1 = self.dsets[self.dset_idx(dsets[0])]
+        dset2 = self.dsets[self.dset_idx(dsets[1])]
 
         # get polarization array from zero'th dset
         pol_arr = map(lambda p: pyuvdata.utils.polnum2str(p), dset1.polarization_array)
@@ -1244,8 +1389,8 @@ class PSpecData(object):
 
         Parameters
         ----------
-        dset_index : int
-            index of dataset in self.dset to phase other datasets to.
+        dset_index : int or str
+            Index or label of dataset in self.dset to phase other datasets to.
 
         inplace : bool, optional
             If True, edits data in dsets in-memory. Else, makes a copy of
@@ -1266,7 +1411,10 @@ class PSpecData(object):
             dsets = self.dsets
         else:
             dsets = copy.deepcopy(self.dsets)
-
+        
+        # Parse dset_index
+        dset_index = self.dset_idx(dset_index)
+        
         # get LST grid we are phasing to
         lst_grid = []
         lst_array = dsets[dset_index].lst_array.ravel()

--- a/hera_pspec/pspecdata.py
+++ b/hera_pspec/pspecdata.py
@@ -1366,8 +1366,10 @@ class PSpecData(object):
             uvp.filename1 = dset1.extra_keywords['filename']
         if hasattr(dset2.extra_keywords, 'filename'): 
             uvp.filename2 = dset2.extra_keywords['filename']
-        uvp.label1 = self.labels[self.dset_idx(dsets[0])]
-        uvp.label2 = self.labels[self.dset_idx(dsets[1])]
+        lbl1 = self.labels[self.dset_idx(dsets[0])]
+        lbl2 = self.labels[self.dset_idx(dsets[1])]
+        if lbl1 is not None: uvp.label1 = lbl1
+        if lbl2 is not None: uvp.label2 = lbl2
         
         # fill data arrays
         uvp.data_array = data_array

--- a/hera_pspec/pspecdata.py
+++ b/hera_pspec/pspecdata.py
@@ -1366,8 +1366,8 @@ class PSpecData(object):
             uvp.filename1 = dset1.extra_keywords['filename']
         if hasattr(dset2.extra_keywords, 'filename'): 
             uvp.filename2 = dset2.extra_keywords['filename']
-        uvp.label1 = self.labels[dset1]
-        uvp.label2 = self.labels[dset2]
+        uvp.label1 = self.labels[self.dset_idx(dsets[0])]
+        uvp.label2 = self.labels[self.dset_idx(dsets[1])]
         
         # fill data arrays
         uvp.data_array = data_array

--- a/hera_pspec/tests/test_pspecdata.py
+++ b/hera_pspec/tests/test_pspecdata.py
@@ -425,10 +425,19 @@ class Test_PSpecData(unittest.TestCase):
         # only expect equality to ~10^-2 to 10^-3
         np.testing.assert_allclose(parseval_phat, parseval_real, rtol=1e-3)
     '''
+    
+    def test_get_V_gaussian(self):
+        nt.assert_raises(NotImplementedError, self.ds.get_V_gaussian, 
+                         (0,1), (0,1))
+        
 
     def test_scalar(self):
         self.ds = pspecdata.PSpecData(dsets=self.d, wgts=self.w, beam=self.bm)
-
+        
+        gauss = pspecbeam.PSpecBeamGauss(0.8, 
+                                  np.linspace(115e6, 130e6, 50, endpoint=False))
+        ds2 = pspecdata.PSpecData(dsets=self.d, wgts=self.w, beam=gauss)
+        
         # Precomputed results in the following test were done "by hand" 
         # using iPython notebook "Scalar_dev2.ipynb" in the tests/ directory
         # FIXME: Uncomment when pyuvdata support for this is ready
@@ -494,6 +503,12 @@ class Test_PSpecData(unittest.TestCase):
         # test basic execution
         psu = ds.units()
         nt.assert_equal(psu, '(UNCALIB)^2 Hz [beam normalization not specified]')
+        
+        ds.primary_beam = pspecbeam.PSpecBeamGauss(0.8, 
+                                  np.linspace(115e6, 130e6, 50, endpoint=False))
+        psu = ds.units(little_h=False)
+        nt.assert_equal(psu, '(UNCALIB)^2 Mpc^3')
+        
 
     def test_delays(self):
         ds = pspecdata.PSpecData()
@@ -642,13 +657,16 @@ class Test_PSpecData(unittest.TestCase):
         nt.assert_raises(TypeError, pspecdata.validate_bls, [1], [1], uvd, uvd)
         nt.assert_raises(TypeError, pspecdata.validate_bls, [[1]], [[1]], 1, uvd)
         nt.assert_raises(TypeError, pspecdata.validate_bls, [[1]], [[1]], uvd, 1)
-
+        
         bls1 = [(24, 25), (37, 38)]
         bls2 = [(24, 25), (37, 52)]
         pspecdata.validate_bls(bls1, bls2, uvd, uvd)
         bls1 = [[(24,25),(37,38)]]
         bls2 = [[(24,25),(37,52)]]
         pspecdata.validate_bls(bls1, bls2, uvd, uvd)
+        
+        nt.assert_raises(TypeError, pspecdata.validate_bls, bls1, bls2, uvd, 1)
+        nt.assert_raises(TypeError, pspecdata.validate_bls, bls1, bls2, 1, uvd)
 
 
 """

--- a/hera_pspec/tests/test_pspecdata.py
+++ b/hera_pspec/tests/test_pspecdata.py
@@ -106,7 +106,8 @@ class Test_PSpecData(unittest.TestCase):
 
         # load another data file
         self.uvd = uv.UVData()
-        self.uvd.read_miriad(os.path.join(DATA_PATH, "zen.2458042.17772.xx.HH.uvXA"))
+        self.uvd.read_miriad(os.path.join(DATA_PATH, 
+                                          "zen.2458042.17772.xx.HH.uvXA"))
 
     def tearDown(self):
         pass
@@ -139,10 +140,41 @@ class Test_PSpecData(unittest.TestCase):
         self.assertRaises(TypeError, ds.add, [1], [None])
 
     def test_add_data(self):
-        # test adding non UVData object
+        """
+        Test adding non UVData object.
+        """
         nt.assert_raises(TypeError, self.ds.add, 1, 1)
-
+    
+    def test_labels(self):
+        """
+        Test that dataset labels work.
+        """
+        # Check that specifying labels does work
+        psd = pspecdata.PSpecData( dsets=[self.d[0], self.d[1],], 
+                                   wgts=[self.w[0], self.w[1], ],
+                                   labels=['red', 'blue'] )
+        np.testing.assert_array_equal( psd.x(('red', 24, 38)), 
+                                       psd.x((0, 24, 38)) )
+        
+        # Check specifying labels using dicts
+        dsdict = {'a':self.d[0], 'b':self.d[1]}
+        psd = pspecdata.PSpecData(dsets=dsdict, wgts=dsdict)
+        self.assertRaises(ValueError, pspecdata.PSpecData, dsets=dsdict, 
+                          wgts=dsdict, labels=['a', 'b'])
+        
+        # Check that invalid labels raise errors
+        self.assertRaises(KeyError, psd.x, ('green', 24, 38))
+    
+    def test_str(self):
+        """
+        Check that strings can be output.
+        """
+        print(self.ds)
+    
     def test_get_Q(self):
+        """
+        Test the Q = dC/dp function.
+        """
         vect_length = 50
         x_vect = np.random.normal(size=vect_length) \
                + 1.j * np.random.normal(size=vect_length)

--- a/hera_pspec/tests/test_pspecdata.py
+++ b/hera_pspec/tests/test_pspecdata.py
@@ -536,7 +536,7 @@ class Test_PSpecData(unittest.TestCase):
     def test_pspec(self):
         # generate ds
         uvd = copy.deepcopy(self.uvd)
-        ds = pspecdata.PSpecData(dsets=[uvd, uvd], wgts=[None, None], beam=self.bm)
+        ds = pspecdata.PSpecData(dsets=[uvd, uvd], wgts=[None, None], beam=self.bm, labels=['red', 'blue'])
 
         # check basic execution with baseline list
         bls = [(24, 25), (37, 38), (38, 39), (52, 53)] 

--- a/hera_pspec/tests/test_pspecdata.py
+++ b/hera_pspec/tests/test_pspecdata.py
@@ -169,7 +169,10 @@ class Test_PSpecData(unittest.TestCase):
         """
         Check that strings can be output.
         """
-        print(self.ds)
+        ds = pspecdata.PSpecData()
+        print(ds) # print empty psd
+        ds.add(self.uvd, None)
+        print(ds) # print populated psd
     
     def test_get_Q(self):
         """

--- a/hera_pspec/tests/test_uvpspec.py
+++ b/hera_pspec/tests/test_uvpspec.py
@@ -55,6 +55,8 @@ def build_example_uvpspec():
     norm = "I"
     git_hash = "random"
     scalar_array = np.ones((Nspws, Npols), np.float)
+    label1 = 'red'
+    #label2 = 'blue' # Leave commented out to make sure non-named UVPSpecs work!
 
     telescope_location = np.array([5109325.85521063, 
                                    2005235.09142983, 
@@ -77,7 +79,7 @@ def build_example_uvpspec():
               'integration_array', 'bl_array', 'bl_vecs', 'telescope_location', 
               'units', 'channel_width', 'weighting', 'history', 'taper', 'norm', 
               'git_hash', 'nsample_array', 'time_avg_array', 'lst_avg_array', 
-              'cosmo', 'scalar_array']
+              'cosmo', 'scalar_array', 'label1']
     
     # Set all parameters
     for p in params:

--- a/hera_pspec/uvpspec.py
+++ b/hera_pspec/uvpspec.py
@@ -64,9 +64,9 @@ class UVPSpec(object):
         self._units = PSpecParam("units", description="units of the power spectra.", expected_type=str)
         self._scalar_array = PSpecParam("scalar_array", description="power spectrum scalar from pspecbeam module.", expected_type=np.ndarray, form="(Nspws, Npols)")
         self._filename1 = PSpecParam("filename1", description="filename of data from first dataset", expected_type=str)
-        self._filename2 = PSpecParam("filename1", description="filename of data from second dataset", expected_type=str)
-        self._tag1 = PSpecParam("tag1", description="tag of data from first dataset", expected_type=str)
-        self._tag2 = PSpecParam("tag2", description="tag of data from second dataset", expected_type=str)
+        self._filename2 = PSpecParam("filename2", description="filename of data from second dataset", expected_type=str)
+        self._label1 = PSpecParam("label1", description="label of data from first dataset", expected_type=str)
+        self._label2 = PSpecParam("label2", description="label of data from second dataset", expected_type=str)
         self._git_hash = PSpecParam("git_hash", description="GIT hash of hera_pspec when pspec was generated.", expected_type=str)
         self._cosmo_params = PSpecParam("cosmo_params", description="LCDM cosmological parameter string, used to instantiate a conversions.Cosmo_Conversions object.", expected_type=str)
         self._beamfile = PSpecParam("beamfile", description="filename of beam-model used to normalized pspectra.", expected_type=str)
@@ -79,10 +79,10 @@ class UVPSpec(object):
                             "data_array", "wgt_array", "integration_array", "spw_array", "freq_array", "dly_array",
                             "pol_array", "lst_1_array", "lst_2_array", "time_1_array", "time_2_array", "blpair_array",
                             "Nbls", "bl_vecs", "bl_array", "channel_width", "telescope_location", "weighting", "units",
-                            "taper", "norm", "git_hash", "nsample_array", 'lst_avg_array', 'time_avg_array', 'folded']
+                            "taper", "norm", "git_hash", "nsample_array", 'lst_avg_array', 'time_avg_array', 'folded', "label1", "label2"]
 
         self._immutables = ["Ntimes", "Nblpairts", "Nblpairs", "Nspwdlys", "Nspws", "Ndlys", "Npols", "Nfreqs", "history",
-                            "Nbls", "channel_width", "weighting", "units", "filename1", "filename2", "tag1", "tag2",
+                            "Nbls", "channel_width", "weighting", "units", "filename1", "filename2", "label1", "label2",
                             "norm", "taper", "git_hash", "cosmo_params", "beamfile" ,'folded']
         self._ndarrays = ["spw_array", "freq_array", "dly_array", "pol_array", "lst_1_array", 'lst_avg_array', 'time_avg_array', 
                           "lst_2_array", "time_1_array", "time_2_array", "blpair_array",
@@ -1220,6 +1220,8 @@ class UVPSpec(object):
         uvp.integration_array = ints_array
         uvp.wgt_array = wgts_array
         uvp.nsample_array = nsmp_array
+        uvp.label1 = self.label1
+        uvp.label2 = self.label2
 
         uvp.check()
 

--- a/hera_pspec/uvpspec.py
+++ b/hera_pspec/uvpspec.py
@@ -79,7 +79,7 @@ class UVPSpec(object):
                             "data_array", "wgt_array", "integration_array", "spw_array", "freq_array", "dly_array",
                             "pol_array", "lst_1_array", "lst_2_array", "time_1_array", "time_2_array", "blpair_array",
                             "Nbls", "bl_vecs", "bl_array", "channel_width", "telescope_location", "weighting", "units",
-                            "taper", "norm", "git_hash", "nsample_array", 'lst_avg_array', 'time_avg_array', 'folded', "label1", "label2"]
+                            "taper", "norm", "git_hash", "nsample_array", 'lst_avg_array', 'time_avg_array', 'folded']
 
         self._immutables = ["Ntimes", "Nblpairts", "Nblpairs", "Nspwdlys", "Nspws", "Ndlys", "Npols", "Nfreqs", "history",
                             "Nbls", "channel_width", "weighting", "units", "filename1", "filename2", "label1", "label2",
@@ -1220,8 +1220,8 @@ class UVPSpec(object):
         uvp.integration_array = ints_array
         uvp.wgt_array = wgts_array
         uvp.nsample_array = nsmp_array
-        uvp.label1 = self.label1
-        uvp.label2 = self.label2
+        if hasattr(self, 'label1'): uvp.label1 = self.label1
+        if hasattr(self, 'label2'): uvp.label2 = self.label2
 
         uvp.check()
 


### PR DESCRIPTION
Adds a new `labels` argument so datasets can be referred to using strings instead of indices if desired.

Also adds `__str__` function to PSpecData to allow pretty printing.