### PR TITLE
bootstrap_run

### DIFF
--- a/hera_pspec/container.py
+++ b/hera_pspec/container.py
@@ -317,7 +317,7 @@ class PSpecContainer(object):
             pass
 
 
-def merge_spectra(psc, uvp_split_str='_x_', ext_split_str='_', verbose=True):
+def merge_spectra(psc, dset_split_str='_x_', ext_split_str='_', verbose=True):
     """
     Iterate through a PSpecContainer and, within each group,
     merge spectra of similar name but different psname extension.
@@ -326,13 +326,17 @@ def merge_spectra(psc, uvp_split_str='_x_', ext_split_str='_', verbose=True):
 
     dset1_x_dset2_ext1, dset1_x_dset2_ext2, ...
 
-    where _x_ is the default uvp_split_str, and _ is the default ext_split_str.
-    The spectra are first split by uvp_split_str, and then by ext_split_str. In
+    where _x_ is the default dset_split_str, and _ is the default ext_split_str.
+    The spectra names are first split by dset_split_str, and then by ext_split_str. In
     this particular case, all instances of dset1_x_dset2* will be merged together.
+
+    In order to merge spectra names with no dset distinction and only an extension,
+    feed dset_split_str as '' or None. Example, to merge together: uvp_1, uvp_2, uvp_3
+    feed dset_split_str=None and ext_split_str='_'.
 
     Parameters:
     -----------
-    uvp_split_str : str
+    dset_split_str : str
         The pattern used to split dset1 from dset2 in the psname.
 
     ext_split_str : str
@@ -357,8 +361,11 @@ def merge_spectra(psc, uvp_split_str='_x_', ext_split_str='_', verbose=True):
         # Get unique spectra by splitting and then re-joining
         unique_spectra = []
         for spc in spectra:
-            sp = utils.flatten([s.split(ext_split_str) for s in spc.split(uvp_split_str)])[:2]
-            sp = uvp_split_str.join(sp)
+            if dset_split_str == '' or dset_split_str is None:
+                sp = spc.split(ext_split_str)[0]
+            else:
+                sp = utils.flatten([s.split(ext_split_str) for s in spc.split(dset_split_str)])[:2]
+                sp = dset_split_str.join(sp)
             if sp not in unique_spectra:
                 unique_spectra.append(sp)
 
@@ -391,13 +398,10 @@ def get_merge_spectra_argparser():
                    help="Filename of HDF5 container (PSpecContainer) containing "
                         "groups / input power spectra.")
    
-    a.add_argument("--uvp_split_str", default='_x_', type=str, help='The pattern used to split dset1 '
+    a.add_argument("--dset_split_str", default='_x_', type=str, help='The pattern used to split dset1 '
                    'from dset2 in the psname.')
     a.add_argument("--ext_split_str", default='_', type=str, help='The pattern used to split the dset '
                    'names from their extension in the psname (if it exists).')
-    a.add_argument("--verbose", type=bool, default=False, action='store_true', help='Report feedback to stdout.')
+    a.add_argument("--verbose", default=False, action='store_true', help='Report feedback to stdout.')
     
     return a
-
-
-

--- a/hera_pspec/grouping.py
+++ b/hera_pspec/grouping.py
@@ -562,7 +562,7 @@ def bootstrap_average_blpairs(uvp_list, blpair_groups=None, time_avg=False, seed
     Generate a bootstrap-sampled average over a set of power spectra. The 
     sampling is done over user-defined groups of baseline pairs (with 
     replacement).
-    
+
     Multiple UVPSpec objects can be passed to this function. The bootstrap 
     sampling is carried out over all of the available baseline-pairs (in a 
     user-specified group) across all UVPSpec objects. (This means that each 
@@ -707,7 +707,7 @@ def bootstrap_average_blpairs(uvp_list, blpair_groups=None, time_avg=False, seed
         return uvp_avg, blpair_wgts_list
 
 
-def bootstrap_resampled_error(uvp, blpair_groups=None, time_avg=False, Nsamples=1000, seed=0,
+def bootstrap_resampled_error(uvp, blpair_groups=None, time_avg=False, Nsamples=1000, seed=None,
                               normal_std=True, robust_std=True, conf_ints=None, bl_error_tol=1.0,
                               add_to_history='', verbose=False):
     """
@@ -773,12 +773,15 @@ def bootstrap_resampled_error(uvp, blpair_groups=None, time_avg=False, Nsamples=
     # Uniform average
     uvp_avg = average_spectra(uvp, blpair_groups=blpair_groups, time_avg=time_avg, inplace=False)
 
+    # initialize a seed
+    if seed is not None: np.random.seed(seed)
+
     # Iterate over Nsamples and create bootstrap resamples
     uvp_boots = []
     uvp_wgts = []
     for i in range(Nsamples):
         # resample
-        boot, wgt = bootstrap_average_blpairs(uvp, blpair_groups=blpair_groups, time_avg=time_avg, seed=seed)
+        boot, wgt = bootstrap_average_blpairs(uvp, blpair_groups=blpair_groups, time_avg=time_avg, seed=None)
         uvp_boots.append(boot)
         uvp_wgts.append(wgt)
 
@@ -801,7 +804,7 @@ def bootstrap_resampled_error(uvp, blpair_groups=None, time_avg=False, Nsamples=
     if conf_ints is not None:
         for ci in conf_ints:
             ci_tag = "conf_int_{:05.2f}".format(ci)
-            stats_array[ci_tag]
+            stats_array[ci_tag] = odict()
             for k in keys:
                 stats_array[ci_tag][k] = np.percentile(uvp_boot_data[k].real, ci, axis=0) \
                                             + 1j*np.percentile(uvp_boot_data[k].imag, ci, axis=0)
@@ -952,11 +955,11 @@ def get_bootstrap_run_argparser():
                     help="Whether to calculate a 'robust' standard deviation (astropy.stats.biweight_midvariance).")
     a.add_argument("--conf_ints", default=None, type=float, nargs='+',
                     help="Confidence intervals (precentage from 0 < ci < 100) to calculate.")
-    a.add_argument("--keep_samples", default=False, action='store_true', type=bool,
+    a.add_argument("--keep_samples", default=False, action='store_true',
                     help="If True, store bootstrap resamples in PSpecContainer object with *_bs# extension.")
     a.add_argument("--bl_error_tol", type=float, default=1.0,
                     help="Baseline redudancy tolerance if calculating redundant groups.")
-    a.add_argument("--overwrite", default=False, action='store_true', type=bool, help="overwrite outputs if they exist.")
+    a.add_argument("--overwrite", default=False, action='store_true', help="overwrite outputs if they exist.")
     a.add_argument("--add_to_history", default='', type=str, help="String to add to history of power spectra.")
     a.add_argument("--verbose", default=False, action='store_true', help="report feedback to stdout.")
     

--- a/hera_pspec/pspecdata.py
+++ b/hera_pspec/pspecdata.py
@@ -1775,9 +1775,9 @@ class PSpecData(object):
             integration_array[i] = spw_ints
             sclr_arr.append(spw_scalar)
 
-        # raise error if none of pols are consistent witht the UVData objects
-        if len(spw_pol)==0:
-            raise ValueError("None of the specified polarization pair match that of the UVData objects")
+            # raise error if none of pols are consistent witht the UVData objects
+            if len(spw_pol)==0:
+                raise ValueError("None of the specified polarization pair match that of the UVData objects")
 
         # fill uvp object
         uvp = uvpspec.UVPSpec()
@@ -2052,6 +2052,8 @@ def pspec_run(dsets, filename, groupname=None, dset_labels=None, dset_pairs=None
         List of strings to label the input datasets. These labels form
         the psname of each UVPSpec object. Default is "dset0_x_dset1"
         where 0 and 1 are replaced with the dset index in dsets.
+        Note: it is not advised to put underscores in the dset label names,
+        as some downstream functions assume this to be the case.
 
     dset_pairs : list of len-2 integer tuples
         List of tuples specifying the dset pairs to use in OQE estimation.
@@ -2206,6 +2208,8 @@ def pspec_run(dsets, filename, groupname=None, dset_labels=None, dset_pairs=None
 
     if dset_labels is None:
         dset_labels = ["dset{}".format(i) for i in range(Ndsets)]
+    else:
+        assert not np.any(['_' in dl for dl in dset_labels]), "cannot accept underscores in input dset_labels: {}".format(dset_labels)
 
     # load data if fed as filepaths
     if isinstance(dsets[0], (str, np.str)):
@@ -2367,6 +2371,7 @@ def get_pspec_run_argparser():
     a.add_argument("--bl_deg_range", default=(0, 180), nargs='+', type=float, help="If blpairs is not provided, limit the baseline used based on a min and max angle cut in ENU frame in degrees.")
     a.add_argument("--bl_error_tol", default=1.0, type=float, help="If blpairs is not provided, this is the error tolerance in forming redundant baseline groups in meters.")
     a.add_argument("--overwrite", default=False, action='store_true', help="Overwrite output if it exists.")
+    a.add_argument("--psname_ext", default='', type=str, help="Extension for pspectra name in PSpecContainer.")
     a.add_argument("--verbose", default=False, action='store_true', help="Report feedback to standard output.")
     return a
 

--- a/hera_pspec/pspecdata.py
+++ b/hera_pspec/pspecdata.py
@@ -1,7 +1,7 @@
 import numpy as np
 import aipy
 from pyuvdata import UVData
-import copy, operator, itertools
+import copy, operator, itertools, sys
 from collections import OrderedDict as odict
 import hera_cal as hc
 from hera_pspec import uvpspec, utils, version, pspecbeam, container
@@ -2025,12 +2025,12 @@ class PSpecData(object):
 
 
 def pspec_run(dsets, filename, groupname=None, dset_labels=None, dset_pairs=None,
-              spw_ranges=None, pol_pairs=None, blpairs=None,
+              psname_ext=None, spw_ranges=None, n_dlys=None, pol_pairs=None, blpairs=None,
               input_data_weight='identity', norm='I', taper='none',
               exclude_auto_bls=True, exclude_permutations=True,
-              Nblps_per_group=None, bl_len_range=(0, 1e10), bl_error_tol=1.0,
-              beam=None, cosmo=None, rephase_to_dset=None, Jy2mK=True,
-              overwrite=True, verbose=True, history=''):
+              Nblps_per_group=None, bl_len_range=(0, 1e10), bl_deg_range=(0, 180), bl_error_tol=1.0,
+              beam=None, cosmo=None, rephase_to_dset=None, trim_dset_lsts=False, broadcast_dset_flags=True,
+              time_thresh=0.2, Jy2mK=False, overwrite=True, verbose=True, history=''):
     """
     Create a PSpecData object, run OQE delay spectrum estimation and write
     results to a PSpecContainer object.
@@ -2056,9 +2056,16 @@ def pspec_run(dsets, filename, groupname=None, dset_labels=None, dset_pairs=None
         List of tuples specifying the dset pairs to use in OQE estimation.
         Default is to form all N_choose_2 pairs from input dsets.
 
+    psname_ext : string
+        A string extension for the psname in the container object.
+
     spw_ranges : list of len-2 integer tuples
         List of tuples specifying the spectral window range. See
         PSpecData.pspec() for details. Default is the entire band.
+
+    n_dlys : list
+        List of integers denoting number of delays to use per spectral window.
+        Same length as spw_ranges.
 
     pol_pairs : list of len-2 tuples
         List of string or integer tuples specifying the polarization
@@ -2108,6 +2115,10 @@ def pspec_run(dsets, filename, groupname=None, dset_labels=None, dset_pairs=None
         A tuple containing the minimum and maximum baseline length to use
         in utils.calc_reds call. Only used if blpairs is None.
 
+    bl_deg_range : len-2 float tuple
+        A tuple containing the min and max baseline angle (ENU frame in degrees)
+        to use in utils.calc_reds. Total range is between 0 and 180 degrees.
+
     bl_error_tol : float
         Baseline vector error tolerance when constructing redundant groups.
 
@@ -2125,6 +2136,17 @@ def pspec_run(dsets, filename, groupname=None, dset_labels=None, dset_pairs=None
         This adds a phasor correction to all others dataset to phase the
         visibility data to the LST-grid of this dataset. Default behavior
         is no rephasing.
+
+    trim_dset_lsts : boolean
+        If True, look for constant offset in LST between all dsets, and trim
+        non-overlapping LSTs.
+
+    broadcast_dset_flags : boolean
+        If True, broadcast dset flags across time using fractional time_thresh.
+
+    time_thresh : float
+        Fractional flagging threshold to trigger broadcast across time if
+        broadcast_dset_flags is True.
 
     Jy2mK : boolean
         If True, use the beam model provided to convert the units of each
@@ -2151,7 +2173,12 @@ def pspec_run(dsets, filename, groupname=None, dset_labels=None, dset_pairs=None
     if isinstance(dsets, (str, np.str, UVData)):
         dsets = [dsets]
     assert isinstance(dsets, (list, tuple, np.ndarray)), err_msg
-    Ndsets = len(dsets)
+
+    # parse psname
+    if psname_ext is not None:
+        assert isinstance(psname_ext, (str, np.str))
+    else:
+        psname_ext = ''
 
     # polarizations check
     if pol_pairs is not None:
@@ -2171,17 +2198,32 @@ def pspec_run(dsets, filename, groupname=None, dset_labels=None, dset_pairs=None
         # get redundant baseline groups
         bls = None
 
+    # Construct dataset pairs to operate on
+    Ndsets = len(dsets)
+    if dset_pairs is None:
+        dset_pairs = list(itertools.combinations(range(Ndsets), 2))
+
+    if dset_labels is None:
+        dset_labels = ["dset{}".format(i) for i in range(Ndsets)]
+
     # load data if fed as filepaths
     if isinstance(dsets[0], (str, np.str)):
-        # load data into UVData objects if fed as list of strings
-        t0 = time.time()
-        _dsets = []
-        for d in dsets:
-            uvd = UVData()
-            uvd.read_miriad(d, bls=bls, polarizations=pols)
-            _dsets.append(uvd)
-        dsets = _dsets
-        utils.log("Loaded data in %1.1f sec." % (time.time() - t0), lvl=1, verbose=verbose)
+        try:
+            # load data into UVData objects if fed as list of strings
+            t0 = time.time()
+            _dsets = []
+            for i, dset in enumerate(dsets):
+                # read data
+                uvd = UVData()
+                uvd.read_miriad(dset, bls=bls, polarizations=pols)
+                _dsets.append(uvd)
+            dsets = _dsets
+            utils.log("Loaded data in %1.1f sec." % (time.time() - t0), lvl=1, verbose=verbose)
+        except ValueError:
+            # at least one of the dset loads failed due to no data being present
+            utils.log("One of the dset loads failed due to no data overlap given the bls and pols selection", verbose=verbose)
+            return
+
     err_msg = "dsets must be fed as a list of dataset string paths or UVData objects."
     assert np.all([isinstance(d, UVData) for d in dsets]), err_msg
 
@@ -2209,15 +2251,19 @@ def pspec_run(dsets, filename, groupname=None, dset_labels=None, dset_pairs=None
     if rephase_to_dset is not None:
         ds.rephase_to_dset(rephase_to_dset)
 
+    # trim dset LSTs
+    if trim_dset_lsts:
+        ds.trim_dset_lsts()
+
+    # broadcast flags
+    if broadcast_dset_flags:
+        ds.broadcast_dset_flags(time_thresh=time_thresh)
+
     # perform Jy to mK conversion if desired
     if Jy2mK:
         ds.Jy_to_mK()
 
-    # Construct dataset pairs to operate on
-    if dset_pairs is None:
-        dset_pairs = list(itertools.combinations(range(Ndsets), 2))
-    if dset_labels is None:
-        dset_labels = ["dset{}".format(i) for i in range(Ndsets)]
+    # check dset pair type
     err_msg = "dset_pairs must be fed as a list of len-2 integer tuples"
     assert isinstance(dset_pairs, list), err_msg
     assert np.all([isinstance(d, tuple) for d in dset_pairs]), err_msg
@@ -2233,7 +2279,8 @@ def pspec_run(dsets, filename, groupname=None, dset_labels=None, dset_pairs=None
                                        exclude_auto_bls=exclude_auto_bls,
                                        exclude_permutations=exclude_permutations,
                                        Nblps_per_group=Nblps_per_group,
-                                       bl_len_range=bl_len_range)
+                                       bl_len_range=bl_len_range,
+                                       bl_deg_range=bl_deg_range)
             bls1_list.append(bls1)
             bls2_list.append(bls2)
 
@@ -2262,12 +2309,16 @@ def pspec_run(dsets, filename, groupname=None, dset_labels=None, dset_pairs=None
     # Loop over dataset combinations
     for i, dset_idxs in enumerate(dset_pairs):
 
+        # check bls lists aren't empty
+        if len(bls1_list[i]) == 0 or len(bls2_list[i]) == 0:
+            continue
+
         # Run OQE
-        uvp = ds.pspec(bls1_list[i], bls2_list[i], dset_idxs, pol_pairs, spw_ranges=spw_ranges,
+        uvp = ds.pspec(bls1_list[i], bls2_list[i], dset_idxs, pol_pairs, spw_ranges=spw_ranges, n_dlys=n_dlys,
                        input_data_weight=input_data_weight, norm=norm, taper=taper, history=history)
 
         # Store output
-        psname = '{}_x_{}'.format(dset_labels[dset_idxs[0]], dset_labels[dset_idxs[1]])
+        psname = '{}_x_{}{}'.format(dset_labels[dset_idxs[0]], dset_labels[dset_idxs[1]], psname_ext)
         psc.set_pspec(group=groupname, psname=psname, pspec=uvp, overwrite=overwrite)
 
     return psc
@@ -2282,6 +2333,7 @@ def get_pspec_run_argparser():
     a.add_argument("--dset_pairs", default=None, type=tuple, nargs='*', help="List of len-2 integer tuples of dset pairings for OQE.")
     a.add_argument("--dset_labels", default=None, type=str, nargs='*', help="List of string labels for each input dataset.")
     a.add_argument("--spw_ranges", default=None, type=tuple, nargs='*', help="List of len-2 integer tuples of spectral window selections for OQE.")
+    a.add_argument("--n_dlys", default=None, type=int, nargs='*', help="List of integers specifying number of delays to use per spectral window selection.")
     a.add_argument("--pol_pairs", default=None, type=tuple, nargs='*', help="List of len-2 integer of string tuples of polarization pairs for OQE.")
     a.add_argument("--blpairs", default=None, type=tuple, nargs='*', help="List of integer tuples containing baseline pair to run OQE on. Ex: [((1, 2), (3, 4)), ((1, 2), (5, 6)), ...]")
     a.add_argument("--input_data_weight", default='identity', type=str, help="Data weighting for OQE. See PSpecData.pspec for details.")
@@ -2290,11 +2342,15 @@ def get_pspec_run_argparser():
     a.add_argument("--beam", default=None, type=str, help="Filepath to UVBeam healpix map of antenna beam.")
     a.add_argument("--cosmo", default=None, nargs='*', type=float, help="List of float values for [Om_L, Om_b, Om_c, H0, Om_M, Om_k].")
     a.add_argument("--rephase_to_dset", default=None, type=int, help="dset integer index to phase all other dsets to. Default is no rephasing.")
+    a.add_argument("--trim_dset_lsts", default=False, action='store_true', help="Trim non-overlapping dset LSTs.")
+    a.add_argument("--broadcast_dset_flags", default=False, action='store_true', help="Broadcast dataset flags across time according to time_thresh.")
+    a.add_argument("--time_thresh", default=0.2, type=float, help="Fractional flagging threshold across time to trigger flag broadcast if broadcast_dset_flags is True")
     a.add_argument("--Jy2mK", default=False, action='store_true', help="Convert datasets from Jy to mK if a beam model is provided.")
     a.add_argument("--exclude_auto_bls", default=False, action='store_true', help='If blpairs is not provided, exclude all baselines paired with itself.')
     a.add_argument("--exclude_permutations", default=False, action='store_true', help='If blpairs is not provided, exclude a basline-pair permutations. Ex: if (A, B) exists, exclude (B, A).')
     a.add_argument("--Nblps_per_group", default=None, type=int, help="If blpairs is not provided and group == True, set the number of blpairs in each group.")
     a.add_argument("--bl_len_range", default=(0, 1e10), type=tuple, help="If blpairs is not provided, limit the baselines used based on their minimum and maximum length in meters.")
+    a.add_argument("--bl_deg_range", default=(0, 180), type=tuple, help="If blpairs is not provided, limit the baseline used based on a min and max angle cut in ENU frame in degrees.")
     a.add_argument("--bl_error_tol", default=1.0, type=float, help="If blpairs is not provided, this is the error tolerance in forming redundant baseline groups in meters.")
     a.add_argument("--overwrite", default=False, action='store_true', help="Overwrite output if it exists.")
     a.add_argument("--verbose", default=False, action='store_true', help="Report feedback to standard output.")

--- a/hera_pspec/pspecdata.py
+++ b/hera_pspec/pspecdata.py
@@ -2316,7 +2316,7 @@ def pspec_run(dsets, filename, groupname=None, dset_labels=None, dset_pairs=None
 
         # Run OQE
         uvp = ds.pspec(bls1_list[i], bls2_list[i], dset_idxs, pol_pairs, spw_ranges=spw_ranges, n_dlys=n_dlys,
-                       input_data_weight=input_data_weight, norm=norm, taper=taper, history=history)
+                       input_data_weight=input_data_weight, norm=norm, taper=taper, history=history, verbose=verbose)
 
         # Store output
         psname = '{}_x_{}{}'.format(dset_labels[dset_idxs[0]], dset_labels[dset_idxs[1]], psname_ext)

--- a/hera_pspec/tests/test_container.py
+++ b/hera_pspec/tests/test_container.py
@@ -1,9 +1,10 @@
 import unittest
 from nose.tools import assert_raises
+import nose.tools as nt
 import numpy as np
 import os, sys, copy
 from hera_pspec.data import DATA_PATH
-from hera_pspec import PSpecContainer, UVPSpec, testing
+from hera_pspec import container, PSpecContainer, UVPSpec, testing
 
 
 class Test_PSpecContainer(unittest.TestCase):
@@ -124,3 +125,51 @@ class Test_PSpecContainer(unittest.TestCase):
         # Check that save() can be called
         ps_store.save()
         
+
+def test_merge_spectra():
+    fname = os.path.join(DATA_PATH, "zen.2458042.17772.xx.HH.uvXA")
+    uvp1 = testing.uvpspec_from_data(fname, [(24, 25), (37, 38)], spw_ranges=[(10, 40)])
+    uvp2 = testing.uvpspec_from_data(fname, [(38, 39), (52, 53)], spw_ranges=[(10, 40)])
+
+    # test basic execution
+    if os.path.exists('ex.h5'):
+        os.remove('ex.h5')
+    psc = PSpecContainer("ex.h5", mode='rw')
+    psc.set_pspec("grp1", "uvp_a", uvp1, overwrite=True)
+    psc.set_pspec("grp1", "uvp_b", uvp2, overwrite=True)
+    container.merge_spectra(psc, dset_split_str=None, ext_split_str='_')
+    nt.assert_equal(psc.spectra('grp1'), [u'uvp'])
+
+    # test dset name handling
+    if os.path.exists('ex.h5'):
+        os.remove('ex.h5')
+    psc = PSpecContainer("ex.h5", mode='rw')
+    psc.set_pspec("grp1", "d1_x_d2_a", uvp1, overwrite=True)
+    psc.set_pspec("grp1", "d1_x_d2_b", uvp2, overwrite=True)
+    psc.set_pspec("grp1", "d2_x_d3_a", uvp1, overwrite=True)
+    psc.set_pspec("grp1", "d2_x_d3_b", uvp2, overwrite=True)
+    container.merge_spectra('ex.h5', dset_split_str='_x_', ext_split_str='_')
+    nt.assert_equal(psc.spectra('grp1'), [u'd1_x_d2', u'd2_x_d3'])
+
+    # test exceptions
+    if os.path.exists('ex.h5'):
+        os.remove('ex.h5')
+    psc = PSpecContainer("ex.h5", mode='rw')
+    # test no group exception
+    nt.assert_raises(AssertionError, container.merge_spectra, psc)
+    # test failed combine_uvpspec
+    psc.set_pspec("grp1", "d1_x_d2_a", uvp1, overwrite=True)
+    psc.set_pspec("grp1", "d1_x_d2_b", uvp1, overwrite=True)
+    container.merge_spectra(psc, dset_split_str='_x_', ext_split_str='_')
+    nt.assert_equal(psc.spectra('grp1'), [u'd1_x_d2_a', u'd1_x_d2_b'])
+
+    if os.path.exists("ex.h5"):
+        os.remove("ex.h5")
+
+def test_merge_spectra_argparser():
+    args = container.get_merge_spectra_argparser()
+    a = args.parse_args(["filename", "--dset_split_str", "_x_", "--ext_split_str", "_"])
+    nt.assert_equal(a.filename, "filename")
+    nt.assert_equal(a.dset_split_str, "_x_")
+    nt.assert_equal(a.ext_split_str, "_")
+

--- a/hera_pspec/tests/test_grouping.py
+++ b/hera_pspec/tests/test_grouping.py
@@ -213,5 +213,9 @@ class Test_grouping(unittest.TestCase):
                                times=True, pols=True, inplace=True)
         self.assertEqual(uvp1, uvp2)
         
+
+def test_get_pspec_bootstrap_argparser():
+    a = grouping.get_pspec_bootstrap_argparser()
+
 if __name__ == "__main__":
     unittest.main()

--- a/hera_pspec/tests/test_grouping.py
+++ b/hera_pspec/tests/test_grouping.py
@@ -5,7 +5,10 @@ import os
 from hera_pspec.data import DATA_PATH
 from hera_pspec import uvpspec, conversions, parameter, pspecbeam, pspecdata, testing
 from hera_pspec import uvpspec_utils as uvputils
-from hera_pspec import grouping
+from hera_pspec import grouping, container
+from pyuvdata import UVData
+from hera_cal import redcal
+
 
 class Test_grouping(unittest.TestCase):
 
@@ -213,9 +216,96 @@ class Test_grouping(unittest.TestCase):
                                times=True, pols=True, inplace=True)
         self.assertEqual(uvp1, uvp2)
         
+def test_bootstrap_resampled_error():
+    # generate a UVPSpec
+    visfile = os.path.join(DATA_PATH, "zen.even.xx.LST.1.28828.uvOCRSA")
+    beamfile = os.path.join(DATA_PATH, "HERA_NF_dipole_power.beamfits")
+    cosmo = conversions.Cosmo_Conversions()
+    beam = pspecbeam.PSpecBeamUV(beamfile, cosmo=cosmo)
+    uvd = UVData()
+    uvd.read_miriad(visfile)
+    ap, a = uvd.get_ENU_antpos(pick_data_ants=True)
+    reds = redcal.get_pos_reds(dict(zip(a, ap)), low_hi=True, bl_error_tol=1.0)[:3]
+    uvp = testing.uvpspec_from_data(uvd, reds, spw_ranges=[(50, 100)], beam=beam, cosmo=cosmo)
 
-def test_get_pspec_bootstrap_argparser():
-    a = grouping.get_pspec_bootstrap_argparser()
+    # Lots of this function is already tested by bootstrap_run
+    # so only test the stuff not already tested
+    if os.path.exists("uvp.h5"):
+        os.remove("uvp.h5")
+    uvp.write_hdf5("uvp.h5", overwrite=True)
+    ua, ub, uw = grouping.bootstrap_resampled_error("uvp.h5", blpair_groups=None, Nsamples=10, seed=0, verbose=False)
+    # check number of boots
+    nt.assert_equal(len(ub), 10)
+    # check seed has been used properly
+    nt.assert_equal(uw[0][0][:5], [1.0, 1.0, 0.0, 2.0, 1.0])
+    nt.assert_equal(uw[0][1][:5], [2.0, 1.0, 1.0, 6.0, 1.0])
+    nt.assert_equal(uw[1][0][:5], [2.0, 2.0, 1.0, 1.0, 2.0])
+    nt.assert_equal(uw[1][1][:5], [1.0, 0.0, 1.0, 1.0, 4.0])
+
+    if os.path.exists("uvp.h5"):
+        os.remove("uvp.h5")
+
+def test_bootstrap_run():
+    # generate a UVPSpec and container
+    visfile = os.path.join(DATA_PATH, "zen.even.xx.LST.1.28828.uvOCRSA")
+    beamfile = os.path.join(DATA_PATH, "HERA_NF_dipole_power.beamfits")
+    cosmo = conversions.Cosmo_Conversions()
+    beam = pspecbeam.PSpecBeamUV(beamfile, cosmo=cosmo)
+    uvd = UVData()
+    uvd.read_miriad(visfile)
+    ap, a = uvd.get_ENU_antpos(pick_data_ants=True)
+    reds = redcal.get_pos_reds(dict(zip(a, ap)), low_hi=True, bl_error_tol=1.0)[:3]
+    uvp = testing.uvpspec_from_data(uvd, reds, spw_ranges=[(50, 100)], beam=beam, cosmo=cosmo)
+    if os.path.exists("ex.h5"):
+        os.remove("ex.h5")
+    psc = container.PSpecContainer("ex.h5", mode='rw')
+    psc.set_pspec("grp1", "uvp", uvp)
+
+    # Test basic bootstrap run
+    grouping.bootstrap_run(psc, time_avg=True, Nsamples=100, seed=0,
+                           normal_std=True, robust_std=True, conf_ints=[16, 84], keep_samples=True,
+                           bl_error_tol=1.0, overwrite=True, add_to_history='hello!', verbose=False)
+    spcs = psc.spectra("grp1")
+    # assert all bs samples were written
+    nt.assert_true(np.all(["uvp_bs{}".format(i) in spcs for i in range(100)]))
+    # assert average was written
+    nt.assert_true("uvp_avg" in spcs and "uvp" in spcs)
+    # assert average only has one time and 3 blpairs
+    uvp_avg = psc.get_pspec("grp1", "uvp_avg")
+    nt.assert_equal(uvp_avg.Ntimes, 1)
+    nt.assert_equal(uvp_avg.Nblpairs, 3)
+    # check avg file history
+    nt.assert_true("hello!" in uvp_avg.history)
+    # assert original uvp is unchanged
+    nt.assert_true(uvp == psc.get_pspec("grp1", 'uvp'))
+    # check stats array
+    ## TODO
+
+    # test exceptions
+    del psc
+    if os.path.exists("ex.h5"):
+        os.remove("ex.h5")
+    psc = container.PSpecContainer("ex.h5", mode='rw')
+    # test empty groups
+    nt.assert_raises(AssertionError, grouping.bootstrap_run, "ex.h5")
+    # test bad filename
+    nt.assert_raises(AssertionError, grouping.bootstrap_run, 1)
+    # test fed spectra doesn't exist
+    psc.set_pspec("grp1", "uvp", uvp)
+    nt.assert_raises(AssertionError, grouping.bootstrap_run, psc, spectra=['grp1/foo'])
+    if os.path.exists("ex.h5"):
+        os.remove("ex.h5")
+
+
+def test_get_bootstrap_run_argparser():
+    args = grouping.get_bootstrap_run_argparser()
+    a = args.parse_args(['fname', '--spectra', 'grp1/uvp1', 'grp1/uvp2', 'grp2/uvp1',
+                         '--blpair_groups', '101102103104 101102102103, 102103104105',
+                         '--time_avg', 'True', '--Nsamples', '100', '--conf_ints', '16', '84'])
+    nt.assert_equal(a.spectra, ['grp1/uvp1', 'grp1/uvp2', 'grp2/uvp1'])
+    nt.assert_equal(a.blpair_groups, [[101102103104, 101102102103], [102103104105]])
+    nt.assert_equal(a.conf_ints, [16.0, 84.0])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/hera_pspec/tests/test_pspecdata.py
+++ b/hera_pspec/tests/test_pspecdata.py
@@ -1035,8 +1035,12 @@ def test_pspec_run():
 
 def test_get_argparser():
     args = pspecdata.get_pspec_run_argparser()
-    a = args.parse_args([['foo'], 'bar'])
-
+    a = args.parse_args([['foo'], 'bar', '--dset_pairs', '0 0, 1 1', '--pol_pairs', 'xx xx, yy yy',
+                         '--spw_ranges', '300 400, 600 800', '--blpairs', '24 25 24 25, 37 38 37 38'])
+    nt.assert_equal(a.pol_pairs, [('xx', 'xx'), ('yy', 'yy')])
+    nt.assert_equal(a.dset_pairs, [(0, 0), (1, 1)])
+    nt.assert_equal(a.spw_ranges, [(300, 400), (600, 800)])
+    nt.assert_equal(a.blpairs, [((24, 25), (24, 25)), ((37, 38), (37, 38))])
 
 """
 # LEGACY MONTE CARLO TESTS

--- a/hera_pspec/tests/test_utils.py
+++ b/hera_pspec/tests/test_utils.py
@@ -189,13 +189,13 @@ class Test_Utils(unittest.TestCase):
         uv_template = os.path.join(DATA_PATH, "zen.{group}.{pol}.LST.1.28828.uvOCRSA")
         groupings = utils.config_pspec_blpairs(uv_template, [('xx', 'xx')], [('even', 'odd')], verbose=False)
         nt.assert_equal(len(groupings), 1)
-        nt.assert_equal(groupings.keys()[0], (('xx', 'even'), ('xx', 'odd')))
+        nt.assert_equal(groupings.keys()[0], (('even', 'odd'), ('xx', 'xx')))
         nt.assert_equal(len(groupings.values()[0]), 11833)
 
         # test multiple, some non-existant pairs
         groupings = utils.config_pspec_blpairs(uv_template, [('xx', 'xx'), ('yy', 'yy')], [('even', 'odd'), ('even', 'odd')], verbose=False)
         nt.assert_equal(len(groupings), 1)
-        nt.assert_equal(groupings.keys()[0], (('xx', 'even'), ('xx', 'odd')))
+        nt.assert_equal(groupings.keys()[0], (('even', 'odd'), ('xx', 'xx')))
 
         # test xants
         groupings = utils.config_pspec_blpairs(uv_template, [('xx', 'xx')], [('even', 'odd')], xants=[0, 1, 2], verbose=False)

--- a/hera_pspec/tests/test_utils.py
+++ b/hera_pspec/tests/test_utils.py
@@ -8,7 +8,6 @@ from collections import OrderedDict as odict
 from pyuvdata import UVData
 
 
-
 def test_cov():
     # load another data file
     uvd = UVData()
@@ -183,6 +182,27 @@ class Test_Utils(unittest.TestCase):
         uvd2 = copy.deepcopy(uvd)
         uvd2.antenna_positions[0] += 2
         nt.assert_raises(AssertionError, utils.calc_reds, uvd, uvd2)
+
+    def test_config_pspec_blpairs(self):
+        # test basic execution
+        uv_template = os.path.join(DATA_PATH, "zen.{group}.{pol}.LST.1.28828.uvOCRSA")
+        groupings = utils.config_pspec_blpairs(uv_template, [('xx', 'xx')], [('even', 'odd')], verbose=False)
+        nt.assert_equal(len(groupings), 1)
+        nt.assert_equal(groupings.keys()[0], (('xx', 'even'), ('xx', 'odd')))
+        nt.assert_equal(len(groupings.values()[0]), 11833)
+
+        # test multiple, some non-existant pairs
+        groupings = utils.config_pspec_blpairs(uv_template, [('xx', 'xx'), ('yy', 'yy')], [('even', 'odd'), ('even', 'odd')], verbose=False)
+        nt.assert_equal(len(groupings), 1)
+        nt.assert_equal(groupings.keys()[0], (('xx', 'even'), ('xx', 'odd')))
+
+        # test xants
+        groupings = utils.config_pspec_blpairs(uv_template, [('xx', 'xx')], [('even', 'odd')], xants=[0, 1, 2], verbose=False)
+        nt.assert_equal(len(groupings.values()[0]), 9735)
+
+        # test exceptions
+        nt.assert_raises(AssertionError, utils.config_pspec_blpairs, uv_template, [('xx', 'xx'), ('xx', 'xx')], [('even', 'odd')], verbose=False)
+        
 
 def test_log():
     """

--- a/hera_pspec/utils.py
+++ b/hera_pspec/utils.py
@@ -7,6 +7,12 @@ import operator
 from hera_cal import redcal
 import itertools
 import argparse
+import glob
+import os
+import aipy
+from collections import OrderedDict as odict
+from pyuvdata import utils as uvutils
+
 
 def hash(w):
     """
@@ -343,7 +349,7 @@ def spw_range_from_freqs(data, freq_range, bounds_error=True):
     spw_range : tuple or list of tuples
         Indices of the channels at the lower and upper bounds of the specified 
         spectral window(s). 
-        
+
         Note: If the requested spectral window is outside the available 
         frequency range, and bounds_error is False, '(None, None)' is returned. 
     """
@@ -504,4 +510,100 @@ def flatten(nested_list):
     Flatten a list of nested lists
     """
     return [item for sublist in nested_list for item in sublist]
+
+def config_pspec_blpairs(uv_templates, pol_pairs, group_pairs, exclude_auto_bls=True, 
+                        exclude_permutations=True, bl_len_range=(0, 1e10), bl_deg_range=(0, 180),
+                        xants=None, verbose=True):
+    """
+    Given a list of miriad file templates and selections for
+    polarization and group labels, construct a master list of
+    blpair-group-pol pairs using utils.construct_reds().
+
+    Note: currently, each file to-be-searched for must contain a single
+    baseline type, and must have the baseline length and angle (ENU in meters)
+    in the filename separated by an underscore: 
+    e.g. "zen.{len:.0f}_{deg:.0f}.{pol}.{group}.HH.uv" There also must be only 
+    one underscore in the filename.
+
+    A baseline-pair is formed by self-matching unique-files in the
+    glob-parsed master list, and then string-formatting-in appropriate 
+    pol and group selections given pol_pairs and group_pairs. Those two
+    files are then passed to utils.calc_reds(..., **kwargs) to construct
+    the baseline-pairs for that particular file-matching.
+
+    Parameters
+    ----------
+
+
+
+    Returns
+    -------
+
+    """
+    # type check
+    if isinstance(uv_templates, (str, np.str)):
+        uv_templates = [uv_templates]
+    assert len(pol_pairs) == len(group_pairs), "len(pol_pairs) must equal len(group_pairs)"
+
+    # get unique pols and groups
+    pols = sorted(set([item for sublist in pol_pairs for item in sublist]))
+    groups = sorted(set([item for sublist in group_pairs for item in sublist]))
+
+    # parse wildcards in uv_templates to get wildcard-unique filenames
+    unique_files = []
+    pol_grps = []
+    for template in uv_templates:
+        for pol in pols:
+            for group in groups:
+                # parse wildcards with pol / group selection
+                files = glob.glob(template.format(pol=pol, group=group))
+                # if any files were parsed, add to pol_grps
+                if len(files) > 0:
+                    pol_grps.append((pol, group))
+                # insert into unique_files with {pol} and {group} re-inserted
+                for _file in files:
+                    _unique_file = _file.replace(".{pol}.".format(pol=pol), ".{pol}.").replace(".{group}.".format(group=group), ".{group}.")
+                    if _unique_file not in unique_files:
+                        unique_files.append(_unique_file)
+    unique_files = sorted(unique_files)
+
+    # iterate over unique files and get their baseline length and angle
+    lens, angs = [], []
+    for uf in unique_files:
+        lens.append(float(uf.split('_')[0].split('.')[-1]))
+        angs.append(float(uf.split('_')[1].split('.')[0]))
+
+    # use a single file from unique_files and a single pol-group combination to get antenna positions
+    _file = unique_files[0].format(pol=pol_grps[0][0], group=pol_grps[0][1])
+    _, _, uvd = uvutils.get_miriad_antpos(_file)
+
+    # get baseline pairs
+    (_bls1, _bls2, _, _, 
+     _) = calc_reds(uvd, uvd, filter_blpairs=False, exclude_auto_bls=exclude_auto_bls,
+                    exclude_permutations=exclude_permutations, bl_len_range=bl_len_range,
+                    bl_deg_range=bl_deg_range)
+
+    # take out xants if fed
+    if xants is not None:
+        bls1, bls2 = [], []
+        for bl1, bl2 in zip(_bls1, _bls2):
+            if bl1 not in xants and bl2 not in xants:
+                bls1.append(bl1)
+                bls2.append(bl2)
+    else:
+        bls1, bls2 = _bls1, _bls2
+    blps = zip(bls1, bls2)
+
+    # iterate over pol-group pairs that exist
+    keys = odict()
+    for pp, gp in zip(pol_pairs, group_pairs):
+        if (pp[0], gp[0]) not in pol_grps or (pp[1], gp[1]) not in pol_grps:
+            if verbose:
+                print "pol_pair {} and group_pair {} not found in data files".format(pp, gp)
+            continue
+        keys[(pp, gp)] = blps
+
+    return keys
+
+
 

--- a/hera_pspec/utils.py
+++ b/hera_pspec/utils.py
@@ -644,7 +644,7 @@ def config_pspec_blpairs(uv_templates, pol_pairs, group_pairs, exclude_auto_bls=
             if verbose:
                 print "pol_pair {} and group_pair {} not found in data files".format(pp, gp)
             continue
-        groupings[tuple(zip(pp, gp))] = blps
+        groupings[(gp, pp)] = blps
 
     return groupings
 

--- a/hera_pspec/utils.py
+++ b/hera_pspec/utils.py
@@ -649,10 +649,11 @@ def config_pspec_blpairs(uv_templates, pol_pairs, group_pairs, exclude_auto_bls=
     return groupings
 
 
-def get_blvec_reds(blvecs, bl_error_tol=0):
+def get_blvec_reds(blvecs, bl_error_tol=1.0):
     """
     Given a blvecs dictionary, form groups of baseline-pair objects based on
-    redundancy in ENU coordinates.
+    redundancy in ENU coordinates. Note: this only uses the East-North components
+    of the baseline vectors to calculate redundancy.
 
     Parameters:
     -----------

--- a/hera_pspec/utils.py
+++ b/hera_pspec/utils.py
@@ -644,7 +644,7 @@ def config_pspec_blpairs(uv_templates, pol_pairs, group_pairs, exclude_auto_bls=
             if verbose:
                 print "pol_pair {} and group_pair {} not found in data files".format(pp, gp)
             continue
-        groupings[(gp, pp)] = blps
+        groupings[(tuple(gp), tuple(pp))] = blps
 
     return groupings
 

--- a/hera_pspec/utils.py
+++ b/hera_pspec/utils.py
@@ -649,4 +649,88 @@ def config_pspec_blpairs(uv_templates, pol_pairs, group_pairs, exclude_auto_bls=
     return groupings
 
 
+def get_blvec_reds(blvecs, bl_error_tol=0):
+    """
+    Given a blvecs dictionary, form groups of baseline-pair objects based on
+    redundancy in ENU coordinates.
 
+    Parameters:
+    -----------
+    blvecs : dictionary (or UVPSpec object)
+        A dictionary with baseline vectors as values. Alternatively, this
+        can be a UVPSpec object with baseline-pairs and baseline vectors.
+
+    bl_error_tol : int
+        Redundancy tolerance of baseline vector in meters.
+
+    Returns:
+    --------
+    red_bl_grp : list
+        A list of baseline groups, ordered by ascending baseline length.
+
+    red_bl_len : list
+        A list of baseline lengths in meters for each bl group
+
+    red_bl_ang : list
+        A list of baseline angles in degrees for each bl group
+
+    red_bl_tag : list
+        A list of baseline string tags denoting bl length and angle
+    """
+    from hera_pspec import UVPSpec
+    # type check
+    assert isinstance(blvecs, (dict, odict, UVPSpec)), "blpairs must be fed as a dict or UVPSpec"
+    if isinstance(blvecs, UVPSpec):
+        # get baseline vectors
+        uvp = blvecs
+        bls = uvp.bl_array
+        bl_vecs = uvp.get_ENU_bl_vecs()[:, :2]
+        blvecs = dict(zip(map(uvp.bl_to_antnums, bls), bl_vecs))
+        # get baseline-pairs
+        blpairs = uvp.get_blpairs()
+        # form dictionary
+        _blvecs = odict()
+        for blp in blpairs:
+            bl1 = blp[0]
+            bl2 = blp[1]
+            _blvecs[blp] = (blvecs[bl1] + blvecs[bl2]) / 2.
+        blvecs = _blvecs
+
+    # create empty lists
+    red_bl_grp = []
+    red_bl_vec = []
+    red_bl_len = []
+    red_bl_ang = []
+    red_bl_tag = []
+
+    # iterate over each baseline in blvecs
+    for bl in blvecs.keys():
+        # get bl vector and properties
+        bl_vec = blvecs[bl][:2]
+        bl_len = np.linalg.norm(bl_vec)
+        bl_ang = np.arctan2(*bl_vec[::-1]) * 180 / np.pi
+        if bl_ang < 0: bl_ang = (bl_ang + 180) % 360
+        bl_tag = "{:03.0f}_{:03.0f}".format(bl_len, bl_ang)
+
+        # append to list if unique within tolerance
+        match = [np.all(np.isclose(blv, bl_vec, bl_error_tol)) for blv in red_bl_vec]
+        if np.any(match):
+            match_id = np.where(match)[0][0]
+            red_bl_grp[match_id].append(bl)
+
+        # else create new list
+        else:
+            red_bl_grp.append([bl])
+            red_bl_vec.append(bl_vec)
+            red_bl_len.append(bl_len)
+            red_bl_ang.append(bl_ang)
+            red_bl_tag.append(bl_tag)
+
+    # order based on tag
+    order = np.argsort(red_bl_tag)
+    red_bl_grp = [red_bl_grp[i] for i in order]
+    red_bl_len = [red_bl_len[i] for i in order]
+    red_bl_ang = [red_bl_ang[i] for i in order]
+    red_bl_tag = [red_bl_tag[i] for i in order]
+
+    return red_bl_grp, red_bl_len, red_bl_ang, red_bl_tag

--- a/hera_pspec/uvpspec.py
+++ b/hera_pspec/uvpspec.py
@@ -766,7 +766,6 @@ class UVPSpec(object):
                         (self.bl_vecs + self.telescope_location).T, \
                         *uvutils.LatLonAlt_from_XYZ(self.telescope_location)).T
     
-    
     def read_from_group(self, grp, just_meta=False, spws=None, bls=None, 
                         blpairs=None, times=None, pols=None, 
                         only_pairs_in_bls=False):
@@ -838,7 +837,6 @@ class UVPSpec(object):
             self.cosmo = conversions.Cosmo_Conversions(**ast.literal_eval(self.cosmo))
 
         self.check(just_meta=just_meta)
-
 
     def read_hdf5(self, filepath, just_meta=False, spws=None, bls=None,
                   blpairs=None, times=None, pols=None, 
@@ -933,7 +931,7 @@ class UVPSpec(object):
                                  dtype=np.float)
     
         # denote as a uvpspec object
-        group.attrs['pspec_type'] = group.__class__.__name__
+        group.attrs['pspec_type'] = self.__class__.__name__
 
     def write_hdf5(self, filepath, overwrite=False, run_check=True):
         """
@@ -960,7 +958,6 @@ class UVPSpec(object):
         # Write file
         with h5py.File(filepath, 'w') as f:
             self.write_to_group(f, run_check=run_check)
-
 
     def set_cosmology(self, new_cosmo, overwrite=False, new_beam=None, 
                       verbose=True):

--- a/hera_pspec/uvpspec.py
+++ b/hera_pspec/uvpspec.py
@@ -807,6 +807,10 @@ class UVPSpec(object):
             If True, keep only baseline-pairs whose first _and_ second baseline
             are found in the 'bls' list. Default: False.
         """
+        # Make sure the group is a UVPSpec object
+        assert 'pspec_type' in grp.attrs, "This object is not a UVPSpec object"
+        assert grp.attrs['pspec_type'] == 'UVPSpec', "This object is not a UVPSpec object"
+        
         # Clear all data in the current object
         self._clear()
 
@@ -928,6 +932,9 @@ class UVPSpec(object):
                                  data=self.nsample_array[i], 
                                  dtype=np.float)
     
+        # denote as a uvpspec object
+        group.attrs['pspec_type'] = group.__class__.__name__
+
     def write_hdf5(self, filepath, overwrite=False, run_check=True):
         """
         Write a UVPSpec object to HDF5 file.
@@ -1579,6 +1586,9 @@ def combine_uvpspec(uvps, verbose=True):
                     u.nsample_array[i][j, k] = uvps[l].integration_array[m][n, q]
                     u.label_1_array[i, j, k] = u.labels.index(uvps[l].labels[uvps[l].label_1_array[m, n, q]])
                     u.label_2_array[i, j, k] = u.labels.index(uvps[l].labels[uvps[l].label_1_array[m, n, q]])
+                    if j == 0:
+                        # only update once
+                        u.scalar_array[i, k] = uvps[l].scalar_array[m, q]
 
             u.time_1_array[j] = uvps[l].time_1_array[n]
             u.time_2_array[j] = uvps[l].time_2_array[n]

--- a/hera_pspec/uvpspec_utils.py
+++ b/hera_pspec/uvpspec_utils.py
@@ -177,8 +177,6 @@ def _select(uvp, spws=None, bls=None, only_pairs_in_bls=False, blpairs=None, tim
         pass
 
 
-
-
 def _blpair_to_antnums(blpair):
     """
     Convert baseline-pair integer to nested tuple of antenna numbers.

--- a/pipelines/idr2_preprocessing/preprocess_data.py
+++ b/pipelines/idr2_preprocessing/preprocess_data.py
@@ -194,7 +194,8 @@ if timeavg_sub:
     datafiles, datapols = uvt.utils.search_data(input_data_template.format(group=groupname, pol='{pol}'), pols, matched_pols=False, reverse_nesting=False, flatten=False)
 
     # load a datafile and get antenna numbers
-    _, _, uvd = uvutils.get_miriad_antpos(datafiles[0][0])
+    uvd = UVData()
+    uvd.read_miriad_metadata(datafiles[0][0])
     antpos, ants = uvd.get_ENU_antpos()
     antpos_dict = dict(zip(ants, antpos))
 
@@ -296,6 +297,9 @@ if timeavg_sub:
                             print "baseline {} not found in time-averaged spectrum".format(bl)
                             uvd.flag_array[bl_inds, :, :, pol_ind] = True
 
+                # put uniq_bls in if it doesn't exist
+                if not uvd.extra_keywords.has_key('uniq_bls'):
+                    uvd.extra_keywords['uniq_bls'] = json.dumps(np.unique(uvd.baseline_array).tolist())
                 # write tavg-subtracted data
                 out_df = os.path.join(out_dir, os.path.basename(df) + p['file_ext'])
                 uvd.history += "\nTime-Average subtracted."
@@ -332,7 +336,8 @@ if time_avg:
     datafiles, datapols = uvt.utils.search_data(input_data_template.format(group=groupname, pol='{pol}'), pols, matched_pols=False, reverse_nesting=False, flatten=False)
 
     # load a datafile and get antenna numbers
-    _, _, uvd = uvutils.get_miriad_antpos(datafiles[0][0])
+    uvd = UVData()
+    uvd.read_miriad_metadata(datafiles[0][0])
     antpos, ants = uvd.get_ENU_antpos()
     antpos_dict = dict(zip(ants, antpos))
 

--- a/scripts/bootstrap_run.py
+++ b/scripts/bootstrap_run.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+"""
+Pipeline script to load a PSpecContainer and bootstrap over redundant baseline-
+pair groups to produce errorbars.
+"""
+import sys
+import os
+from hera_pspec import pspecdata, grouping
+from hera_pspec import uvpspec_utils as uvputils
+
+# Parse commandline args
+args = grouping.get_bootstrap_run_argparser()
+a = args.parse_args()
+kwargs = vars(a) # dict of args
+
+# Get arguments
+filename = kwargs.pop('filename')
+
+# Run bootstrap
+grouping.bootstrap_run(filename, **kwargs)
+

--- a/scripts/psc_merge_spectra.py
+++ b/scripts/psc_merge_spectra.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+"""
+Command-line script for merging UVPSpec power spectra
+within a PSpecContainer.
+"""
+from hera_pspec import container
+
+# Parse commandline args
+args = container.get_merge_spectra_argparser()
+a = args.parse_args()
+
+container.merge_spectra(a.filename, uvp_split_str=a.uvp_split_str, 
+                        ext_split_str=a.ext_split_str, verbose=a.verbose)

--- a/setup.py
+++ b/setup.py
@@ -33,8 +33,7 @@ setup_args = {
     'install_requires': ['numpy>=1.10', 'scipy>=0.19',],
     'include_package_data': True,
     'scripts': ['scripts/pspec_run.py', 'scripts/pspec_red.py',
-                'pipelines/idr2_preprocessing/preprocess_data.py'],
-    'zip_safe':     False,
+                'pipelines/idr2_preprocessing/preprocess_data.py']
 }
 
 if __name__ == '__main__':


### PR DESCRIPTION
This adds a command-line interface to deriving bootstrap resampled errorbars on averaged `UVPSpec` objects. This adds
• `grouping.bootstrap_resampled_error` to get bootstrapped errorbars
• `grouping.bootstrap_run` and `bootstrap_run.py` for an easy command-line interface
• `container.merge_spectra` and `psc_merge_spectra.py` for an easy command-line interface for merging `UVPSpec` objects within `PSpecContainer`s
• `utils.get_blvec_reds` for deriving redundant baseline groups given a `UVPSpec` object (for bootstrapping)

This should be merged __after__ the `stats_array` PR, and __after__ the `pspec_run_config` PR.