### PR TITLE
RFI

### DIFF
--- a/hera_pspec/pspecdata.py
+++ b/hera_pspec/pspecdata.py
@@ -1088,6 +1088,38 @@ class PSpecData(object):
         """
         return np.dot(M, q)
 
+    def unify_dset_flags(self, time_thresh=0.2, unflag=False):
+        """
+        For each dataset in self.dset, update the flag_array such that
+        the flagging patterns are time-independent for each baseline.
+        For each frequency pixel, if the fraction of flagged times exceeds
+        time_thresh, all times are flagged. If it does not, the specific
+        integrations with flags in that freq channel are removed from this 
+        and all other dsets.
+        One can also unflag the data entirely if desired.
+
+        Parameters
+        ----------
+
+
+        """
+        # validate datasets
+        self.validate_datasets()
+
+        # unflag
+        if unflag:
+            # iterate over datasets
+            for dset in self.dsets:
+                # unflag
+                dset.flag_array[:] = False
+            return
+
+        # enact time threshold on flag waterfalls
+
+
+
+
+
     def units(self, little_h=True):
         """
         Return the units of the power spectrum. These are inferred from the

--- a/hera_pspec/pspecdata.py
+++ b/hera_pspec/pspecdata.py
@@ -525,7 +525,7 @@ class PSpecData(object):
         R_matrix : string or matrix
             If set to "identity", sets R = I
             If set to "iC", sets R = C^-1
-            If set to "identity_with_flags", sets R = diagonal according to pspecdata weights
+            If set to "diagonal", sets R = diagonal according to pspecdata weights
             Otherwise, accepts a user inputted dictionary
         """
         if R_matrix == "identity":

--- a/hera_pspec/pspecdata.py
+++ b/hera_pspec/pspecdata.py
@@ -525,13 +525,14 @@ class PSpecData(object):
         R_matrix : string or matrix
             If set to "identity", sets R = I
             If set to "iC", sets R = C^-1
+            If set to "identity_with_flags", sets R = diagonal according to pspecdata weights
             Otherwise, accepts a user inputted dictionary
         """
         if R_matrix == "identity":
             self.R = self.I
         elif R_matrix == "iC":
             self.R = self.iC
-        elif R_matrix == "identity_with_flags"
+        elif R_matrix == "diagonal":
             self.R = self.diag_inv_covar
         else:
             self.R = R_matrix

--- a/hera_pspec/pspecdata.py
+++ b/hera_pspec/pspecdata.py
@@ -531,8 +531,8 @@ class PSpecData(object):
         Returns
         -------
         Y : array_like
-            spw_Nfreqs x spw_Nfreqs diagonal matrix holding logical_OR of flags
-            across time as a float-type. 
+            spw_Nfreqs x spw_Nfreqs diagonal matrix holding AND of flags
+            across all times for each freq channel. 
         """
         assert isinstance(key, tuple)
         # parse key

--- a/hera_pspec/pspecdata.py
+++ b/hera_pspec/pspecdata.py
@@ -532,7 +532,7 @@ class PSpecData(object):
             self.R = self.I
         elif R_matrix == "iC":
             self.R = self.iC
-        elif R_matrix == "diagonal":
+        elif R_matrix == "identity_with_flags"
             self.R = self.diag_inv_covar
         else:
             self.R = R_matrix

--- a/hera_pspec/pspecdata.py
+++ b/hera_pspec/pspecdata.py
@@ -253,8 +253,7 @@ class PSpecData(object):
             keys will be removed. Default: None.
         """
         if keys is None:
-            self._C, self._I, self._iC = {}, {}, {}
-            self._iCt = {}
+            self._C, self._I, self._iC, self._diag_inv_covar = {}, {}, {}, {}
         else:
             for k in keys:
                 try: del(self._C[k])
@@ -262,6 +261,8 @@ class PSpecData(object):
                 try: del(self._I[k])
                 except(KeyError): pass
                 try: del(self._iC[k])
+                except(KeyError): pass
+                try: del(self._diag_inv_covar[k])
                 except(KeyError): pass
 
     def dset_idx(self, dset):
@@ -530,6 +531,8 @@ class PSpecData(object):
             self.R = self.I
         elif R_matrix == "iC":
             self.R = self.iC
+        elif R_matrix == "identity_with_flags"
+            self.R = self.diag_inv_covar
         else:
             self.R = R_matrix
 

--- a/hera_pspec/tests/test_pspecdata.py
+++ b/hera_pspec/tests/test_pspecdata.py
@@ -880,6 +880,7 @@ class Test_PSpecData(unittest.TestCase):
                                 little_h=True, verbose=False)
         qe_unflagged = uvp_unflagged.get_data(0, ((24, 25), (37, 38)), 'xx')[0]
         qe_flagged = uvp_flagged.get_data(0, ((24, 25), (37, 38)), 'xx')[0]
+
         # assert answers are same to within 0.1%
         nt.assert_true(np.isclose(np.real(qe_unflagged)/np.real(qe_flagged), 1, atol=0.001, rtol=0.001).all())
 

--- a/hera_pspec/tests/test_pspecdata.py
+++ b/hera_pspec/tests/test_pspecdata.py
@@ -839,6 +839,77 @@ class Test_PSpecData(unittest.TestCase):
         # assert answers are same to within 3%
         nt.assert_true(np.isclose(np.real(oqe)/np.real(legacy), 1, atol=0.03, rtol=0.03).all())
 
+    def test_diag_inv_covar(self):
+        # generate ds and weights
+        uvd = copy.deepcopy(self.uvd)
+        test_wgts = copy.deepcopy(self.uvd)
+        test_wgts.data_array = np.ones_like((test_wgts.data_array), dtype=np.float)
+        Nfreq = uvd.data_array.shape[2]
+
+        # Basic test of shape
+        ds = pspecdata.PSpecData(dsets=[uvd, uvd], wgts=[test_wgts, test_wgts], beam=self.bm)
+        test_R = ds.diag_inv_covar((1, 37, 38, 'XX'))
+        self.assertEqual(test_R.shape, (Nfreq, Nfreq))
+
+        # First test that the flagging option does nothing if there are no flags (i.e., all weights equal one)
+        bls1 = [(24, 25)]
+        bls2 = [(37, 38)]
+        ds = pspecdata.PSpecData(dsets=[uvd, uvd], wgts=[test_wgts, test_wgts], beam=self.bm, labels=['red', 'blue'])
+        uvp_unflagged = ds.pspec(bls1, bls2, (0, 1), ('xx','xx'), input_data_weight='identity', norm='I', taper='none',
+                                little_h=True, verbose=False)
+        uvp_flagged = ds.pspec(bls1, bls2, (0, 1), ('xx','xx'), input_data_weight='diagonal', norm='I', taper='none',
+                                little_h=True, verbose=False)
+
+        qe_unflagged = uvp_unflagged.get_data(0, ((24, 25), (37, 38)), 'xx')[0]
+        qe_flagged = uvp_flagged.get_data(0, ((24, 25), (37, 38)), 'xx')[0]
+
+        # assert answers are same to within 0.1%
+        nt.assert_true(np.isclose(np.real(qe_unflagged)/np.real(qe_flagged), 1, atol=0.001, rtol=0.001).all())
+
+        # Test that when flagged, the data within a channel really don't have any effect on the final result
+        test_wgts_flagged = copy.deepcopy(test_wgts)
+        test_wgts_flagged.data_array[:,:,40:60] = 0. # Flag 20 channels
+        ds = pspecdata.PSpecData(dsets=[uvd, uvd], wgts=[test_wgts_flagged, test_wgts_flagged], beam=self.bm)
+        uvp_flagged = ds.pspec(bls1, bls2, (0, 1), ('xx','xx'), input_data_weight='diagonal', norm='I', taper='none',
+                                little_h=True, verbose=False)
+
+        uvd.data_array[:,:,40:60] *= 9234.913
+        ds = pspecdata.PSpecData(dsets=[uvd, uvd], wgts=[test_wgts_flagged, test_wgts_flagged], beam=self.bm)
+        uvp_flagged_mod = ds.pspec(bls1, bls2, (0, 1), ('xx','xx'), input_data_weight='diagonal', norm='I', taper='none',
+                                little_h=True, verbose=False)
+
+        qe_flagged_mod = uvp_flagged_mod.get_data(0, ((24, 25), (37, 38)), 'xx')[0]
+        qe_flagged = uvp_flagged.get_data(0, ((24, 25), (37, 38)), 'xx')[0]        
+
+        # assert answers are same to within 0.1%
+        nt.assert_true(np.isclose(np.real(qe_flagged_mod)/np.real(qe_flagged), 1, atol=0.001, rtol=0.001).all())
+
+        # Test below commented out because this sort of aggressive symmetrization is not yet implemented.
+        # # Test that flagging a channel for one dataset (e.g. just left hand dataset x2) 
+        # # is equivalent to flagging for both x1 and x2.
+        # test_wgts_flagged = copy.deepcopy(test_wgts)
+        # test_wgts_flagged.data_array[:,:,40:60] = 0. # Flag 20 channels
+        # ds = pspecdata.PSpecData(dsets=[uvd, uvd], wgts=[test_wgts_flagged, test_wgts_flagged], beam=self.bm)
+        # print "mode alpha"
+        # uvp_flagged = ds.pspec(bls1, bls2, (0, 1), ('xx','xx'), input_data_weight='diagonal', norm='I', taper='none',
+        #                         little_h=True, verbose=False)
+        # ds = pspecdata.PSpecData(dsets=[uvd, uvd], wgts=[None, test_wgts_flagged], beam=self.bm)
+        # print "mode beta"
+        # uvp_flagged_asymm = ds.pspec(bls1, bls2, (0, 1), ('xx','xx'), input_data_weight='diagonal', norm='I', taper='none',
+        #                         little_h=True, verbose=False)
+
+        # qe_flagged_asymm = uvp_flagged_asymm .get_data(0, ((24, 25), (37, 38)), 'xx')[0]
+        # qe_flagged = uvp_flagged.get_data(0, ((24, 25), (37, 38)), 'xx')[0]
+
+        # #print np.real(qe_flagged_asymm)/np.real(qe_flagged)
+
+        # # assert answers are same to within 3%
+        # nt.assert_true(np.isclose(np.real(qe_flagged_asymm)/np.real(qe_flagged), 1, atol=0.03, rtol=0.03).all())
+
+
+
+        print uvd.data_array.shape
+
     def test_validate_blpairs(self):
         # test exceptions
         uvd = copy.deepcopy(self.uvd)

--- a/hera_pspec/tests/test_pspecdata.py
+++ b/hera_pspec/tests/test_pspecdata.py
@@ -860,12 +860,32 @@ class Test_PSpecData(unittest.TestCase):
         ds.broadcast_dset_flags(spw_ranges=None, time_thresh=0.2, unflag=True)
         nt.assert_false(ds.dsets[0].get_flags(24, 25)[:, :].any())
 
-        # test single integration being thrown out
+        # test single integration being flagged within spw
         ds = pspecdata.PSpecData(dsets=[copy.deepcopy(uvd), copy.deepcopy(uvd)], wgts=[None, None])
         ds.dsets[0].flag_array[ds.dsets[0].antpair2ind(24, 25)[3], 0, 600, 0] = True
         ds.broadcast_dset_flags(spw_ranges=[(400, 800)], time_thresh=0.25, unflag=False)
         nt.assert_true(ds.dsets[0].get_flags(24, 25)[3, 400:800].all())
         nt.assert_false(ds.dsets[0].get_flags(24, 25)[3, :].all())
+
+        # test pspec run sets flagged integration to have zero weight
+        uvd.flag_array[uvd.antpair2ind(24, 25)[3], 0, 400, :] = True
+        ds = pspecdata.PSpecData(dsets=[copy.deepcopy(uvd), copy.deepcopy(uvd)], wgts=[None, None])
+        ds.broadcast_dset_flags(spw_ranges=[(400, 450)], time_thresh=0.25)
+        uvp = ds.pspec([(24, 25), (37, 38), (38, 39)], [(24, 25), (37, 38), (38, 39)], (0, 1), ('xx', 'xx'),
+                        spw_ranges=[(400, 450)], verbose=False)
+        # assert flag broadcast above hits weight arrays in uvp
+        nt.assert_true(np.all(np.isclose(uvp.get_wgts(0, ((24, 25), (24, 25)), 'xx')[3], 0.0)))
+        # assert flag broadcast above hits integration arrays
+        nt.assert_true(np.isclose(uvp.get_integrations(0, ((24, 25), (24, 25)), 'xx')[3], 0.0))
+        # average spectra
+        avg_uvp = uvp.average_spectra(blpair_groups=[sorted(np.unique(uvp.blpair_array))], time_avg=True, inplace=False)
+        # repeat but change data in flagged portion
+        ds.dsets[0].data_array[uvd.antpair2ind(24, 25)[3], 0, 400:450, :] *= 100
+        uvp2 = ds.pspec([(24, 25), (37, 38), (38, 39)], [(24, 25), (37, 38), (38, 39)], (0, 1), ('xx', 'xx'),
+                        spw_ranges=[(400, 450)], verbose=False)
+        avg_uvp2 = uvp.average_spectra(blpair_groups=[sorted(np.unique(uvp.blpair_array))], time_avg=True, inplace=False)
+        # assert average before and after are the same!
+        nt.assert_equal(avg_uvp, avg_uvp2)
 
     def test_RFI_flag_propagation(self):
         # generate ds and weights


### PR DESCRIPTION
Here's the PR for dealing with RFI flags.

Something that occurred to me while I was putting this together: we probably want to enforce that if a channel is flagged in x_1 but not x_2 (or vice versa), the channel is flagged for both. We can either try to enforce this in the pspec code, or we could do it in the preprocessing.

Thank you!