### PR TITLE
pspecdata.I now accounts for flags in data by taking time avg

### DIFF
--- a/hera_pspec/pspecdata.py
+++ b/hera_pspec/pspecdata.py
@@ -296,7 +296,6 @@ class PSpecData(object):
         else:
             raise TypeError("dset must be either an int or string")
     
-    
     def blkey(self, dset, bl=None, pol=None):
         """
         Return a key specifying a particular dataset, baseline, and 
@@ -337,7 +336,6 @@ class PSpecData(object):
         if pol is not None: key += (pol,)
         return key
         
-    
     def x(self, key):
         """
         Get data for a given dataset and baseline, as specified in a standard
@@ -476,7 +474,7 @@ class PSpecData(object):
         key = (self.dset_idx(key[0]),) + key[1:]  # Sanitize dataset name
 
         if not self._I.has_key(key):
-            self._I[key] = np.identity(self.spw_Nfreqs)
+            self._I[key] = np.identity(self.spw_Nfreqs) * np.mean(self.w(key), axis=1)
         return self._I[key]
 
     def iC(self, key):
@@ -559,7 +557,7 @@ class PSpecData(object):
             "spw_range must be fed as len-2 integer tuple"
         self.spw_range = spw_range
         self.spw_Nfreqs = spw_range[1] - spw_range[0]
-
+    
     def q_hat(self, key1, key2, use_fft=True, taper='none'):
         """
         Construct an unnormalized bandpower, q_hat, from a given pair of

--- a/hera_pspec/tests/test_pspecdata.py
+++ b/hera_pspec/tests/test_pspecdata.py
@@ -174,6 +174,28 @@ class Test_PSpecData(unittest.TestCase):
         ds.add(self.uvd, None)
         print(ds) # print populated psd
     
+    def test_get_I(self):
+        """ test identity matrix weighting techniques """
+        d1 = copy.deepcopy(self.uvd)
+        d2 = copy.deepcopy(self.uvd)
+        d1.flag_array[:, :, 50:60, :] = True
+        d2.flag_array[:, :, 50:60, :] = True
+        ds = pspecdata.PSpecData(dsets=[d1, d2], wgts=[None, None])
+        # confirm that get_I has flags in it
+        key1 = (0, (24, 25))
+        key2 = (1, (38, 39))
+        I1 = ds.I(key1)
+        I2 = ds.I(key2)
+        nt.assert_true(np.isclose(I1[50:60, 50:60].max(), 0.0))
+        nt.assert_true(np.isclose(I2[50:60, 50:60].max(), 0.0))
+        # make pspec, change data in flagged boundary
+        # make pspec again and confirm no change
+        uvp1 = ds.pspec([(24, 25)], [(37, 38)], (0, 1), input_data_weight='identity', norm='I', verbose=False)
+        ds.dsets[0].data_array[:, :, 50:60, :] *= 1e10
+        ds.dsets[1].data_array[:, :, 50:60, :] *= 1e10
+        uvp2 = ds.pspec([(24, 25)], [(37, 38)], (0, 1), input_data_weight='identity', norm='I', verbose=False)
+        nt.assert_equal(uvp1, uvp2)
+
     def test_get_Q(self):
         """
         Test the Q = dC/dp function.


### PR DESCRIPTION
previously, `pspecdata.I()` was not accounting for data flags. this PR accounts for data flags by taking the time average of the data weights and multiplying that into the diagonal of identity.

addresses #72 and partially addresses #55 