### PR TITLE
Allow users to build PSpecBeam objects from solid angle arrays

### DIFF
--- a/examples/PSpecBeam_tutorial.ipynb
+++ b/examples/PSpecBeam_tutorial.ipynb
@@ -1,0 +1,476 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Creating and using `PSpecBeam` objects\n",
+    "`PSpecBeam` objects carry information about the primary beam, such as how the beam solid angle varies with frequency. This information is needed to rescale power spectra into cosmological units, through the computation of a 'beam scalar'.\n",
+    "\n",
+    "There are several different ways to construct a `PSpecBeam` object."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Gaussian beams: `PSpecBeamGauss`\n",
+    "A Gaussian beam type is provided for simple testing purposes. We will use this to demonstrate the basic usage of `PSpecBeam` objects."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "%matplotlib inline\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "import hera_pspec as hp"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# Each beam is defined over a frequency interval:\n",
+    "beam_freqs = np.linspace(100e6, 200e6, 200) # in Hz\n",
+    "\n",
+    "# Create a new Gaussian beam object with full-width at half-max. of 0.1 radians\n",
+    "beam_gauss = hp.PSpecBeamGauss(fwhm=0.1, beam_freqs=beam_freqs)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We now have a `PSpecBeamGauss` object, with a constant FWHM of 0.1 radians, defined over a frequency interval of [100, 200] MHz. This beam only supports the `pseudo_I` (pseudo-Stoke I) polarization by default.\n",
+    "\n",
+    "`PSpecBeam` objects have a cosmology attached to them. Because we didn't manually specify a cosmology, this object was automatically instantiated with the default cosmology from `hera_pspec.conversions`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Cosmo_Conversions object at <0x7fcc011dd950>\n",
+      "Om_L : 0.6844; Om_b : 0.0491; Om_c : 0.2644; Om_M : 0.3135; Om_k : 0.0021; H0 : 67.2700\n"
+     ]
+    }
+   ],
+   "source": [
+    "print beam_gauss.cosmo"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Calculating the scalar conversion factor\n",
+    "\n",
+    "There are two main `PSpecBeam` methods that are needed by other bits of `hera_pspec`. The first is `compute_pspec_scalar()`, which outputs the scalar conversion factor for a specified range of frequencies. This factor is used to convert power spectra into physical units, e.g. in `PSpecData.pspec()`. It is calculated by performing two integrals, over the beam solid angle and the beam solid angle squared, and multiplying their ratio by a cosmological distance factor.\n",
+    "\n",
+    "The `compute_pspec_scalar()` method takes several arguments: to specify the frequency range to integrate the scalar over (`lower_freq`, `upper_freq`, and `num_freqs`); to specify which polarization to calculate the scalar for (`stokes`), and to specify whether a tapering function has been applied to the power spectrum (`taper`):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Scalar: 280222020.675\n"
+     ]
+    }
+   ],
+   "source": [
+    "scalar = beam_gauss.compute_pspec_scalar(lower_freq=100e6, upper_freq=120e6, num_freqs=20, \n",
+    "                                         num_steps=5000, stokes='pseudo_I', taper='none', \n",
+    "                                         little_h=True)\n",
+    "print \"Scalar:\", scalar"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In `PSpecData`, the delay spectrum returned by `p_hat` (calculated by applying an optimal quadratic estimator to a pair of visbilities) is multiplied by `scalar` to convert it to cosmological units.\n",
+    "\n",
+    "In the above, the frequency range should correspond to the frequency range that the delay spectrum was calculated over. The `num_freqs` argument sets the size of the grid to evaluate the scalar integrand over, and is usually chosen to be a reasonably small value, since the integrand tends to vary quite smoothly with frequency.\n",
+    "\n",
+    "### Beam solid angle integrals\n",
+    "The `num_steps` argument, on the other hand, specifies the size of the grid over which the beam solid angle should be interpolated before it is integrated (i.e. to produce the scalar integrand). This should normally be set to a larger value, as accuracy is more important here. The integrals of the beam solid angle are returned by the following methods (which return arrays of the same size as `beam_freqs`):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<matplotlib.text.Text at 0x7fcbfc46ab90>"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYcAAAEPCAYAAACp/QjLAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAF6tJREFUeJzt3X2wXPV93/H3BymKseMnNSZuABEcQQVMaoNjmUnd5I6J\nQc7EqG4HLDJtFIemHVOMazuNoHarq5m0NeQJO4zb8YzsYgb7DlEeLKjB2FFuMh0LkAu2cSSZ25oH\nCbA9AYNJHDNC/vaPPRLL/la6q3tXD9Z9v2Z29Du/8z1nzzmzOp97frtnN1WFJEn9TjjaGyBJOvYY\nDpKkhuEgSWoYDpKkhuEgSWoYDpKkxkjhkGRVkp1JHkiybsj8JUmmkswk2ZpkWde/NMmWJM8k+Uhf\n/YlJbkuyI8n9Sf7r+HZJkjRfs4ZDkhOAG4CLgHOAy5KsGCi7HHiyqs4Argeu6/q/D3wQeP+QVf9O\nVZ0FnAu8KclFc9sFSdK4jXLlsBKYqaqHq2oPMAWsHqhZDdzYtTcBFwBU1feq6ovAs/3FVfX3VfWX\nXfs54F7glDnvhSRprEYJh5OBXX3Tu7u+oTVVtRd4KsnSUTYgySuAtwF/Pkq9JOnwGyUcMqRv8Ds3\nBmsypKZdcbII+BRwfVU9NMK2SJKOgMUj1OwGlvVNnwI8NlCzCzgVeKw74b+sqr4zwro/Bny9qv7w\nQAVJ/PInSZqDqhr2x/1IRrly2AYsT3JakiXAGmDzQM2twNqufQmwZch6XrCRSX6bXoi8d7YNqCof\nVaxfv/6ob8Ox8vBYeCw8Fgd/zNesVw5VtTfJlcCd9MJkY1XtSLIB2FZVtwEbgZuSzABP0AsQAJI8\nCLwUWJJkNXAh8AzwH4EdSe6jNwR1Q1V9fN57JEmat1GGlaiqO4B/NNC3vq/9LHDpAZY9/QCr9QY8\nSTpGeYL+ITIxMXG0N+GY4bF4nsfieR6L8ck4xqYOpyR1rG+jJB1rklCH+Q1pSdICYzhIkhqGgySp\nYThIkhqGgySpYThIkhqGgySpYThIkhqGgySpYThIkhqGgySpYThIkhqGgySpYThIkhqGgySpMdIv\nwR1tmfM3kkuS5uKHIhz8rR9JOjTz/aPaYSVJUsNwkCQ1DAdJUsNwkCQ1RgqHJKuS7EzyQJJ1Q+Yv\nSTKVZCbJ1iTLuv6lSbYkeSbJRwaW+e0kjyT57nh2RZI0LrOGQ5ITgBuAi4BzgMuSrBgouxx4sqrO\nAK4Hruv6vw98EHj/kFVvBt4wx+2WJB1Go1w5rARmqurhqtoDTAGrB2pWAzd27U3ABQBV9b2q+iLw\n7OBKq+qeqvrWnLdcknTYjBIOJwO7+qZ3d31Da6pqL/BUkqVj2UJJ0hE3yk1ww26lGLwtbbAmQ2rm\nbHJycn97YmKCiYmJca1ako4L09PTTE9Pj219qVluP05yPjBZVau66auBqqpr+2pu72ruTrIIeLyq\nTuqbvxZ4fVVdNWT9362qlx3k+Wu2bZQkvVASqmrO90mPMqy0DVie5LQkS4A19N5M7ncrsLZrXwJs\nGbatB1i/35wkSceYWcOhew/hSuBO4K+BqarakWRDkl/uyjYCP55kBvj3wNX7lk/yIPB7wNruo6sr\nuv5rk+wCTuz6//NY90ySNGezDisdbQ4rSdKhOxLDSpKkBcZwkCQ1DAdJUsNwkCQ1DAdJUsNwkCQ1\nDAdJUsNwkCQ1DAdJUsNwkCQ1DAdJUsNwkCQ1DAdJUsNwkCQ1DAdJUsNwkCQ1DAdJUsNwkCQ1DAdJ\nUsNwkCQ1DAdJUsNwkCQ1DAdJUmOkcEiyKsnOJA8kWTdk/pIkU0lmkmxNsqzrX5pkS5JnknxkYJnz\nkny1W+f149kdSdI4zBoOSU4AbgAuAs4BLkuyYqDscuDJqjoDuB64ruv/PvBB4P1DVv3fgX9dVWcC\nZya5aG67IEkat1GuHFYCM1X1cFXtAaaA1QM1q4Ebu/Ym4AKAqvpeVX0ReLa/OMmrgZdW1T1d1yeB\nfza3XZAkjdso4XAysKtvenfXN7SmqvYCTyVZOss6d8+yTknSUbJ4hJoM6atZajKk5lDXud/k5OT+\n9sTEBBMTEwdZtSQtPNPT00xPT49tfaOEw25gWd/0KcBjAzW7gFOBx5IsAl5WVd+ZZZ2nzrLO/frD\nQZLUGvzDecOGDfNa3yjDStuA5UlOS7IEWANsHqi5FVjbtS8BtgxZz/6rhar6JvDdJCuTBPhV4DOH\nuvGSpMMjVQcb/emKklXAh+mFycaq+lCSDcC2qrotyY8CNwHnAk8Aa6rqoW7ZB4GXAkuAp4ALq2pn\nktcD/xN4EfDZqnrPAZ67RtlGSdLzklBVw4bwR1v+WD/xGg6SdOjmGw7eIS1JahgOkqSG4SBJahgO\nkqSG4SBJahgOkqSG4SBJahgOkqSG4SBJahgOkqSG4SBJahgOkqSG4SBJahgOkqSG4SBJahgOkqSG\n4SBJahgOkqSG4SBJahgOkqSG4SBJahgOkqSG4SBJaowUDklWJdmZ5IEk64bMX5JkKslMkq1JlvXN\nu6br35Hkwr7+9yS5v3tcNZ7dkSSNw6zhkOQE4AbgIuAc4LIkKwbKLgeerKozgOuB67plzwYuBc4C\n3gp8ND3ndMv8LPA64G1Jfno8uyRJmq9RrhxWAjNV9XBV7QGmgNUDNauBG7v2JuDNXftiYKqqnquq\nh4CZbn1nAXdV1bNVtRf4S+Dt89oTSdLYjBIOJwO7+qZ3d31Da7qT/dNJlg5Z9tGu72vAzyd5ZZIX\nA78EnDqnPZAkjd3iEWoypK9GrBnaX1U7k1wLfAF4Bvgy8NyBNmBycnJ/e2JigomJiYNvsSQtMNPT\n00xPT49tfakaPM8PFCTnA5NVtaqbvpreCf7avprbu5q7kywCHq+qkwZrk9wBrK+quwee478Au6rq\nfwx5/pptGyVJL5SEqhr2B/pIRhlW2gYsT3JakiXAGmDzQM2twNqufQmwpWtvBtZ0n2Y6HVgO3NNt\n+Ku6f5fRe7/h03PdCUnSeM06rFRVe5NcCdxJL0w2VtWOJBuAbVV1G7ARuCnJDPAEvQChqrYnuQXY\nDuwBrui7DPjj7n2Jff1Pj3vnJElzM+uw0tHmsJIkHbojMawkSVpgDAdJUsNwkCQ1DAdJUsNwkCQ1\nDAdJUsNwkCQ1DAdJUsNwkCQ1DAdJUsNwkCQ1DAdJUsNwkCQ1DAdJUsNwkCQ1DAdJUsNwkCQ1DAdJ\nUsNwkCQ1DAdJUsNwkCQ1DAdJUsNwkCQ1RgqHJKuS7EzyQJJ1Q+YvSTKVZCbJ1iTL+uZd0/XvSHJh\nX/97k3wtyVeT3JxkyXh2SZI0X7OGQ5ITgBuAi4BzgMuSrBgouxx4sqrOAK4HruuWPRu4FDgLeCvw\n0fT8JPBu4Lyq+sfAYmDNeHZJkjRfo1w5rARmqurhqtoDTAGrB2pWAzd27U3Am7v2xcBUVT1XVQ8B\nM936ABYBL0myGHgx8Nic90KSNFajhMPJwK6+6d1d39CaqtoLPJ1k6ZBlHwVOrqrHgN8DHun6nqqq\nL8xpDyRJY7d4hJoM6asRa4b2J3kFvauN04CngU1JfqWqPjVsAyYnJ/e3JyYmmJiYmH2rJWkBmZ6e\nZnp6emzrS9XgeX6gIDkfmKyqVd301UBV1bV9Nbd3NXcnWQQ8XlUnDdYmuQNYD5wKXFRVv9H1/yvg\njVV15ZDnr9m2UZL0QkmoqmF/oI9klGGlbcDyJKd1nyhaA2weqLkVWNu1LwG2dO3NwJru00ynA8uB\ne+gNJ52f5EVJAlwA7JjrTkiSxmvWYaWq2pvkSuBOemGysap2JNkAbKuq24CNwE1JZoAn6D55VFXb\nk9wCbAf2AFd0lwH3JNkE3Nf13wd8bPy7J0mai1mHlY42h5Uk6dAdiWElSdICYzhIkhqGgySpYThI\nkhqGgySpYThIkhqGgySpYThIkhqGgySpYThIkhqGgySpYThIkhqGgySpYThIkhqGgySpYThIkhqG\ngySpYThIkhqGgySpYThIkhqGgySpYThIkhqGgySpMVI4JFmVZGeSB5KsGzJ/SZKpJDNJtiZZ1jfv\nmq5/R5ILu74zk9yX5N7u36eTXDW+3ZIkzUeq6uAFyQnAA8AFwGPANmBNVe3sq3kX8DNVdUWSdwBv\nr6o1Sc4GbgbeAJwCfAE4o/qetFv/buCNVbVryPPXbNsoSXqhJFRV5rr8KFcOK4GZqnq4qvYAU8Dq\ngZrVwI1dexPw5q59MTBVVc9V1UPATLe+fr8I/L9hwSBJOjpGCYeTgf4T9+6ub2hNVe0Fnk6ydMiy\njw5Z9h3Apw9hmyVJh9niEWqGXZYMjvMcqOagyyb5EXpXF1cfbAMmJyf3tycmJpiYmDhYuSQtONPT\n00xPT49tfaO853A+MFlVq7rpq4Gqqmv7am7vau5Osgh4vKpOGqxNcgewvqru7qYvBq7Yt+4DPL/v\nOUjSIToS7zlsA5YnOS3JEmANsHmg5lZgbde+BNjStTcDa7pPM50OLAfu6VvuMhxSkqRjzqzDSlW1\nN8mVwJ30wmRjVe1IsgHYVlW3ARuBm5LMAE/QCxCqanuSW4DtwB56VwkFkOREem9G/5vDsF+SpHmY\ndVjpaHNYSZIO3ZEYVpIkLTCGgySpYThIkhqGgySpYThIkhqGgySpYThIkhqGgySpYThIkhqGgySp\nYThIkhqGgySpYThIkhqGgySpYThIkhqGgySpYThIkhqGgySpYThIkhqGgySpYThIkhqGgySpYThI\nkhojhUOSVUl2Jnkgyboh85ckmUoyk2RrkmV9867p+nckubCv/+VJ/qjr/+skbxzPLkmS5mvWcEhy\nAnADcBFwDnBZkhUDZZcDT1bVGcD1wHXdsmcDlwJnAW8FPpok3TIfBj5bVWcBrwV2zH93JEnjMMqV\nw0pgpqoerqo9wBSweqBmNXBj194EvLlrXwxMVdVzVfUQMAOsTPJS4J9W1ScAuvnfnd+uSJLGZZRw\nOBnY1Te9u+sbWlNVe4GnkywdsuyjXd9rgL9J8okk9yb5WJIT57gPkqQxWzxCTYb01Yg1B+pfDJwH\n/Luq+lKS64GrgfXDNmBycnJ/e2JigomJiVk3WpIWkunpaaanp8e2vlQNnucHCpLzgcmqWtVNXw1U\nVV3bV3N7V3N3kkXA41V10mBtkjvoBcBDwNaqek3X/yZgXVW9bcjz12zbKEl6oSRU1bA/0EcyyrDS\nNmB5ktOSLAHWAJsHam4F1nbtS4AtXXszsKb7NNPpwHLgnqr6FrAryZld3QXA9rnuhCRpvGYdVqqq\nvUmuBO6kFyYbq2pHkg3Atqq6DdgI3JRkBniCXoBQVduT3ELvxL8HuKLvMuAq4OYkPwJ8A3jnmPdN\nkjRHsw4rHW0OK0nSoTsSw0qSpAXGcJAkNQwHSVLDcJAkNQwHSVLDcJAkNUb5+oyjL3P+NJYkaQ5+\nOMLB+xwk6dDM849qh5UkSQ3DQZLUMBwkSQ3DQZLUMBwkSQ3DQZLUMBwkSQ3DQZLUMBwkSQ3DQZLU\nMBwkSQ3DQZLUMBwkSQ3DQZLUGCkckqxKsjPJA0nWDZm/JMlUkpkkW5Ms65t3Tde/I8mFff0PJflK\nkvuS3DOe3ZEkjcOs4ZDkBOAG4CLgHOCyJCsGyi4HnqyqM4Drgeu6Zc8GLgXOAt4KfDTZ/yXjPwAm\nqurcqlo5jp053k1PTx/tTThmeCye57F4nsdifEa5clgJzFTVw1W1B5gCVg/UrAZu7NqbgDd37YuB\nqap6rqoeAma69QFkxOdXxxf+8zwWz/NYPM9jMT6jnJxPBnb1Te/u+obWVNVe4OkkS4cs+2jfsgV8\nLsm2JL8xh22XJB0mo/xM6LDfmhv83c4D1Rxs2Z+rqm8meRXw+SQ7qup/j7A9kqTDraoO+gDOB+7o\nm74aWDdQczvwxq69CPj2sFrgjn11A8uvB953gOcvHz58+PBx6I/Zzu8He4xy5bANWJ7kNOBxYA1w\n2UDNrcBa4G7gEmBL178ZuDnJH9AbTloO3JPkxcAJVfW3SV4CXAhsGPbkVTW/X8mWJB2yWcOhqvYm\nuRK4k957FBurakeSDcC2qroN2AjclGQGeIJegFBV25PcAmwH9gBXVFUl+QngT5NUtw03V9Wdh2MH\nJUmHLt3QjSRJ+x3Vj5Im2ZjkW0m+2tf3yiR3Jvl6ks8leXnfvI90N9R9Ocnrjs5WHx4HOBbXdTcP\nfjnJHyd5Wd+8oTcXHg+GHYu+eb+Z5Afdp+H29S2o10XX/+7uxtT7k3yor39BvS6SvLa78fa+JPck\neUPfvOP5dXFKki1Jtnevgau6/vGdP+fzhsV8H8CbgNcBX+3ruxb4ra69DvhQ134r8L+69huBu47m\nth+hY/GL9N6bAfgQ8N+69tnAffSG5H4K+L90V4HHw2PYsej6T6H3oYYHgaUL+HUxQW+Yd3E3/ePd\nv2cttNcF8Dngwr7Xwl907V86zl8XrwZe17V/DPg6sGKc58+jeuVQvY+ufmegu/+Guht5/oa71cAn\nu+XuBl7evXdxXBh2LKrqC1X1g27yLnonRzj4zYU/9A7wugD4A+A/DPQtuNcF8C56/+mf62r+putf\nzcJ7XfwA2PfX8Svo3UsFvf8jx/Pr4ptV9eWu/bfADnrnh7GdP4/FO5RPqqpvQe8AACd1/Qe7oW4h\n+HXgs117wR2LJG8DdlXV/QOzFtyxAM4Efj7JXUn+Isnru/6FeCzeC/xukkfofW3PNV3/gjkWSX6K\n3hXVXcBPjOv8eSyGw4GMcjPecSnJB4A9VfXpfV1Dyo7bY5HkROAD9O6HaWYP6Ttuj0VnMfCKqjof\n+C3gj7r+hXgs3gW8p6qW0QuKj3f9C+JYJPkxel9Z9J7uCuJA+3jIx+NYDIdv7bvcSfJq4Ntd/27g\n1L66U4DHjvC2HXFJ1tIbP/2Vvu6Fdix+mt4Y+leSPEhvf+9NchIL71hA7y/APwGoqm3A3iT/gN6x\nWNZXtxCOxdqq+jOAqtoE7HtD+rh/XSRZTC8Ybqqqz3TdYzt/HgvhEF6YapuBX+vavwZ8pq//VwGS\nnA88te/y6TjygmORZBW9vwwvrqpn++o2A2u6r0o/ne7mwiO6pYff/mNRVV+rqldX1Wuq6nR6L/Rz\nq+rbLMDXBfBnwAUASc4EllTVE/SOxTsWyuui82iSXwBIcgG991lgYbwuPg5sr6oP9/WN7/x5lN9x\n/xS99HoWeAR4J/BK4Av03n3/PL3L5331N9D7BMZXgPOO9icGjsCxmAEeBu7tHh/tq7+mOxY76D6t\ncbw8hh2LgfnfoPu00gJ9XSwGbgLuB74E/MJCfV0AP9cdg/uArfT+aFgIr4t/AuwFvtzt+73AKmDp\nuM6f3gQnSWocC8NKkqRjjOEgSWoYDpKkhuEgSWoYDpKkhuEgSWoYDjpuJNmb5N7u65vvTbJs9qXm\n9Xxrk3w7yce66V/ovk78nX01r+v63tdNfyLJPx9YzzMHeY4Xdfvz/f6vKZcOt1F+JlT6YfF3VXXe\ngWYmWVRVe8f8nFNVdVXf9P3AO4BPdNNr6N2odDAHvNmoqr4PnJvkG/PaSukQeeWg40nz5WLdX/e3\nJNlM77v/9/1g0D3dj56s76v9QPcDOncm+dS+v/YP0SPAi5K8qpteBdw+0sYnG/quenYn2XiwfZMO\nJ68cdDw5Mcm99E6k36iqf9H1nw/8TFU9neQtwBlVtTJJgM1J3gR8D7gUeC2whN7XEXxpjtuxCbg0\nyX3A/6H3dQ/9fjfJB7v2/pN+Va0H1qf3i39/BfzhHJ9fmjfDQceT7x1gWOnzVfV0174QeEtfiLwE\nOAN4GfCn1fuCw2e7K425KOCW7rEC+DS978Hp95tV9Sf7JpJ8d2D+zcDvV/djLtLR4LCSFoK/62uH\n3s+tnldV51bVmVW17/2BsXzRWPW+LXYPvZ95/fNDWTbJJPBIVX1yHNsizZXhoOPJKOPynwN+PclL\nAJL8ZPf+wF8Bb0/yo0leCrxtntvyn4B1Ndo3W6bbll8G3gK8Z57PLc2bw0o6nsx6Iq6qzydZAWzt\nveXAM8C/rKr7ktxC7+uMH6IXFgAk+be9RetjI29I1V2HsI37+t4H/ENgW5ICNlfV5KjPKY2TX9kt\nDdF9iumZqvr9g9SsBX62qt59BLbnQeD1VfXk4X4uCRxWkubj74FV+26COxz23QQHLAJ+cLieRxrk\nlYMkqeGVgySpYThIkhqGgySpYThIkhqGgySpYThIkhr/H+GbeqI6SKtzAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x7fcc17ccfd90>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "OmegaP = beam_gauss.power_beam_int()\n",
+    "OmegaPP = beam_gauss.power_beam_sq_int()\n",
+    "\n",
+    "plt.plot(beam_freqs/1e6, OmegaP, 'b-')\n",
+    "plt.plot(beam_freqs/1e6, OmegaPP, 'r-')\n",
+    "plt.xlabel(\"Freq. [MHz]\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The integrals of the beam solid angle are trivial in this example, as we are using a Gaussian beam with a FWHM that is constant in frequency.\n",
+    "\n",
+    "### Units and normalization\n",
+    "\n",
+    "The `compute_pspec_scalar()` has several other keyword arguments. In the example above, `little_h=True` was specified, to return the scalar in units that will result in a power spectrum that is in $(h^{-1} {\\rm Mpc})^3$ units.\n",
+    "\n",
+    "The normalization of the power spectrum also depends on whether a taper was applied to the data. The taper that was used can be specified as a string, using the `taper` keyword argument (which we set to `none` here).\n",
+    "\n",
+    "### Noise power spectrum normalization\n",
+    "Noise power spectra need a different normalization scalar to signal power spectra. To calculate the scalar for a noise power spectrum, pass `noise_scalar=True` to `compute_pspec_scalar()`.\n",
+    "\n",
+    "### Conversion to temperature units\n",
+    "A beam solid angle is also needed to convert between flux density units and temperature units. The `Jy_to_mK()` method performs this conversion. To calculate this factor, pass a frequency and polarization:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[ 287.25252717  183.84161739  127.66778985   93.79674357   71.81313179]\n"
+     ]
+    }
+   ],
+   "source": [
+    "freqs = np.linspace(100e6, 200e6, 5) # in Hz\n",
+    "print beam_gauss.Jy_to_mK(freqs, stokes='pseudo_I')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Assuming that you have visibilities that are known to be in Jy units, you can apply this conversion to a `pyuvdata.UVData` object like so:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "from pyuvdata import UVData\n",
+    "import os\n",
+    "\n",
+    "# Create a UVData object and fill it with data\n",
+    "datafile = os.path.join('../hera_pspec/data/', 'zen.2458042.12552.xx.HH.uvXAA')\n",
+    "uvd = UVData()\n",
+    "uvd.read_miriad(datafile)\n",
+    "\n",
+    "# Apply unit conversion factor to UVData\n",
+    "uvd.data_array *= beam_gauss.Jy_to_mK(np.unique(uvd.freq_array))[None, None, :, None]\n",
+    "# The expression [None, None, :, None] reshapes the conversion factor into the same shape as as the data_array"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Any power spectra created using this `UVData` object will be ${\\rm mK}$ units (actually, ${\\rm mK}^2 ({\\rm Mpc})^3$ or similar)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Passing a beam to `PSpecData`\n",
+    "The main purpose of `PSpecBeam` objects is to provide the `PSpecData` class with a way of normalizing the power spectra that it produces. To attach a `PSpecBeam` object to a `PSpecData` object, you can either pass one in when you instantiate the class, i.e."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# Create PSpecData with a beam attached\n",
+    "psd = hp.PSpecData(dsets=[], wgts=[], beam=beam_gauss)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Or, you can specify a beam manually, i.e."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "psd.primary_beam = beam_gauss"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `PSpecData.scalar()` method will then use the correct beam to rescale the power spectra output by `PSpecData.pspec()`.\n",
+    "\n",
+    "Note that if you do not specify a beam file at any point, `PSpecData.scalar()` will raise the following warning when it is called: \"Warning: self.primary_beam is not defined, so pspectra are not properly normalized\". It will then set `scalar = 1` and continue running."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Beams from a `UVBeam` object: `PSpecBeamUV`\n",
+    "Real beams are considerably more complicated than the Gaussian example. The `hera_pspec` module currently supports beams that are specified in the `UVBeam` format provided by the `pyuvdata` package. These usually contain Healpix-pixelated beams as a function of frequency and polarization.\n",
+    "\n",
+    "To create a beam that uses this format, simply create a new `PSpecBeamUV` instance with the name of a `beamfits` file that is supported by `UVBeam`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "beamfile = os.path.join('../hera_pspec/data/', 'NF_HERA_Beams.beamfits')\n",
+    "beam_uv = hp.PSpecBeamUV(beamfile)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Internally, `PSpecBeam` will calculate the beam solid angle integrals using the `UVBeam.get_beam_area()` and `UVBeam.get_beam_sq_area()` methods. These use Healpix to perform the integrals using spherical harmonic transforms. The relevant frequency ranges will be read directly from the `UVBeam` object. Other than this detail, `PSpecBeamUV` objects behave in the same way as `PSpecBeamGauss` object, e.g. to calculate the beam scalar:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Scalar: 2036735393.83\n"
+     ]
+    }
+   ],
+   "source": [
+    "scalar = beam_uv.compute_pspec_scalar(lower_freq=100e6, upper_freq=120e6, num_freqs=20, \n",
+    "                                      num_steps=5000, stokes='pseudo_I', taper='none', \n",
+    "                                      little_h=True)\n",
+    "print \"Scalar:\", scalar"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To access the `UVBeam` object stored inside a `PSpecBeamUV`, you can do the following:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<pyuvdata.uvbeam.UVBeam object at 0x7fcc011ddd10>\n"
+     ]
+    }
+   ],
+   "source": [
+    "uvbeam = beam_uv.primary_beam\n",
+    "print uvbeam"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Beam from beam solid angle arrays: `PSpecBeamFromArray`\n",
+    "If you want to experiment with non-trivial primary beam models without having to construct `UVBeam` objects and all of the metadata that they require, use `PSpecBeamFromArray`. This allows you to provide the integrated beam and beam-squared solid angles (i.e. the outputs of the `power_beam_int()` and `power_beam_sq_int()` methods) manually, as a set of arrays as a function of frequency.\n",
+    "\n",
+    "You can either pass in arrays for a single polarization (which will be assumed to be `pseudo_I`), or you can pass in dictionaries with arrays for multiple polarizations."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# Add the integrated beam arrays that we output for the Gaussian beam earlier\n",
+    "custom_beam = hp.PSpecBeamFromArray(OmegaP=OmegaP, OmegaPP=OmegaPP, beam_freqs=beam_freqs)\n",
+    "\n",
+    "# Use the same beam arrays, but to specify multiple polarizations using dicts\n",
+    "custom_beam2 = hp.PSpecBeamFromArray(OmegaP={'pseudo_I': OmegaP, 'pseudo_Q': OmegaP}, \n",
+    "                                     OmegaPP={'pseudo_I': OmegaPP, 'pseudo_Q': OmegaPP},\n",
+    "                                     beam_freqs=beam_freqs)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can also add additional polarizations (or replace existing ones) using the `add_pol()` method:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "custom_beam.add_pol(pol='pseudo_U', OmegaP=OmegaP, OmegaPP=OmegaPP)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can check which polarizations are available in a couple of ways:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Method 1: ['pseudo_I', 'pseudo_U']\n",
+      "Method 2: PSpecBeamFromArray object\n",
+      "\tFrequency range: Min. 1.0000e+08 Hz, Max. 2.0000e+08 Hz\n",
+      "\tAvailable pols: pseudo_I, pseudo_U\n"
+     ]
+    }
+   ],
+   "source": [
+    "print \"Method 1:\", custom_beam.OmegaP.keys()\n",
+    "print \"Method 2:\", custom_beam"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Creating your own `PSpecBeam` class\n",
+    "In case you have beam information in a custom format and want to create your own `PSpecBeam` class, subclass off `PSpecBeamBase`. This provides the `compute_pspec_scalar()` and `Jy_to_mK()` methods, and your subclass should provide `power_beam_int(stokes)` and `power_beam_sq_int(stokes)` methods.\n",
+    "\n",
+    "It should also set the `self.beam_freqs` and `self.cosmo` properties, as these are expected by the `PSpecBeamBase` methods."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.14"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/hera_pspec/__init__.py
+++ b/hera_pspec/__init__.py
@@ -7,7 +7,8 @@ from hera_pspec.uvpspec import UVPSpec
 from hera_pspec.pspecdata import PSpecData
 from hera_pspec.container import PSpecContainer
 from hera_pspec.parameter import PSpecParam
-from hera_pspec.pspecbeam import PSpecBeamUV
+from hera_pspec import pspecbeam as beam
+from hera_pspec.pspecbeam import PSpecBeamUV, PSpecBeamGauss, PSpecBeamFromArray
 
 # XXX: This will eventually be deprecated
 from hera_pspec import legacy_pspec as legacy

--- a/hera_pspec/pspecbeam.py
+++ b/hera_pspec/pspecbeam.py
@@ -524,7 +524,6 @@ class PSpecBeamFromArray(PSpecBeamBase):
         # Check that array dimensions are consistent
         if OmegaP.shape != self.beam_freqs.shape \
           or OmegaPP.shape != self.beam_freqs.shape:
-               print OmegaP.shape, OmegaPP.shape, self.beam_freqs.shape
                raise ValueError("OmegaP and OmegaPP should both "
                                 "have the same shape as beam_freqs.")
         # Store arrays

--- a/hera_pspec/pspecbeam.py
+++ b/hera_pspec/pspecbeam.py
@@ -8,8 +8,9 @@ from scipy import integrate
 from scipy.interpolate import interp1d
 
 
-def _compute_pspec_scalar(cosmo, beam_freqs, omega_ratio, pspec_freqs, num_steps=5000,
-                          taper='none', little_h=True, noise_scalar=False):
+def _compute_pspec_scalar(cosmo, beam_freqs, omega_ratio, pspec_freqs, 
+                          num_steps=5000, taper='none', little_h=True, 
+                          noise_scalar=False):
     """
     This is not to be used by the novice user to calculate a pspec scalar.
     Instead, look at the PSpecBeamUV and PSpecBeamGauss classes.
@@ -21,88 +22,105 @@ def _compute_pspec_scalar(cosmo, beam_freqs, omega_ratio, pspec_freqs, num_steps
 
     Parameters
     ----------
-    cosmo : hera_pspec.conversions.Cosmo_Conversions instance
-            Instance of the cosmological conversion object
-            conversions.Cosmo_Conversions()
+    cosmo : conversions.Cosmo_Conversions instance
+        Instance of the cosmological conversion object.
 
     beam_freqs : array of floats
-            Frequency of beam integrals in omega_ratio in units of Hz.
+        Frequency of beam integrals in omega_ratio in units of Hz.
 
     omega_ratio : array of floats
-            Ratio of the integrated squared-beam power over the square of the integrated beam power
-            for each frequency in beam_freqs. i.e. Omega_pp(nu) / Omega_p(nu)^2
+        Ratio of the integrated squared-beam power over the square of the 
+        integrated beam power for each frequency in beam_freqs. 
+        i.e. Omega_pp(nu) / Omega_p(nu)^2
 
     pspec_freqs : array of floats
-            Array of frequencies over which power spectrum is estimated in Hz.
+        Array of frequencies over which power spectrum is estimated in Hz.
 
     num_steps : int, optional
-            Number of steps to use when interpolating primary beams for
-            numerical integral
+        Number of steps to use when interpolating primary beams for numerical 
+        integral. Default: 5000.
 
     taper : str, optional
-            Whether a tapering function (e.g. Blackman-Harris) is being
-            used in the power spectrum estimation.
-            Default: none
+        Whether a tapering function (e.g. Blackman-Harris) is being used in the 
+        power spectrum estimation. Default: 'none'.
 
     little_h : boolean, optional
-            Whether to have cosmological length units be h^-1 Mpc or Mpc
-            Value of h is obtained from cosmo object stored in pspecbeam
-            Default: h^-1 Mpc
+        Whether to have cosmological length units be h^-1 Mpc or Mpc. Value of 
+        h is obtained from cosmo object stored in pspecbeam. Default: h^-1 Mpc.
 
     noise_scalar : boolean, optional
-            Whether to calculate power spectrum scalar, or noise power scalar. The noise power
-            scalar only differs in that the Bpp_over_BpSq term turns into 1_over_Bp.
-            See Pober et al. 2014, ApJ 782, 66, and Parsons HERA Memo #27
+        Whether to calculate power spectrum scalar, or noise power scalar. The 
+        noise power scalar only differs in that the Bpp_over_BpSq term turns 
+        into 1_over_Bp. See Pober et al. 2014, ApJ 782, 66, and Parsons HERA 
+        Memo #27. Default: False.
 
     Returns
     -------
     scalar: float
-            [\int dnu (\Omega_PP / \Omega_P^2) ( B_PP / B_P^2 ) / (X^2 Y)]^-1
-            in h^-3 Mpc^3 or Mpc^3.
+        [\int dnu (\Omega_PP / \Omega_P^2) ( B_PP / B_P^2 ) / (X^2 Y)]^-1
+        Units: h^-3 Mpc^3 or Mpc^3.
     """
-    # get integration freqs, redshift and cosmological scalars
+    # Get integration freqs
     df = np.median(np.diff(pspec_freqs))
-    integration_freqs = np.linspace(pspec_freqs.min(), pspec_freqs.min()+df*len(pspec_freqs), num_steps, endpoint=True, dtype=np.float)
-    integration_freqs_MHz = integration_freqs / 1e6  # The interpolations are generally more stable in MHz
+    integration_freqs = np.linspace(pspec_freqs.min(), 
+                                    pspec_freqs.min() + df*len(pspec_freqs), 
+                                    num_steps, endpoint=True, dtype=np.float)
+    
+    # The interpolations are generally more stable in MHz
+    integration_freqs_MHz = integration_freqs / 1e6
+    
+    # Get redshifts and cosmological functions
     redshifts = cosmo.f2z(integration_freqs).flatten()
     X2Y = np.array(map(lambda z: cosmo.X2Y(z, little_h=little_h), redshifts))
 
-    # Use linear interpolation to interpolate the frequency-dependent quantities
-    # derived from the beam model to the same frequency grid as the power spectrum
-    # estimation
+    # Use linear interpolation to interpolate the frequency-dependent 
+    # quantities derived from the beam model to the same frequency grid as the 
+    # power spectrum estimation
     beam_model_freqs_MHz = beam_freqs / 1e6
-    dOpp_over_Op2_fit = interp1d(beam_model_freqs_MHz, omega_ratio, kind='quadratic', fill_value='extrapolate')
+    dOpp_over_Op2_fit = interp1d(beam_model_freqs_MHz, omega_ratio, 
+                                 kind='quadratic', fill_value='extrapolate')
     dOpp_over_Op2 = dOpp_over_Op2_fit(integration_freqs_MHz)
 
     # Get B_pp = \int dnu taper^2 and Bp = \int dnu
     if taper == 'none':
         dBpp_over_BpSq = np.ones_like(integration_freqs, np.float)
     else:
-        dBpp_over_BpSq = aipy.dsp.gen_window(len(pspec_freqs), taper)**2
-        dBpp_over_BpSq = interp1d(pspec_freqs, dBpp_over_BpSq, kind='nearest', fill_value='extrapolate')(integration_freqs)
-    dBpp_over_BpSq /= (integration_freqs[-1] - integration_freqs[0])**2
+        dBpp_over_BpSq = aipy.dsp.gen_window(len(pspec_freqs), taper)**2.
+        dBpp_over_BpSq = interp1d(pspec_freqs, dBpp_over_BpSq, kind='nearest', 
+                                  fill_value='extrapolate')(integration_freqs)
+    dBpp_over_BpSq /= (integration_freqs[-1] - integration_freqs[0])**2.
 
     # Keep dBpp_over_BpSq term or not
     if noise_scalar:
-        dBpp_over_BpSq = 1/(integration_freqs[-1] - integration_freqs[0])
+        dBpp_over_BpSq = 1. / (integration_freqs[-1] - integration_freqs[0])
 
-    # integrate to get scalar
+    # Integrate to get scalar
     d_inv_scalar = dBpp_over_BpSq * dOpp_over_Op2 / X2Y
-    scalar = 1.0 / integrate.trapz(d_inv_scalar, x=integration_freqs)
-
+    scalar = 1. / integrate.trapz(d_inv_scalar, x=integration_freqs)
     return scalar
 
 
 class PSpecBeamBase(object):
 
     def __init__(self, cosmo=None):
+        """
+        Base class for PSpecBeam objects. Provides compute_pspec_scalar() 
+        method to integrate over and interpolate beam solid angles, and 
+        Jy_to_mK() method to convert units.
+        
+        Parameters
+        ----------
+        cosmo : conversions.Cosmo_Conversions object, optional
+            Cosmology object. Uses the default cosmology object if not 
+            specified. Default: None.
+        """
         if cosmo is not None:
             self.cosmo = cosmo
         else:
             self.cosmo = conversions.Cosmo_Conversions()
 
-    def compute_pspec_scalar(self, lower_freq, upper_freq, num_freqs, num_steps=5000, pol='I',
-                             taper='none', little_h=True, noise_scalar=False):
+    def compute_pspec_scalar(self, lower_freq, upper_freq, num_freqs, num_steps=5000, 
+                             pol='I', taper='none', little_h=True, noise_scalar=False):
         """
         Computes the scalar function to convert a power spectrum estimate
         in "telescope units" to cosmological units
@@ -115,21 +133,20 @@ class PSpecBeamBase(object):
 
         Parameters
         ----------
-        lower_freq: float
-                Bottom edge of frequency band over which power spectrum is
-                being estimated. Assumed to be in Hz.
+        lower_freq : float
+            Bottom edge of frequency band over which power spectrum is being 
+            estimated. Assumed to be in Hz.
 
-        upper_freq: float
-                Top edge of frequency band over which power spectrum is
-                being estimated. Assumed to be in Hz.
+        upper_freq : float
+            Top edge of frequency band over which power spectrum is being 
+            estimated. Assumed to be in Hz.
 
         num_freqs : int, optional
-                Number of frequencies used in estimating power spectrum.
+            Number of frequencies used in estimating power spectrum.
 
         num_steps : int, optional
-                Number of steps to use when interpolating primary beams for
-                numerical integral
-                Default: 10000
+            Number of steps to use when interpolating primary beams for 
+            numerical integral. Default: 10000.
 
         pol: str, optional
                 Which polarization to compute the beam scalar for.
@@ -137,53 +154,57 @@ class PSpecBeamBase(object):
                 Default: 'I'
 
         taper : str, optional
-                Whether a tapering function (e.g. Blackman-Harris) is being
-                used in the power spectrum estimation.
-                Default: none
+            Whether a tapering function (e.g. Blackman-Harris) is being used in 
+            the power spectrum estimation. Default: none.
 
         little_h : boolean, optional
-                Whether to have cosmological length units be h^-1 Mpc or Mpc
-                Value of h is obtained from cosmo object stored in pspecbeam
-                Default: h^-1 Mpc
+            Whether to have cosmological length units be h^-1 Mpc or Mpc. Value 
+            of h is obtained from cosmo object stored in pspecbeam.
+            Default: h^-1 Mpc
 
         noise_scalar : boolean, optional
-                Whether to calculate power spectrum scalar, or noise power scalar. The noise power
-                scalar only differs in that the Bpp_over_BpSq term just because 1_over_Bp.
-                See Pober et al. 2014, ApJ 782, 66
+            Whether to calculate power spectrum scalar, or noise power scalar. 
+            The noise power scalar only differs in that the Bpp_over_BpSq term 
+            just because 1_over_Bp. See Pober et al. 2014, ApJ 782, 66.
 
         Returns
         -------
         scalar: float
-                [\int dnu (\Omega_PP / \Omega_P^2) ( B_PP / B_P^2 ) / (X^2 Y)]^-1
-                in h^-3 Mpc^3 or Mpc^3.
+            [\int dnu (\Omega_PP / \Omega_P^2) ( B_PP / B_P^2 ) / (X^2 Y)]^-1
+            Units: h^-3 Mpc^3 or Mpc^3.
         """
-        # get pspec_Freqs
-        pspec_freqs = np.linspace(lower_freq, upper_freq, num_freqs, endpoint=False)
+        # Get pspec_freqs
+        pspec_freqs = np.linspace(lower_freq, upper_freq, num_freqs, 
+                                  endpoint=False)
 
         # Get omega_ratio
-        omega_ratio = self.power_beam_sq_int(pol) / self.power_beam_int(pol)**2
+        omega_ratio = self.power_beam_sq_int(pol) \
+                      / self.power_beam_int(pol)**2
 
         # Get scalar
-        scalar = _compute_pspec_scalar(self.cosmo, self.beam_freqs, omega_ratio, pspec_freqs,
-                                       num_steps=num_steps, taper=taper, little_h=little_h,
+        scalar = _compute_pspec_scalar(self.cosmo, self.beam_freqs, 
+                                       omega_ratio, pspec_freqs,
+                                       num_steps=num_steps, taper=taper, 
+                                       little_h=little_h,
                                        noise_scalar=noise_scalar)
-
         return scalar
 
     def Jy_to_mK(self, freqs, pol='I'):
         """
-        Return the multiplicative factor, M [mK / Jy], to convert a visibility from Jy -> mK,
+        Return the multiplicative factor [mK / Jy], to convert a visibility 
+        from Jy -> mK,
 
-        M = 1e3 * 1e-23 * c^2 / [2 * k_b * nu^2 * Omega_p(nu)]
+        factor = 1e3 * 1e-23 * c^2 / [2 * k_b * nu^2 * Omega_p(nu)]
 
         where k_b is boltzmann constant, c is speed of light, nu is frequency 
         and Omega_p is the integral of the unitless beam-response (steradians),
-        and the 1e3 is the conversion from K -> mK and the 1e-23 is the conversion 
-        from Jy to cgs.
+        and the 1e3 is the conversion from K -> mK and the 1e-23 is the 
+        conversion from Jy to cgs.
 
         Parameters
         ----------
-        freqs : float ndarray, contains frequencies to evaluate conversion factor [Hz]
+        freqs : float ndarray
+            Contains frequencies to evaluate conversion factor [Hz].
 
         pol: str, optional
                 Which polarization to compute the beam scalar for.
@@ -192,37 +213,50 @@ class PSpecBeamBase(object):
 
         Returns
         -------
-        M : float ndarray, contains Jy -> mK factor at each frequency
+        factor : float ndarray
+            Contains Jy -> mK factor at each frequency.
         """
+        # Check input types
         if isinstance(freqs, (np.float, float)):
             freqs = np.array([freqs])
         elif not isinstance(freqs, np.ndarray):
             raise TypeError("freqs must be fed as a float ndarray")
-        elif isinstance(freqs, np.ndarray) and freqs.dtype not in (float, np.float, np.float64):
+        elif isinstance(freqs, np.ndarray) \
+            and freqs.dtype not in (float, np.float, np.float64):
             raise TypeError("freqs must be fed as a float ndarray")
+        
+        # Check frequency bounds
         if np.min(freqs) < self.beam_freqs.min():
             raise ValueError("Warning: min freq {} < self.beam_freqs.min(), extrapolating...".format(np.min(freqs)))
         if np.max(freqs) > self.beam_freqs.max(): 
             raise ValueError("Warning: max freq {} > self.beam_freqs.max(), extrapolating...".format(np.max(freqs)))
+        
+        Op = interp1d(self.beam_freqs/1e6, self.power_beam_int(pol=pol), 
+                      kind='quadratic', fill_value='extrapolate')(freqs/1e6)
 
-        Op = interp1d(self.beam_freqs/1e6, self.power_beam_int(pol=pol), kind='quadratic', fill_value='extrapolate')(freqs/1e6)
-
-        return 1e-20 * conversions.cgs_units.c**2 / (2 * conversions.cgs_units.kb * freqs**2 * Op)
+        return 1e-20 * conversions.cgs_units.c**2 \
+               / (2 * conversions.cgs_units.kb * freqs**2 * Op)
 
 
 class PSpecBeamGauss(PSpecBeamBase):
 
     def __init__(self, fwhm, beam_freqs, cosmo=None):
         """
-        Object to store a toy (frequency independent) Gaussian beam in a PspecBeamBase object
+        Object to store a simple (frequency independent) Gaussian beam in a 
+        PspecBeamBase object.
 
         Parameters
         ----------
-        fwhm: float, in radians
-                Full width half max of the beam
+        fwhm: float
+            Full width half max of the beam, in radians.
 
         beam_freqs: float, array-like
-                Frequencies over which this Gaussian beam is to be created. Units assumed to be Hz.
+            Frequencies over which this Gaussian beam is to be created. Units 
+            assumed to be Hz.
+        
+        cosmo : conversions.Cosmo_Conversions object, optional
+            Cosmology object. Uses the default cosmology object if not 
+            specified. Default: None.
         """
         self.fwhm = fwhm
         self.beam_freqs = beam_freqs
@@ -252,9 +286,11 @@ class PSpecBeamGauss(PSpecBeamBase):
 
         Returns
         -------
-        primary beam area: float, array-like
+        primary_beam_area: float, array-like
+            Primary beam area.
         """
-        return np.ones_like(self.beam_freqs) * 2. * np.pi * self.fwhm**2 / (8. * np.log(2.))
+        return np.ones_like(self.beam_freqs) * 2. * np.pi * self.fwhm**2 \
+               / (8. * np.log(2.))
 
     def power_beam_sq_int(self, pol='I'):
         """
@@ -277,9 +313,11 @@ class PSpecBeamGauss(PSpecBeamBase):
 
         Returns
         -------
-        primary beam area: float, array-like
+        primary_beam_area: float, array-like
+            Primary beam area.
         """
-        return np.ones_like(self.beam_freqs) * np.pi * self.fwhm**2 / (8. * np.log(2.))
+        return np.ones_like(self.beam_freqs) * np.pi * self.fwhm**2 \
+               / (8. * np.log(2.))
 
 
 class PSpecBeamUV(PSpecBeamBase):
@@ -293,7 +331,11 @@ class PSpecBeamUV(PSpecBeamBase):
         Parameters
         ----------
         beam_fname: str
-                Path to a pyuvdata UVBeam file
+            Path to a pyuvdata UVBeam file.
+        
+        cosmo : conversions.Cosmo_Conversions object, optional
+            Cosmology object. Uses the default cosmology object if not 
+            specified. Default: None.
         """
         self.primary_beam = pyuvdata.UVBeam()
         self.primary_beam.read_beamfits(beam_fname)
@@ -322,7 +364,8 @@ class PSpecBeamUV(PSpecBeamBase):
 
         Returns
         -------
-        primary beam area: float, array-like
+        primary_beam_area: float, array-like
+            Scalar integral over beam solid angle.
         """
         if hasattr(self.primary_beam, 'get_beam_area'):
             return self.primary_beam.get_beam_area(pol)
@@ -347,9 +390,206 @@ class PSpecBeamUV(PSpecBeamBase):
 
         Returns
         -------
-        primary beam area: float, array-like
+        primary_beam_area: float, array-like
         """
         if hasattr(self.primary_beam, 'get_beam_area'):
             return self.primary_beam.get_beam_sq_area(pol)
         else:
             raise NotImplementedError("Outdated version of pyuvdata.")
+
+
+class PSpecBeamFromArray(PSpecBeamBase):
+    
+    def __init__(self, OmegaP, OmegaPP, beam_freqs, cosmo=None):
+        """
+        Primary beam model built from user-defined arrays for the integrals 
+        over beam solid angle and beam solid angle squared.
+        
+        Allowed polarizations are: 
+        
+            pseudo_I, pseudo_Q, pseudo_U, pseudo_V, XX, YY, XY, YX
+        
+        Other polarizations will be ignored.
+        
+        Parameters
+        ----------
+        OmegaP : array_like of float (or dict of array_like)
+            Integral over beam solid angle, as a function of frequency. 
+            
+            If only one array is specified, this will be assumed to be for the 
+            pseudo_I polarization. If a dict is specified, an OmegaP array for 
+            several polarizations can be specified.
+        
+        OmegaPP : array_like of float (or dict of array_like)
+            Integral over beam solid angle squared, as a function of frequency. 
+            
+            If only one array is specified, this will be assumed to be for the 
+            pseudo_I polarization. If a dict is specified, an OmegaP array for 
+            several polarizations can be specified.
+        
+        beam_freqs : array_like of float
+            Frequencies at which beam solid angles OmegaP and OmegaPP are 
+            evaluated, in Hz. This should be specified as a single array, not 
+            as a dict.
+        
+        cosmo : conversions.Cosmo_Conversions object, optional
+            Cosmology object. Uses the default cosmology object if not 
+            specified. Default: None.
+        """
+        self.allowed_pols = ['pseudo_I', 'pseudo_Q', 'pseudo_U', 'pseudo_V', 
+                             'XX', 'YY', 'XY', 'YX']
+        self.OmegaP = {}; self.OmegaPP = {}
+        
+        # Set beam_freqs
+        self.beam_freqs = np.array(beam_freqs)
+        
+        if isinstance(OmegaP, np.ndarray) and isinstance(OmegaPP, np.ndarray):
+            # Only single arrays were specified; assume pseudo_I
+            OmegaP = {'pseudo_I': OmegaP}
+            OmegaPP = {'pseudo_I': OmegaPP}
+        
+        elif isinstance(OmegaP, np.ndarray) or isinstance(OmegaPP, np.ndarray):
+            # Mixed dict and array types are not allowed
+            raise TypeError("OmegaP and OmegaPP must both be either dicts "
+                            "or arrays. Mixing dicts and arrays is not "
+                            "allowed.")
+        else:
+            pass
+        
+        # Should now have two dicts if everything is OK
+        if not isinstance(OmegaP, dict) or not isinstance(OmegaPP, dict):
+            raise TypeError("OmegaP and OmegaPP must both be either dicts or "
+                            "arrays.")
+        
+        # Check for disallowed polarizations
+        for key in OmegaP.keys():
+            if key not in self.allowed_pols:
+              raise KeyError("Unrecognized polarization '%s' in OmegaP." % key)
+        for key in OmegaPP.keys():
+            if key not in self.allowed_pols:
+              raise KeyError("Unrecognized polarization '%s' in OmegaPP." % key)
+        
+        # Check for available polarizations
+        for pol in self.allowed_pols:
+            if pol in OmegaP.keys() or pol in OmegaPP.keys():
+                if pol not in OmegaP.keys() or pol not in OmegaPP.keys():
+                    raise KeyError("Polarization '%s' must be specified for"
+                                   " both OmegaP and OmegaPP." % pol)
+                
+                # Add arrays for this polarization
+                self.add_pol(pol, OmegaP[pol], OmegaPP[pol])
+        
+        # Set cosmology
+        if cosmo is None:
+            self.cosmo = conversions.Cosmo_Conversions()
+        else:
+            self.cosmo = cosmo
+    
+    
+    def add_pol(self, pol, OmegaP, OmegaPP):
+        """
+        Add OmegaP and OmegaPP for a new polarization.
+        
+        Parameters
+        ----------
+        pol: str
+            Which polarization to add beam solid angle arrays for. Valid 
+            options are:
+            
+              'pseudo_I', 'pseudo_Q', 'pseudo_U', 'pseudo_V', 
+              'XX', 'YY', 'XY', 'YX' 
+            
+            If the arrays already exist for the specified polarization, they 
+            will be overwritten.
+        
+        OmegaP : array_like of float
+            Integral over beam solid angle, as a function of frequency. Must 
+            have the same shape as self.beam_freqs.
+        
+        OmegaPP : array_like of float
+            Integral over beam solid angle squared, as a function of frequency.  
+            Must have the same shape as self.beam_freqs.
+        """
+        # Check for allowed polarization
+        if pol not in self.allowed_pols:
+            raise KeyError("Polarization '%s' is not valid." % pol)
+        
+        # Make sure OmegaP and OmegaPP are arrays
+        try:
+            OmegaP = np.array(OmegaP).astype(float)
+            OmegaPP = np.array(OmegaPP).astype(float)
+        except:
+            raise TypeError("OmegaP and OmegaPP must both be array_like.")
+        
+        # Check that array dimensions are consistent
+        if OmegaP.shape != self.beam_freqs.shape \
+          or OmegaPP.shape != self.beam_freqs.shape:
+               print OmegaP.shape, OmegaPP.shape, self.beam_freqs.shape
+               raise ValueError("OmegaP and OmegaPP should both "
+                                "have the same shape as beam_freqs.")
+        # Store arrays
+        self.OmegaP[pol] = OmegaP
+        self.OmegaPP[pol] = OmegaPP
+            
+    
+    def power_beam_int(self, stokes='pseudo_I'):
+        """
+        Computes the integral of the beam over solid angle to give
+        a beam area (in str) as a function of frequency.
+
+        Parameters
+        ----------
+        stokes: str, optional
+            Which Stokes parameters to compute the beam scalar for. 
+                'pseudo_I', 'pseudo_Q', 'pseudo_U', 'pseudo_V', 
+                'XX', 'YY', 'XY', 'YX'
+            Default: pseudo_I.
+
+        Returns
+        -------
+        primary_beam_area: float, array-like
+            Scalar integral over beam solid angle.
+        """
+        if stokes in self.OmegaP.keys():
+            return self.OmegaP[stokes]
+        else:
+            available_pols = ", ".join(self.OmegaP.keys())
+            raise KeyError("OmegaP not specified for polarization '%s'. " 
+                           "Available polarizations are: %s" \
+                           % (stokes, available_pols))
+    
+    def power_beam_sq_int(self, stokes='pseudo_I'):
+        """
+        Computes the integral of the beam**2 over solid angle to give
+        a beam**2 area (in str) as a function of frequency.
+
+        Parameters
+        ----------
+        stokes: str, optional
+            Which Stokes parameters to compute the beam scalar for.
+              'pseudo_I', 'pseudo_Q', 'pseudo_U', 'pseudo_V', 
+              'XX', 'YY', 'XY', 'YX' 
+            Default: pseudo_I.
+
+        Returns
+        -------
+        primary_beam_area: float, array-like
+        """
+        if stokes in self.OmegaPP.keys():
+            return self.OmegaPP[stokes]
+        else:
+            available_pols = ", ".join(self.OmegaPP.keys())
+            raise KeyError("OmegaPP not specified for polarization '%s'. " 
+                           "Available polarizations are: %s" \
+                           % (stokes, available_pols))
+    
+    def __str__(self):
+        """
+        Print string with useful information.
+        """
+        s = "PSpecBeamFromArray object\n"
+        s += "\tFrequency range: Min. %4.4e Hz, Max. %4.4e Hz\n" \
+              % (np.min(self.beam_freqs), np.max(self.beam_freqs))
+        s += "\tAvailable pols: %s" % (", ".join(self.OmegaP.keys()))
+        return s
+        

--- a/hera_pspec/pspecbeam.py
+++ b/hera_pspec/pspecbeam.py
@@ -146,7 +146,7 @@ class PSpecBeamBase(object):
 
         num_steps : int, optional
             Number of steps to use when interpolating primary beams for 
-            numerical integral. Default: 10000.
+            numerical integral. Default: 5000.
 
         pol: str, optional
                 Which polarization to compute the beam scalar for.

--- a/hera_pspec/pspecbeam.py
+++ b/hera_pspec/pspecbeam.py
@@ -407,7 +407,7 @@ class PSpecBeamFromArray(PSpecBeamBase):
         
         Allowed polarizations are: 
         
-            pseudo_I, pseudo_Q, pseudo_U, pseudo_V, XX, YY, XY, YX
+            I, Q, U, V, XX, YY, XY, YX
         
         Other polarizations will be ignored.
         
@@ -417,14 +417,14 @@ class PSpecBeamFromArray(PSpecBeamBase):
             Integral over beam solid angle, as a function of frequency. 
             
             If only one array is specified, this will be assumed to be for the 
-            pseudo_I polarization. If a dict is specified, an OmegaP array for 
+            I polarization. If a dict is specified, an OmegaP array for 
             several polarizations can be specified.
         
         OmegaPP : array_like of float (or dict of array_like)
             Integral over beam solid angle squared, as a function of frequency. 
             
             If only one array is specified, this will be assumed to be for the 
-            pseudo_I polarization. If a dict is specified, an OmegaP array for 
+            I polarization. If a dict is specified, an OmegaP array for 
             several polarizations can be specified.
         
         beam_freqs : array_like of float
@@ -436,7 +436,7 @@ class PSpecBeamFromArray(PSpecBeamBase):
             Cosmology object. Uses the default cosmology object if not 
             specified. Default: None.
         """
-        self.allowed_pols = ['pseudo_I', 'pseudo_Q', 'pseudo_U', 'pseudo_V', 
+        self.allowed_pols = ['I', 'Q', 'U', 'V', 
                              'XX', 'YY', 'XY', 'YX']
         self.OmegaP = {}; self.OmegaPP = {}
         
@@ -444,9 +444,9 @@ class PSpecBeamFromArray(PSpecBeamBase):
         self.beam_freqs = np.array(beam_freqs)
         
         if isinstance(OmegaP, np.ndarray) and isinstance(OmegaPP, np.ndarray):
-            # Only single arrays were specified; assume pseudo_I
-            OmegaP = {'pseudo_I': OmegaP}
-            OmegaPP = {'pseudo_I': OmegaPP}
+            # Only single arrays were specified; assume I
+            OmegaP = {'I': OmegaP}
+            OmegaPP = {'I': OmegaPP}
         
         elif isinstance(OmegaP, np.ndarray) or isinstance(OmegaPP, np.ndarray):
             # Mixed dict and array types are not allowed
@@ -496,7 +496,7 @@ class PSpecBeamFromArray(PSpecBeamBase):
             Which polarization to add beam solid angle arrays for. Valid 
             options are:
             
-              'pseudo_I', 'pseudo_Q', 'pseudo_U', 'pseudo_V', 
+              'I', 'Q', 'U', 'V', 
               'XX', 'YY', 'XY', 'YX' 
             
             If the arrays already exist for the specified polarization, they 
@@ -531,56 +531,56 @@ class PSpecBeamFromArray(PSpecBeamBase):
         self.OmegaPP[pol] = OmegaPP
             
     
-    def power_beam_int(self, stokes='pseudo_I'):
+    def power_beam_int(self, pol='I'):
         """
         Computes the integral of the beam over solid angle to give
         a beam area (in str) as a function of frequency.
 
         Parameters
         ----------
-        stokes: str, optional
-            Which Stokes parameters to compute the beam scalar for. 
-                'pseudo_I', 'pseudo_Q', 'pseudo_U', 'pseudo_V', 
+        pol: str, optional
+            Which polarization to compute the beam scalar for. 
+                'I', 'Q', 'U', 'V', 
                 'XX', 'YY', 'XY', 'YX'
-            Default: pseudo_I.
+            Default: I.
 
         Returns
         -------
         primary_beam_area: float, array-like
             Scalar integral over beam solid angle.
         """
-        if stokes in self.OmegaP.keys():
-            return self.OmegaP[stokes]
+        if pol in self.OmegaP.keys():
+            return self.OmegaP[pol]
         else:
             available_pols = ", ".join(self.OmegaP.keys())
             raise KeyError("OmegaP not specified for polarization '%s'. " 
                            "Available polarizations are: %s" \
-                           % (stokes, available_pols))
+                           % (pol, available_pols))
     
-    def power_beam_sq_int(self, stokes='pseudo_I'):
+    def power_beam_sq_int(self, pol='I'):
         """
         Computes the integral of the beam**2 over solid angle to give
         a beam**2 area (in str) as a function of frequency.
 
         Parameters
         ----------
-        stokes: str, optional
-            Which Stokes parameters to compute the beam scalar for.
-              'pseudo_I', 'pseudo_Q', 'pseudo_U', 'pseudo_V', 
+        pol: str, optional
+            Which polarization to compute the beam scalar for.
+              'I', 'Q', 'U', 'V', 
               'XX', 'YY', 'XY', 'YX' 
-            Default: pseudo_I.
+            Default: I.
 
         Returns
         -------
         primary_beam_area: float, array-like
         """
-        if stokes in self.OmegaPP.keys():
-            return self.OmegaPP[stokes]
+        if pol in self.OmegaPP.keys():
+            return self.OmegaPP[pol]
         else:
             available_pols = ", ".join(self.OmegaPP.keys())
             raise KeyError("OmegaPP not specified for polarization '%s'. " 
                            "Available polarizations are: %s" \
-                           % (stokes, available_pols))
+                           % (pol, available_pols))
     
     def __str__(self):
         """

--- a/hera_pspec/tests/test_pspecbeam.py
+++ b/hera_pspec/tests/test_pspecbeam.py
@@ -195,9 +195,16 @@ class Test_DataSet(unittest.TestCase):
                          OmegaPP={'pseudo_I': 'string',},
                          beam_freqs=beam_freqs)
         
+        nt.assert_raises(ValueError, pspecbeam.PSpecBeamFromArray,
+                         OmegaP={'pseudo_I': Om_P}, 
+                         OmegaPP={'pseudo_I': Om_PP[:-2],},
+                         beam_freqs=beam_freqs)
+        
         # Check that invalid method args raise errors
         nt.assert_raises(KeyError, psbeam.power_beam_int, stokes='blah')
         nt.assert_raises(KeyError, psbeam.power_beam_sq_int, stokes='blah')
+        nt.assert_raises(KeyError, psbeam.add_pol, pol='pseudo_A', 
+                         OmegaP=Om_P, OmegaPP=Om_PP)
         
         # Check that string works
         self.assert_(len(str(psbeam)) > 0)

--- a/hera_pspec/tests/test_pspecbeam.py
+++ b/hera_pspec/tests/test_pspecbeam.py
@@ -150,8 +150,8 @@ class Test_DataSet(unittest.TestCase):
                                               beam_freqs=beam_freqs)
         
         psbeampol = pspecbeam.PSpecBeamFromArray(
-                                OmegaP={'pseudo_I': Om_P, 'pseudo_Q': Om_P},
-                                OmegaPP={'pseudo_I': Om_PP, 'pseudo_Q': Om_PP},
+                                OmegaP={'I': Om_P, 'Q': Om_P},
+                                OmegaPP={'I': Om_PP, 'Q': Om_PP},
                                 beam_freqs=beam_freqs)
         
         # Check that user-defined cosmology can be specified
@@ -161,15 +161,15 @@ class Test_DataSet(unittest.TestCase):
         
         # Compare scalar calculation with Gaussian case
         scalar = psbeam.compute_pspec_scalar(lower_freq, upper_freq, num_freqs, 
-                                             stokes='pseudo_I', num_steps=2000)
+                                             pol='I', num_steps=2000)
         g_scalar = self.gauss.compute_pspec_scalar(lower_freq, upper_freq, 
-                                                   num_freqs, stokes='pseudo_I', 
+                                                   num_freqs, pol='I', 
                                                    num_steps=2000)
         np.testing.assert_array_almost_equal(scalar, g_scalar)
         
         # Check that polarizations are recognized and invalid ones rejected
         scalarp = psbeampol.compute_pspec_scalar(lower_freq, upper_freq, 
-                                                 num_freqs, stokes='pseudo_Q', 
+                                                 num_freqs, pol='Q', 
                                                  num_steps=2000)
         
         # Test taper execution (same as Gaussian case)
@@ -179,31 +179,31 @@ class Test_DataSet(unittest.TestCase):
         
         # Check that invalid init args raise errors
         nt.assert_raises(TypeError, pspecbeam.PSpecBeamFromArray, OmegaP=Om_P, 
-                         OmegaPP={'pseudo_I': Om_PP}, beam_freqs=beam_freqs)
+                         OmegaPP={'I': Om_PP}, beam_freqs=beam_freqs)
         nt.assert_raises(KeyError, pspecbeam.PSpecBeamFromArray,
-                         OmegaP={'pseudo_I': Om_P, 'pseudo_Q': Om_P},
-                         OmegaPP={'pseudo_I': Om_PP,},
+                         OmegaP={'I': Om_P, 'Q': Om_P},
+                         OmegaPP={'I': Om_PP,},
                          beam_freqs=beam_freqs)
         
         nt.assert_raises(KeyError, pspecbeam.PSpecBeamFromArray,
-                         OmegaP={'pseudo_A': Om_P}, 
-                         OmegaPP={'pseudo_A': Om_PP,},
+                         OmegaP={'A': Om_P}, 
+                         OmegaPP={'A': Om_PP,},
                          beam_freqs=beam_freqs)
         
         nt.assert_raises(TypeError, pspecbeam.PSpecBeamFromArray,
-                         OmegaP={'pseudo_I': Om_P,},
-                         OmegaPP={'pseudo_I': 'string',},
+                         OmegaP={'I': Om_P,},
+                         OmegaPP={'I': 'string',},
                          beam_freqs=beam_freqs)
         
         nt.assert_raises(ValueError, pspecbeam.PSpecBeamFromArray,
-                         OmegaP={'pseudo_I': Om_P}, 
-                         OmegaPP={'pseudo_I': Om_PP[:-2],},
+                         OmegaP={'I': Om_P}, 
+                         OmegaPP={'I': Om_PP[:-2],},
                          beam_freqs=beam_freqs)
         
         # Check that invalid method args raise errors
-        nt.assert_raises(KeyError, psbeam.power_beam_int, stokes='blah')
-        nt.assert_raises(KeyError, psbeam.power_beam_sq_int, stokes='blah')
-        nt.assert_raises(KeyError, psbeam.add_pol, pol='pseudo_A', 
+        nt.assert_raises(KeyError, psbeam.power_beam_int, pol='blah')
+        nt.assert_raises(KeyError, psbeam.power_beam_sq_int, pol='blah')
+        nt.assert_raises(KeyError, psbeam.add_pol, pol='A', 
                          OmegaP=Om_P, OmegaPP=Om_PP)
         
         # Check that string works


### PR DESCRIPTION
Adds new `PSpecBeamFromArray` object that lets users build `PSpecBeam` objects from a set of arrays. Based on suggestion from Nick and Ridhima in issue #79.

This PR will also include an example Jupyter notebook.