### PR TITLE
Implemented q_hat speedup using broadcasted einsum

### DIFF
--- a/hera_pspec/pspecdata.py
+++ b/hera_pspec/pspecdata.py
@@ -742,11 +742,8 @@ class PSpecData(object):
             q = []
             for i in xrange(self.spw_Ndlys):
                 Q = self.get_Q_alt(i)
-                # Taking the diagonal here is equivalent to not taking cross
-                # multiplications across different times. If this gets too
-                # slow, can be sped up by not computing off-diagonal terms
-                # before taking the diagonal
-                qi = np.diag(np.dot(Rx1.T.conj(), np.dot(Q, Rx2)))
+                QRx2 = np.dot(Q, Rx2)
+                qi = np.einsum('i...,i...->...', Rx1.conj(), QRx2)
                 q.append(qi)
             return 0.5 * np.array(q)
 

--- a/hera_pspec/tests/test_pspecdata.py
+++ b/hera_pspec/tests/test_pspecdata.py
@@ -360,6 +360,8 @@ class Test_PSpecData(unittest.TestCase):
                 self.ds.set_taper(taper)
                 q_hat_a_slow = self.ds.q_hat(key1, key2, allow_fft=False)
                 q_hat_a = self.ds.q_hat(key1, key2, allow_fft=True)
+                print q_hat_a
+                print 'hey'
                 self.assertTrue(np.isclose(np.real(q_hat_a/q_hat_a_slow), 1).all())
                 self.assertTrue(np.isclose(np.imag(q_hat_a/q_hat_a_slow), 0, atol=1e-6).all())
 

--- a/hera_pspec/tests/test_pspecdata.py
+++ b/hera_pspec/tests/test_pspecdata.py
@@ -360,8 +360,6 @@ class Test_PSpecData(unittest.TestCase):
                 self.ds.set_taper(taper)
                 q_hat_a_slow = self.ds.q_hat(key1, key2, allow_fft=False)
                 q_hat_a = self.ds.q_hat(key1, key2, allow_fft=True)
-                print q_hat_a
-                print 'hey'
                 self.assertTrue(np.isclose(np.real(q_hat_a/q_hat_a_slow), 1).all())
                 self.assertTrue(np.isclose(np.imag(q_hat_a/q_hat_a_slow), 0, atol=1e-6).all())
 


### PR DESCRIPTION
This speeds up the q_hat computation, and hopefully reduces the memory footprint as well. @philbull, could you test with the test case you were trying the other day (the one that gave you a `MemoryError`). And please also make sure my `np.einsum` agrees with your expression? I think I got it right, and the tests confirm, but it's probably safest to check against what's on paper regardless.