### PR TITLE
Added label_*_array to _meta_dsets

### DIFF
--- a/hera_pspec/uvpspec.py
+++ b/hera_pspec/uvpspec.py
@@ -105,7 +105,8 @@ class UVPSpec(object):
 
         # define which attributes are considred meta data. Large attrs should be constructed as datasets
         self._meta_dsets = ["lst_1_array", "lst_2_array", "time_1_array", "time_2_array", "blpair_array", 
-                            "bl_vecs", "bl_array", 'lst_avg_array', 'time_avg_array', 'OmegaP', 'OmegaPP']
+                            "bl_vecs", "bl_array", 'lst_avg_array', 'time_avg_array', 'OmegaP', 'OmegaPP',
+                            "label_1_array", "label_2_array"]
         self._meta_attrs = sorted(set(self._all_params) - set(self._dicts) - set(self._meta_dsets))
         self._meta = sorted(set(self._meta_dsets).union(set(self._meta_attrs)))
 


### PR DESCRIPTION
	modified:   hera_pspec/uvpspec.py

I was having problems using UVPSpec.write_to_group because label_1_array and label_2_array are too large to be written as an attr using HDF5, I was getting an "object header message is too large" error. I added them to _meta_dsets in order for them to be saved properly. A small change.