### PR TITLE
changed "pseudo_stokes" to just "stokes" across the repo

### DIFF
--- a/hera_pspec/noise.py
+++ b/hera_pspec/noise.py
@@ -67,7 +67,7 @@ class Sensitivity(object):
 
         self.beam = beam
 
-    def calc_scalar(self, freqs, stokes, num_steps=5000, little_h=True):
+    def calc_scalar(self, freqs, pol, num_steps=5000, little_h=True):
         """
         Calculate noise power spectrum prefactor from Eqn. (1) of Pober et al. 2014, ApJ 782, 66,
         equal to 
@@ -78,7 +78,7 @@ class Sensitivity(object):
         ----------
         freqs : float ndarray, holds frequency bins of spectral window in Hz
 
-        stokes : str, specification of (pseudo) Stokes polarization, or linear dipole polarization
+        pol : str, specification of polarization to calculate scalar for
             See pyuvdata.utils.polstr2num for options.
 
         num_steps : number of frequency bins to use in numerical integration of scalar
@@ -93,13 +93,13 @@ class Sensitivity(object):
 
         self.subband : float ndarray, frequencies in spectral window used to calculate self.scalar
 
-        self.stokes : str, stokes polarization used to calculate self.scalar
+        self.pol : str, polarization used to calculate self.scalar
         """
-        # parse stokes
+        # compute scalar
         self.scalar = self.beam.compute_pspec_scalar(freqs.min(), freqs.max(), len(freqs), num_steps=num_steps, 
-                                                     stokes=stokes, little_h=little_h, noise_scalar=True)
+                                                     pol=pol, little_h=little_h, noise_scalar=True)
         self.subband = freqs
-        self.stokes = stokes
+        self.pol = pol
 
     def calc_P_N(self, Tsys, t_int, Ncoherent=1, Nincoherent=None, form='Pk', k=None, little_h=True):
         """

--- a/hera_pspec/noise.py
+++ b/hera_pspec/noise.py
@@ -96,7 +96,6 @@ class Sensitivity(object):
         self.stokes : str, stokes polarization used to calculate self.scalar
         """
         # parse stokes
-        if stokes == 'I': stokes = 'pseudo_I'
         self.scalar = self.beam.compute_pspec_scalar(freqs.min(), freqs.max(), len(freqs), num_steps=num_steps, 
                                                      stokes=stokes, little_h=little_h, noise_scalar=True)
         self.subband = freqs

--- a/hera_pspec/pspecbeam.py
+++ b/hera_pspec/pspecbeam.py
@@ -101,7 +101,7 @@ class PSpecBeamBase(object):
         else:
             self.cosmo = conversions.Cosmo_Conversions()
 
-    def compute_pspec_scalar(self, lower_freq, upper_freq, num_freqs, num_steps=5000, stokes='I',
+    def compute_pspec_scalar(self, lower_freq, upper_freq, num_freqs, num_steps=5000, pol='I',
                              taper='none', little_h=True, noise_scalar=False):
         """
         Computes the scalar function to convert a power spectrum estimate
@@ -109,7 +109,7 @@ class PSpecBeamBase(object):
 
         See arxiv:1304.4991 and HERA memo #27 for details.
 
-        Currently, only the Stokes "I", "XX" and "YY" beam are supported.
+        Currently, only the "I", "XX" and "YY" polarization beams are supported.
         See Equations 4 and 5 of Moore et al. (2017) ApJ 836, 154
         or arxiv:1502.05072 for details.
 
@@ -131,10 +131,9 @@ class PSpecBeamBase(object):
                 numerical integral
                 Default: 10000
 
-        stokes: str, optional
-                Which Stokes parameter's to compute the beam scalar for.
+        pol: str, optional
+                Which polarization to compute the beam scalar for.
                 'I', 'Q', 'U', 'V', 'XX', 'YY', 'XY', 'YX', although 
-                currently only 'I' and linear dipole pol (e.g. 'XX') are implemented.
                 Default: 'I'
 
         taper : str, optional
@@ -162,7 +161,7 @@ class PSpecBeamBase(object):
         pspec_freqs = np.linspace(lower_freq, upper_freq, num_freqs, endpoint=False)
 
         # Get omega_ratio
-        omega_ratio = self.power_beam_sq_int(stokes) / self.power_beam_int(stokes)**2
+        omega_ratio = self.power_beam_sq_int(pol) / self.power_beam_int(pol)**2
 
         # Get scalar
         scalar = _compute_pspec_scalar(self.cosmo, self.beam_freqs, omega_ratio, pspec_freqs,
@@ -171,7 +170,7 @@ class PSpecBeamBase(object):
 
         return scalar
 
-    def Jy_to_mK(self, freqs, stokes='I'):
+    def Jy_to_mK(self, freqs, pol='I'):
         """
         Return the multiplicative factor, M [mK / Jy], to convert a visibility from Jy -> mK,
 
@@ -186,10 +185,9 @@ class PSpecBeamBase(object):
         ----------
         freqs : float ndarray, contains frequencies to evaluate conversion factor [Hz]
 
-        stokes: str, optional
-                Which Stokes parameter's to compute the beam scalar for.
+        pol: str, optional
+                Which polarization to compute the beam scalar for.
                 'I', 'Q', 'U', 'V', 'XX', 'YY', 'XY', 'YX', although 
-                currently only 'I' and linear dipole pol (e.g. 'XX') are implemented.
                 Default: 'I'
 
         Returns
@@ -207,7 +205,7 @@ class PSpecBeamBase(object):
         if np.max(freqs) > self.beam_freqs.max(): 
             raise ValueError("Warning: max freq {} > self.beam_freqs.max(), extrapolating...".format(np.max(freqs)))
 
-        Op = interp1d(self.beam_freqs/1e6, self.power_beam_int(stokes=stokes), kind='quadratic', fill_value='extrapolate')(freqs/1e6)
+        Op = interp1d(self.beam_freqs/1e6, self.power_beam_int(pol=pol), kind='quadratic', fill_value='extrapolate')(freqs/1e6)
 
         return 1e-20 * conversions.cgs_units.c**2 / (2 * conversions.cgs_units.kb * freqs**2 * Op)
 
@@ -233,7 +231,7 @@ class PSpecBeamGauss(PSpecBeamBase):
         else:
             self.cosmo = conversions.Cosmo_Conversions()
 
-    def power_beam_int(self, stokes='I'):
+    def power_beam_int(self, pol='I'):
         """
         Computes the integral of the beam over solid angle to give
         a beam area (in sr). Uses analytic formula that the answer
@@ -242,16 +240,14 @@ class PSpecBeamGauss(PSpecBeamBase):
         Trivially this returns an array (i.e., a function of frequency),
         but the results are frequency independent.
 
-        Currently, only the Stokes "I", "XX" and "YY" beam are supported.
         See Equations 4 and 5 of Moore et al. (2017) ApJ 836, 154
         or arxiv:1502.05072 for details.
 
         Parameters
         ----------
-        stokes: str, optional
-                Which Stokes parameter's to compute the beam scalar for.
-                'I', 'Q', 'U', 'V', 'XX', 'YY', 'XY', 'YX', although 
-                currently only 'I' and linear dipole pol (e.g. 'XX') are implemented.
+        pol: str, optional
+                Which polarization to compute the beam scalar for.
+                'I', 'Q', 'U', 'V', 'XX', 'YY', 'XY', 'YX' 
                 Default: 'I'
 
         Returns
@@ -260,7 +256,7 @@ class PSpecBeamGauss(PSpecBeamBase):
         """
         return np.ones_like(self.beam_freqs) * 2. * np.pi * self.fwhm**2 / (8. * np.log(2.))
 
-    def power_beam_sq_int(self, stokes='I'):
+    def power_beam_sq_int(self, pol='I'):
         """
         Computes the integral of the beam**2 over solid angle to give
         a beam area (in str). Uses analytic formula that the answer
@@ -269,16 +265,14 @@ class PSpecBeamGauss(PSpecBeamBase):
         Trivially this returns an array (i.e., a function of frequency),
         but the results are frequency independent.
 
-        Currently, only the Stokes "I", "XX" and "YY" beam are supported.
         See Equations 4 and 5 of Moore et al. (2017) ApJ 836, 154
         or arxiv:1502.05072 for details.
 
         Parameters
         ----------
-        stokes: str, optional
-                Which Stokes parameter's to compute the beam scalar for.
-                'I', 'Q', 'U', 'V', 'XX', 'YY', 'XY', 'YX', although 
-                currently only 'I' and linear dipole pol (e.g. 'XX') are implemented.
+        pol: str, optional
+                Which polarization to compute the beam scalar for.
+                'I', 'Q', 'U', 'V', 'XX', 'YY', 'XY', 'YX' 
                 Default: 'I'
 
         Returns
@@ -310,22 +304,20 @@ class PSpecBeamUV(PSpecBeamBase):
         else:
             self.cosmo = conversions.Cosmo_Conversions()
 
-    def power_beam_int(self, stokes='I'):
+    def power_beam_int(self, pol='I'):
         """
         Computes the integral of the beam over solid angle to give
         a beam area (in str) as a function of frequency. Uses function
         in pyuvdata.
 
-        Currently, only the Stokes "I", "XX" and "YY" beam are supported.
         See Equations 4 and 5 of Moore et al. (2017) ApJ 836, 154
         or arxiv:1502.05072 for details.
 
         Parameters
         ----------
-        stokes: str, optional
-                Which Stokes parameter's to compute the beam scalar for.
-                'I', 'Q', 'U', 'V', 'XX', 'YY', 'XY', 'YX', although 
-                currently only 'I' and linear dipole pol (e.g. 'XX') are implemented.
+        pol: str, optional
+                Which polarization to compute the beam scalar for.
+                'I', 'Q', 'U', 'V', 'XX', 'YY', 'XY', 'YX' 
                 Default: 'I'
 
         Returns
@@ -333,26 +325,24 @@ class PSpecBeamUV(PSpecBeamBase):
         primary beam area: float, array-like
         """
         if hasattr(self.primary_beam, 'get_beam_area'):
-            return self.primary_beam.get_beam_area(stokes)
+            return self.primary_beam.get_beam_area(pol)
         else:
             raise NotImplementedError("Outdated version of pyuvdata.")
 
-    def power_beam_sq_int(self, stokes='I'):
+    def power_beam_sq_int(self, pol='I'):
         """
         Computes the integral of the beam**2 over solid angle to give
         a beam**2 area (in str) as a function of frequency. Uses function
         in pyuvdata.
 
-        Currently, only the Stokes "I", "XX" and "YY" beam are supported.
         See Equations 4 and 5 of Moore et al. (2017) ApJ 836, 154
         or arxiv:1502.05072 for details.
 
         Parameters
         ----------
-        stokes: str, optional
-                Which Stokes parameter's to compute the beam scalar for.
-                'I', 'Q', 'U', 'V', 'XX', 'YY', 'XY', 'YX', although 
-                currently only 'I' and linear dipole pol (e.g. 'XX') are implemented.
+        pol: str, optional
+                Which polarization to compute the beam scalar for.
+                'I', 'Q', 'U', 'V', 'XX', 'YY', 'XY', 'YX'
                 Default: 'I'
 
         Returns
@@ -360,6 +350,6 @@ class PSpecBeamUV(PSpecBeamBase):
         primary beam area: float, array-like
         """
         if hasattr(self.primary_beam, 'get_beam_area'):
-            return self.primary_beam.get_beam_sq_area(stokes)
+            return self.primary_beam.get_beam_sq_area(pol)
         else:
             raise NotImplementedError("Outdated version of pyuvdata.")

--- a/hera_pspec/pspecbeam.py
+++ b/hera_pspec/pspecbeam.py
@@ -101,7 +101,7 @@ class PSpecBeamBase(object):
         else:
             self.cosmo = conversions.Cosmo_Conversions()
 
-    def compute_pspec_scalar(self, lower_freq, upper_freq, num_freqs, num_steps=5000, stokes='pseudo_I',
+    def compute_pspec_scalar(self, lower_freq, upper_freq, num_freqs, num_steps=5000, stokes='I',
                              taper='none', little_h=True, noise_scalar=False):
         """
         Computes the scalar function to convert a power spectrum estimate
@@ -109,7 +109,7 @@ class PSpecBeamBase(object):
 
         See arxiv:1304.4991 and HERA memo #27 for details.
 
-        Currently, only the "pseudo Stokes I", "XX" and "YY" beam are supported.
+        Currently, only the Stokes "I", "XX" and "YY" beam are supported.
         See Equations 4 and 5 of Moore et al. (2017) ApJ 836, 154
         or arxiv:1502.05072 for details.
 
@@ -133,9 +133,9 @@ class PSpecBeamBase(object):
 
         stokes: str, optional
                 Which Stokes parameter's to compute the beam scalar for.
-                'pseudo_I', 'pseudo_Q', 'pseudo_U', 'pseudo_V', 'XX', 'YY', 'XY', 'YX', although 
-                currently only 'pseudo_I' and linear dipole pol (e.g. 'XX') are implemented.
-                Default: 'pseudo_I'
+                'I', 'Q', 'U', 'V', 'XX', 'YY', 'XY', 'YX', although 
+                currently only 'I' and linear dipole pol (e.g. 'XX') are implemented.
+                Default: 'I'
 
         taper : str, optional
                 Whether a tapering function (e.g. Blackman-Harris) is being
@@ -171,7 +171,7 @@ class PSpecBeamBase(object):
 
         return scalar
 
-    def Jy_to_mK(self, freqs, stokes='pseudo_I'):
+    def Jy_to_mK(self, freqs, stokes='I'):
         """
         Return the multiplicative factor, M [mK / Jy], to convert a visibility from Jy -> mK,
 
@@ -188,9 +188,9 @@ class PSpecBeamBase(object):
 
         stokes: str, optional
                 Which Stokes parameter's to compute the beam scalar for.
-                'pseudo_I', 'pseudo_Q', 'pseudo_U', 'pseudo_V', 'XX', 'YY', 'XY', 'YX', although 
-                currently only 'pseudo_I' and linear dipole pol (e.g. 'XX') are implemented.
-                Default: 'pseudo_I'
+                'I', 'Q', 'U', 'V', 'XX', 'YY', 'XY', 'YX', although 
+                currently only 'I' and linear dipole pol (e.g. 'XX') are implemented.
+                Default: 'I'
 
         Returns
         -------
@@ -233,7 +233,7 @@ class PSpecBeamGauss(PSpecBeamBase):
         else:
             self.cosmo = conversions.Cosmo_Conversions()
 
-    def power_beam_int(self, stokes='pseudo_I'):
+    def power_beam_int(self, stokes='I'):
         """
         Computes the integral of the beam over solid angle to give
         a beam area (in sr). Uses analytic formula that the answer
@@ -242,7 +242,7 @@ class PSpecBeamGauss(PSpecBeamBase):
         Trivially this returns an array (i.e., a function of frequency),
         but the results are frequency independent.
 
-        Currently, only the "pseudo Stokes I", "XX" and "YY" beam are supported.
+        Currently, only the Stokes "I", "XX" and "YY" beam are supported.
         See Equations 4 and 5 of Moore et al. (2017) ApJ 836, 154
         or arxiv:1502.05072 for details.
 
@@ -250,9 +250,9 @@ class PSpecBeamGauss(PSpecBeamBase):
         ----------
         stokes: str, optional
                 Which Stokes parameter's to compute the beam scalar for.
-                'pseudo_I', 'pseudo_Q', 'pseudo_U', 'pseudo_V', 'XX', 'YY', 'XY', 'YX', although 
-                currently only 'pseudo_I' and linear dipole pol (e.g. 'XX') are implemented.
-                Default: 'pseudo_I'
+                'I', 'Q', 'U', 'V', 'XX', 'YY', 'XY', 'YX', although 
+                currently only 'I' and linear dipole pol (e.g. 'XX') are implemented.
+                Default: 'I'
 
         Returns
         -------
@@ -260,7 +260,7 @@ class PSpecBeamGauss(PSpecBeamBase):
         """
         return np.ones_like(self.beam_freqs) * 2. * np.pi * self.fwhm**2 / (8. * np.log(2.))
 
-    def power_beam_sq_int(self, stokes='pseudo_I'):
+    def power_beam_sq_int(self, stokes='I'):
         """
         Computes the integral of the beam**2 over solid angle to give
         a beam area (in str). Uses analytic formula that the answer
@@ -269,7 +269,7 @@ class PSpecBeamGauss(PSpecBeamBase):
         Trivially this returns an array (i.e., a function of frequency),
         but the results are frequency independent.
 
-        Currently, only the "pseudo Stokes I", "XX" and "YY" beam are supported.
+        Currently, only the Stokes "I", "XX" and "YY" beam are supported.
         See Equations 4 and 5 of Moore et al. (2017) ApJ 836, 154
         or arxiv:1502.05072 for details.
 
@@ -277,9 +277,9 @@ class PSpecBeamGauss(PSpecBeamBase):
         ----------
         stokes: str, optional
                 Which Stokes parameter's to compute the beam scalar for.
-                'pseudo_I', 'pseudo_Q', 'pseudo_U', 'pseudo_V', 'XX', 'YY', 'XY', 'YX', although 
-                currently only 'pseudo_I' and linear dipole pol (e.g. 'XX') are implemented.
-                Default: 'pseudo_I'
+                'I', 'Q', 'U', 'V', 'XX', 'YY', 'XY', 'YX', although 
+                currently only 'I' and linear dipole pol (e.g. 'XX') are implemented.
+                Default: 'I'
 
         Returns
         -------
@@ -310,13 +310,13 @@ class PSpecBeamUV(PSpecBeamBase):
         else:
             self.cosmo = conversions.Cosmo_Conversions()
 
-    def power_beam_int(self, stokes='pseudo_I'):
+    def power_beam_int(self, stokes='I'):
         """
         Computes the integral of the beam over solid angle to give
         a beam area (in str) as a function of frequency. Uses function
         in pyuvdata.
 
-        Currently, only the "pseudo Stokes I", "XX" and "YY" beam are supported.
+        Currently, only the Stokes "I", "XX" and "YY" beam are supported.
         See Equations 4 and 5 of Moore et al. (2017) ApJ 836, 154
         or arxiv:1502.05072 for details.
 
@@ -324,9 +324,9 @@ class PSpecBeamUV(PSpecBeamBase):
         ----------
         stokes: str, optional
                 Which Stokes parameter's to compute the beam scalar for.
-                'pseudo_I', 'pseudo_Q', 'pseudo_U', 'pseudo_V', 'XX', 'YY', 'XY', 'YX', although 
-                currently only 'pseudo_I' and linear dipole pol (e.g. 'XX') are implemented.
-                Default: 'pseudo_I'
+                'I', 'Q', 'U', 'V', 'XX', 'YY', 'XY', 'YX', although 
+                currently only 'I' and linear dipole pol (e.g. 'XX') are implemented.
+                Default: 'I'
 
         Returns
         -------
@@ -337,13 +337,13 @@ class PSpecBeamUV(PSpecBeamBase):
         else:
             raise NotImplementedError("Outdated version of pyuvdata.")
 
-    def power_beam_sq_int(self, stokes='pseudo_I'):
+    def power_beam_sq_int(self, stokes='I'):
         """
         Computes the integral of the beam**2 over solid angle to give
         a beam**2 area (in str) as a function of frequency. Uses function
         in pyuvdata.
 
-        Currently, only the "pseudo Stokes I", "XX" and "YY" beam are supported.
+        Currently, only the Stokes "I", "XX" and "YY" beam are supported.
         See Equations 4 and 5 of Moore et al. (2017) ApJ 836, 154
         or arxiv:1502.05072 for details.
 
@@ -351,9 +351,9 @@ class PSpecBeamUV(PSpecBeamBase):
         ----------
         stokes: str, optional
                 Which Stokes parameter's to compute the beam scalar for.
-                'pseudo_I', 'pseudo_Q', 'pseudo_U', 'pseudo_V', 'XX', 'YY', 'XY', 'YX', although 
-                currently only 'pseudo_I' and linear dipole pol (e.g. 'XX') are implemented.
-                Default: 'pseudo_I'
+                'I', 'Q', 'U', 'V', 'XX', 'YY', 'XY', 'YX', although 
+                currently only 'I' and linear dipole pol (e.g. 'XX') are implemented.
+                Default: 'I'
 
         Returns
         -------

--- a/hera_pspec/pspecdata.py
+++ b/hera_pspec/pspecdata.py
@@ -759,20 +759,18 @@ class PSpecData(object):
             return utils.get_delays(self.freqs[self.spw_range[0]:self.spw_range[1]]) * 1e9 # convert to ns    
     
     
-    def scalar(self, stokes='I', taper='none', little_h=True, num_steps=2000, beam=None):
+    def scalar(self, pol='I', taper='none', little_h=True, num_steps=2000, beam=None):
         """
         Computes the scalar function to convert a power spectrum estimate
         in "telescope units" to cosmological units, using self.spw_range to set spectral window.
 
         See arxiv:1304.4991 and HERA memo #27 for details.
 
-        Currently this is only for Stokes I.
-
         Parameters
         ----------
-        stokes: str, optional
-                Which Stokes parameter's beam to compute the scalar for.
-                'I', 'Q', 'U', 'V', although currently only 'I' is implemented
+        pol: str, optional
+                Which polarization to compute the scalar for.
+                e.g. 'I', 'Q', 'U', 'V', 'XX', 'YY'...
                 Default: 'I'
 
         taper : str, optional
@@ -806,12 +804,12 @@ class PSpecData(object):
         # calculate scalar
         if beam is None:
             scalar = self.primary_beam.compute_pspec_scalar(
-                                    start, end, len(freqs), stokes=stokes,
+                                    start, end, len(freqs), pol=pol,
                                     taper=taper, little_h=little_h, 
                                     num_steps=num_steps)
         else:
             scalar = beam.compute_pspec_scalar(start, end, len(freqs), 
-                                               stokes=stokes, taper=taper, 
+                                               pol=pol, taper=taper, 
                                                little_h=little_h, 
                                                num_steps=num_steps)
         return scalar

--- a/hera_pspec/pspecdata.py
+++ b/hera_pspec/pspecdata.py
@@ -759,7 +759,7 @@ class PSpecData(object):
             return utils.get_delays(self.freqs[self.spw_range[0]:self.spw_range[1]]) * 1e9 # convert to ns    
     
     
-    def scalar(self, stokes='pseudo_I', taper='none', little_h=True, num_steps=2000, beam=None):
+    def scalar(self, stokes='I', taper='none', little_h=True, num_steps=2000, beam=None):
         """
         Computes the scalar function to convert a power spectrum estimate
         in "telescope units" to cosmological units, using self.spw_range to set spectral window.

--- a/hera_pspec/tests/test_noise.py
+++ b/hera_pspec/tests/test_noise.py
@@ -43,7 +43,7 @@ class Test_Sensitivity(unittest.TestCase):
         freqs = np.linspace(150e6, 160e6, 100, endpoint=False)
         self.sense.calc_scalar(freqs, 'I', num_steps=5000, little_h=True)
         nt.assert_true(np.isclose(freqs, self.sense.subband).all())
-        nt.assert_true(self.sense.stokes, 'I')
+        nt.assert_true(self.sense.pol, 'I')
 
     def test_calc_P_N(self):
         # calculate scalar

--- a/hera_pspec/tests/test_noise.py
+++ b/hera_pspec/tests/test_noise.py
@@ -41,14 +41,14 @@ class Test_Sensitivity(unittest.TestCase):
 
     def test_scalar(self):
         freqs = np.linspace(150e6, 160e6, 100, endpoint=False)
-        self.sense.calc_scalar(freqs, 'pseudo_I', num_steps=5000, little_h=True)
+        self.sense.calc_scalar(freqs, 'I', num_steps=5000, little_h=True)
         nt.assert_true(np.isclose(freqs, self.sense.subband).all())
         nt.assert_true(self.sense.stokes, 'I')
 
     def test_calc_P_N(self):
         # calculate scalar
         freqs = np.linspace(150e6, 160e6, 100, endpoint=False)
-        self.sense.calc_scalar(freqs, 'pseudo_I', num_steps=5000, little_h=True)
+        self.sense.calc_scalar(freqs, 'I', num_steps=5000, little_h=True)
         # basic execution 
         k = np.linspace(0, 3, 10)
         Tsys = 500.0

--- a/hera_pspec/tests/test_pspecbeam.py
+++ b/hera_pspec/tests/test_pspecbeam.py
@@ -44,7 +44,7 @@ class Test_DataSet(unittest.TestCase):
         lower_freq = 120.*10**6
         upper_freq = 128.*10**6
         num_freqs = 20
-        scalar = self.bm.compute_pspec_scalar(lower_freq, upper_freq, num_freqs, stokes='I', num_steps=2000)
+        scalar = self.bm.compute_pspec_scalar(lower_freq, upper_freq, num_freqs, pol='I', num_steps=2000)
         
         # Check that user-defined cosmology can be specified
         bm = pspecbeam.PSpecBeamUV(self.beamfile,
@@ -55,11 +55,11 @@ class Test_DataSet(unittest.TestCase):
         self.assertEqual(Om_pp.ndim, 1)
 
         # Check that errors are raised for other Stokes parameters
-        for stokes in ['Q', 'U', 'V', 'Z']:
-            nt.assert_raises(NotImplementedError, self.bm.power_beam_int, stokes=stokes)
-            nt.assert_raises(NotImplementedError, self.bm.power_beam_sq_int, stokes=stokes)
+        for pol in ['Q', 'U', 'V', 'Z']:
+            nt.assert_raises(NotImplementedError, self.bm.power_beam_int, pol=pol)
+            nt.assert_raises(NotImplementedError, self.bm.power_beam_sq_int, pol=pol)
             nt.assert_raises(NotImplementedError, self.bm.compute_pspec_scalar, 
-                             lower_freq, upper_freq, num_freqs, stokes=stokes)
+                             lower_freq, upper_freq, num_freqs, pol=pol)
 
         self.assertAlmostEqual(Om_p[0], 0.078694909518866998)
         self.assertAlmostEqual(Om_p[18], 0.065472512282419112)
@@ -72,7 +72,7 @@ class Test_DataSet(unittest.TestCase):
         self.assertAlmostEqual(scalar/567871703.75268996, 1.0, delta=1e-4)
         
         # convergence of integral
-        scalar_large_Nsteps = self.bm.compute_pspec_scalar(lower_freq, upper_freq, num_freqs, stokes='I', num_steps=10000) 
+        scalar_large_Nsteps = self.bm.compute_pspec_scalar(lower_freq, upper_freq, num_freqs, pol='I', num_steps=10000) 
         self.assertAlmostEqual(scalar / scalar_large_Nsteps, 1.0, delta=1e-5)
 
         # test taper execution
@@ -93,7 +93,7 @@ class Test_DataSet(unittest.TestCase):
         nt.assert_raises(TypeError, self.bm.Jy_to_mK, np.array([1]))
 
         # test noise scalar
-        sclr = self.bm.compute_pspec_scalar(lower_freq, upper_freq, num_freqs, stokes='I', num_steps=2000, noise_scalar=True)
+        sclr = self.bm.compute_pspec_scalar(lower_freq, upper_freq, num_freqs, pol='I', num_steps=2000, noise_scalar=True)
         nt.assert_almost_equal(sclr, 70.983962969086235)
 
 
@@ -103,7 +103,7 @@ class Test_DataSet(unittest.TestCase):
         lower_freq = 120.*10**6
         upper_freq = 128.*10**6
         num_freqs = 20
-        scalar = self.gauss.compute_pspec_scalar(lower_freq, upper_freq, num_freqs, stokes='I', num_steps=2000)
+        scalar = self.gauss.compute_pspec_scalar(lower_freq, upper_freq, num_freqs, pol='I', num_steps=2000)
         
         # Check that user-defined cosmology can be specified
         bgauss = pspecbeam.PSpecBeamGauss(0.8, 

--- a/hera_pspec/tests/test_pspecbeam.py
+++ b/hera_pspec/tests/test_pspecbeam.py
@@ -44,7 +44,7 @@ class Test_DataSet(unittest.TestCase):
         lower_freq = 120.*10**6
         upper_freq = 128.*10**6
         num_freqs = 20
-        scalar = self.bm.compute_pspec_scalar(lower_freq, upper_freq, num_freqs, stokes='pseudo_I', num_steps=2000)
+        scalar = self.bm.compute_pspec_scalar(lower_freq, upper_freq, num_freqs, stokes='I', num_steps=2000)
         
         # Check that user-defined cosmology can be specified
         bm = pspecbeam.PSpecBeamUV(self.beamfile,
@@ -72,7 +72,7 @@ class Test_DataSet(unittest.TestCase):
         self.assertAlmostEqual(scalar/567871703.75268996, 1.0, delta=1e-4)
         
         # convergence of integral
-        scalar_large_Nsteps = self.bm.compute_pspec_scalar(lower_freq, upper_freq, num_freqs, stokes='pseudo_I', num_steps=10000) 
+        scalar_large_Nsteps = self.bm.compute_pspec_scalar(lower_freq, upper_freq, num_freqs, stokes='I', num_steps=10000) 
         self.assertAlmostEqual(scalar / scalar_large_Nsteps, 1.0, delta=1e-5)
 
         # test taper execution
@@ -93,7 +93,7 @@ class Test_DataSet(unittest.TestCase):
         nt.assert_raises(TypeError, self.bm.Jy_to_mK, np.array([1]))
 
         # test noise scalar
-        sclr = self.bm.compute_pspec_scalar(lower_freq, upper_freq, num_freqs, stokes='pseudo_I', num_steps=2000, noise_scalar=True)
+        sclr = self.bm.compute_pspec_scalar(lower_freq, upper_freq, num_freqs, stokes='I', num_steps=2000, noise_scalar=True)
         nt.assert_almost_equal(sclr, 70.983962969086235)
 
 
@@ -103,7 +103,7 @@ class Test_DataSet(unittest.TestCase):
         lower_freq = 120.*10**6
         upper_freq = 128.*10**6
         num_freqs = 20
-        scalar = self.gauss.compute_pspec_scalar(lower_freq, upper_freq, num_freqs, stokes='pseudo_I', num_steps=2000)
+        scalar = self.gauss.compute_pspec_scalar(lower_freq, upper_freq, num_freqs, stokes='I', num_steps=2000)
         
         # Check that user-defined cosmology can be specified
         bgauss = pspecbeam.PSpecBeamGauss(0.8, 

--- a/hera_pspec/uvpspec.py
+++ b/hera_pspec/uvpspec.py
@@ -962,9 +962,8 @@ class UVPSpec(object):
         # get frequency band
         freqs = self.freq_array[self.spw_to_indices(spw)]
 
-        # calculate scalar, hard-coded to pseudo_I because that is currently all that pyuvdata supports
-        # near-future pyuvdata PR will extend support for extra polarizations
-        self.sensitivity.calc_scalar(freqs, 'pseudo_I', num_steps=num_steps, little_h=little_h)
+        # calculate scalar
+        self.sensitivity.calc_scalar(freqs, pol, num_steps=num_steps, little_h=little_h)
 
         # Get k vectors
         if form == 'DelSq':


### PR DESCRIPTION
In accordance w/ recent `pyuvdata` PR, this PR updates all references to `pseudo_stokes` pol to just `stokes` pol (i.e. `pseudo_I` -> `I`).