### PR TITLE
power spectrum pipeline v1

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,6 @@
+[run]
+omit = */tests/*
+
+[report]
+omit = */tests/*
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ install:
   - conda info -a
 
   # create environment and install dependencies
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy nose pip matplotlib coverage h5py
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy>=1.14 scipy nose pip matplotlib coverage h5py
   - source activate test-environment
   - conda install -c conda-forge aipy
   - pip install coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ install:
   - conda info -a
 
   # create environment and install dependencies
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy>=1.14 scipy nose pip matplotlib coverage h5py
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy=1.14 scipy nose pip matplotlib coverage h5py
   - source activate test-environment
   - conda install -c conda-forge aipy
   - pip install coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ install:
   - pip install scikit-learn
   - pip install h5py
   - pip install pyyaml
-  - pip install muliprocess
+  - pip install multiprocess
   - python setup.py install
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ install:
   - conda info -a
 
   # create environment and install dependencies
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy nose pip matplotlib coverage h5py multiprocess
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy nose pip matplotlib coverage
   - source activate test-environment
   - conda install -c conda-forge aipy
   - pip install coveralls
@@ -41,6 +41,7 @@ install:
   - pip install scikit-learn
   - pip install h5py
   - pip install pyyaml
+  - pip install muliprocess
   - python setup.py install
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,12 +22,12 @@ install:
   - export PATH="$HOME/miniconda/bin:$PATH"
   - hash -r
   - conda config --set always_yes yes --set changeps1 no
-  - conda install -q conda=4.3.25
+  - conda update -q conda
   # Useful for debugging any issues with conda
   - conda info -a
 
   # create environment and install dependencies
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy=1.14 scipy nose pip matplotlib coverage h5py
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy nose pip matplotlib coverage h5py
   - source activate test-environment
   - conda install -c conda-forge aipy
   - pip install coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ install:
   - pip install git+https://github.com/HERA-Team/hera_qm.git
   - pip install git+https://github.com/HERA-Team/uvtools.git
   - pip install git+https://github.com/HERA-Team/hera_cal.git
+  - pip install git+https://github.com/HERA-Team/hera_stats.git
   - pip install healpy
   - pip install scikit-learn
   - pip install h5py

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,6 @@ install:
   - pip install git+https://github.com/HERA-Team/hera_qm.git
   - pip install git+https://github.com/HERA-Team/uvtools.git
   - pip install git+https://github.com/HERA-Team/hera_cal.git
-  - pip install git+https://github.com/HERA-Team/hera_stats.git
   - pip install healpy
   - pip install scikit-learn
   - pip install h5py

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ install:
   - conda info -a
 
   # create environment and install dependencies
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy nose pip matplotlib coverage h5py
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy nose pip matplotlib coverage h5py multiprocess
   - source activate test-environment
   - conda install -c conda-forge aipy
   - pip install coveralls

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,4 +2,5 @@ include *.md
 include LICENSE
 include hera_pspec/VERSION
 include hera_pspec/GIT_INFO
+include pipelines/*/*.yaml
 

--- a/README.md
+++ b/README.md
@@ -23,10 +23,6 @@ For usage examples and documentation, see http://hera-pspec.readthedocs.io/en/la
 
 For anaconda users, we suggest using conda to install astropy, numpy and scipy.
 
-#### Optional Dependencies
-
-* hera_stats (https://github.com/HERA-Team/hera_stats.git)
-
 ### Installing hera_pspec
 Clone the repo using
 `git clone https://github.com/HERA-Team/hera_pspec.git`

--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ For usage examples and documentation, see http://hera-pspec.readthedocs.io/en/la
 
 For anaconda users, we suggest using conda to install astropy, numpy and scipy.
 
+#### Optional Dependencies
+
+* hera_stats (https://github.com/HERA-Team/hera_stats.git)
+
 ### Installing hera_pspec
 Clone the repo using
 `git clone https://github.com/HERA-Team/hera_pspec.git`

--- a/hera_pspec/container.py
+++ b/hera_pspec/container.py
@@ -317,9 +317,9 @@ class PSpecContainer(object):
             pass
 
 
-def merge_spectra(psc, dset_split_str='_x_', ext_split_str='_', verbose=True):
+def merge_spectra(psc, groups=None, dset_split_str='_x_', ext_split_str='_', verbose=True):
     """
-    Iterate through a PSpecContainer and, within each group,
+    Iterate through a PSpecContainer and, within each specified group,
     merge spectra of similar name but different psname extension.
 
     Power spectra to-be-merged are assumed to follow the naming convention
@@ -334,8 +334,11 @@ def merge_spectra(psc, dset_split_str='_x_', ext_split_str='_', verbose=True):
     feed dset_split_str as '' or None. Example, to merge together: uvp_1, uvp_2, uvp_3
     feed dset_split_str=None and ext_split_str='_'.
 
-    Parameters:
-    -----------
+    Parameters
+    ----------
+    groups : list
+        A list of groupnames to operate on. Default is all groups.
+
     dset_split_str : str
         The pattern used to split dset1 from dset2 in the psname.
 
@@ -350,8 +353,12 @@ def merge_spectra(psc, dset_split_str='_x_', ext_split_str='_', verbose=True):
         assert isinstance(psc, PSpecContainer)
 
     # get groups
-    groups = psc.groups()
-    assert len(groups) > 0, "no groups exist in this Container object"
+    _groups = psc.groups()
+    if groups is None:
+        groups = _groups
+    else:
+        groups = [grp for grp in groups if grp in _groups]
+    assert len(groups) > 0, "no specified groups exist in this Container object"
 
     # Iterate over groups
     for grp in groups:

--- a/hera_pspec/container.py
+++ b/hera_pspec/container.py
@@ -317,7 +317,7 @@ class PSpecContainer(object):
             pass
 
 
-def merge_spectra(psc, uvp_split_str='_x_', ext_split_str='_', verbose=True):
+def merge_spectra(psc, dset_split_str='_x_', ext_split_str='_', verbose=True):
     """
     Iterate through a PSpecContainer and, within each group,
     merge spectra of similar name but different psname extension.
@@ -326,13 +326,17 @@ def merge_spectra(psc, uvp_split_str='_x_', ext_split_str='_', verbose=True):
 
     dset1_x_dset2_ext1, dset1_x_dset2_ext2, ...
 
-    where _x_ is the default uvp_split_str, and _ is the default ext_split_str.
-    The spectra are first split by uvp_split_str, and then by ext_split_str. In
+    where _x_ is the default dset_split_str, and _ is the default ext_split_str.
+    The spectra names are first split by dset_split_str, and then by ext_split_str. In
     this particular case, all instances of dset1_x_dset2* will be merged together.
+
+    In order to merge spectra names with no dset distinction and only an extension,
+    feed dset_split_str as '' or None. Example, to merge together: uvp_1, uvp_2, uvp_3
+    feed dset_split_str=None and ext_split_str='_'.
 
     Parameters:
     -----------
-    uvp_split_str : str
+    dset_split_str : str
         The pattern used to split dset1 from dset2 in the psname.
 
     ext_split_str : str
@@ -357,8 +361,11 @@ def merge_spectra(psc, uvp_split_str='_x_', ext_split_str='_', verbose=True):
         # Get unique spectra by splitting and then re-joining
         unique_spectra = []
         for spc in spectra:
-            sp = utils.flatten([s.split(ext_split_str) for s in spc.split(uvp_split_str)])[:2]
-            sp = uvp_split_str.join(sp)
+            if dset_split_str == '' or dset_split_str is None:
+                sp = spc.split(ext_split_str)[0]
+            else:
+                sp = utils.flatten([s.split(ext_split_str) for s in spc.split(dset_split_str)])[:2]
+                sp = dset_split_str.join(sp)
             if sp not in unique_spectra:
                 unique_spectra.append(sp)
 
@@ -391,13 +398,10 @@ def get_merge_spectra_argparser():
                    help="Filename of HDF5 container (PSpecContainer) containing "
                         "groups / input power spectra.")
    
-    a.add_argument("--uvp_split_str", default='_x_', type=str, help='The pattern used to split dset1 '
+    a.add_argument("--dset_split_str", default='_x_', type=str, help='The pattern used to split dset1 '
                    'from dset2 in the psname.')
     a.add_argument("--ext_split_str", default='_', type=str, help='The pattern used to split the dset '
                    'names from their extension in the psname (if it exists).')
-    a.add_argument("--verbose", type=bool, default=False, action='store_true', help='Report feedback to stdout.')
+    a.add_argument("--verbose", default=False, action='store_true', help='Report feedback to stdout.')
     
     return a
-
-
-

--- a/hera_pspec/container.py
+++ b/hera_pspec/container.py
@@ -315,7 +315,8 @@ class PSpecContainer(object):
             pass
 
 
-def combine_psc_spectra(psc, groups=None, dset_split_str='_x_', ext_split_str='_', verbose=True, overwrite=False):
+def combine_psc_spectra(psc, groups=None, dset_split_str='_x_', ext_split_str='_',
+                        verbose=True, overwrite=False):
     """
     Iterate through a PSpecContainer and, within each specified group,
     combine UVPSpec (i.e. spectra) of similar name but varying psname extension.

--- a/hera_pspec/data/_test_utils.yaml
+++ b/hera_pspec/data/_test_utils.yaml
@@ -3,6 +3,7 @@ data:
     root:       ../hera_pspec/
     subdirs:
         - data
+    pairs: [['xx', 'xx'], ['yy', 'yy']]
     template:   zen.*.xx.HH.uvXA
     beam:       data/NF_HERA_Beams.beamfits
     flags:      zen.2458098.66239.yy.HH.uv.vis.uvfits.flags.npz
@@ -13,9 +14,11 @@ pspec:
     weight:             iC
     norm:               I
     taper:              none
-    groupname:          test
+    groupname:          None
     little_h:           True
     avg_group:          False
     exclude_auto_bls:   False
     exclude_permutations:   False
-
+    options:
+      foo:              None
+      bar:              [['foo', 'bar']]

--- a/hera_pspec/grouping.py
+++ b/hera_pspec/grouping.py
@@ -839,7 +839,7 @@ def bootstrap_average_blpairs(uvp_list, blpair_groups, time_avg=False,
         return uvp_avg, blpair_wgts_list
 
 
-def bootstrap_resampled_error(uvp, blpair_groups=None, time_avg=False, Nsamples=1000, seed=0,
+def bootstrap_resampled_error(uvp, blpair_groups=None, time_avg=False, Nsamples=1000, seed=None,
                               normal_std=True, robust_std=True, conf_ints=None, bl_error_tol=1.0,
                               add_to_history='', verbose=False):
     """
@@ -905,12 +905,15 @@ def bootstrap_resampled_error(uvp, blpair_groups=None, time_avg=False, Nsamples=
     # Uniform average
     uvp_avg = average_spectra(uvp, blpair_groups=blpair_groups, time_avg=time_avg, inplace=False)
 
+    # initialize a seed
+    if seed is not None: np.random.seed(seed)
+
     # Iterate over Nsamples and create bootstrap resamples
     uvp_boots = []
     uvp_wgts = []
     for i in range(Nsamples):
         # resample
-        boot, wgt = bootstrap_average_blpairs(uvp, blpair_groups=blpair_groups, time_avg=time_avg, seed=seed)
+        boot, wgt = bootstrap_average_blpairs(uvp, blpair_groups=blpair_groups, time_avg=time_avg, seed=None)
         uvp_boots.append(boot)
         uvp_wgts.append(wgt)
 
@@ -933,7 +936,7 @@ def bootstrap_resampled_error(uvp, blpair_groups=None, time_avg=False, Nsamples=
     if conf_ints is not None:
         for ci in conf_ints:
             ci_tag = "conf_int_{:05.2f}".format(ci)
-            stats_array[ci_tag]
+            stats_array[ci_tag] = odict()
             for k in keys:
                 stats_array[ci_tag][k] = np.percentile(uvp_boot_data[k].real, ci, axis=0) \
                                             + 1j*np.percentile(uvp_boot_data[k].imag, ci, axis=0)
@@ -1084,11 +1087,11 @@ def get_bootstrap_run_argparser():
                     help="Whether to calculate a 'robust' standard deviation (astropy.stats.biweight_midvariance).")
     a.add_argument("--conf_ints", default=None, type=float, nargs='+',
                     help="Confidence intervals (precentage from 0 < ci < 100) to calculate.")
-    a.add_argument("--keep_samples", default=False, action='store_true', type=bool,
+    a.add_argument("--keep_samples", default=False, action='store_true',
                     help="If True, store bootstrap resamples in PSpecContainer object with *_bs# extension.")
     a.add_argument("--bl_error_tol", type=float, default=1.0,
                     help="Baseline redudancy tolerance if calculating redundant groups.")
-    a.add_argument("--overwrite", default=False, action='store_true', type=bool, help="overwrite outputs if they exist.")
+    a.add_argument("--overwrite", default=False, action='store_true', help="overwrite outputs if they exist.")
     a.add_argument("--add_to_history", default='', type=str, help="String to add to history of power spectra.")
     a.add_argument("--verbose", default=False, action='store_true', help="report feedback to stdout.")
     

--- a/hera_pspec/grouping.py
+++ b/hera_pspec/grouping.py
@@ -1,9 +1,12 @@
 import numpy as np
 from collections import OrderedDict as odict
 from hera_pspec import uvpspec_utils as uvputils
-#from hera_pspec import UVPSpec
+from hera_pspec import utils, version
 import random
 import copy
+import argparse
+from astropy import stats as astats
+import os
 
 
 def group_baselines(bls, Ngroups, keep_remainder=False, randomize=False,
@@ -228,9 +231,9 @@ def select_common(uvp_list, spws=True, blpairs=True, times=True, pols=True,
     if not inplace: return out_list
 
 
-def average_spectra(uvp_in, blpair_groups=None, time_avg=False,
-                    blpair_weights=None, error_field=None,
-                    normalize_weights=True, inplace=True):
+def average_spectra(uvp_in, blpair_groups=None, time_avg=False, 
+                    blpair_weights=None, normalize_weights=True, inplace=True,
+                    add_to_history=''):
     """
     Average power spectra across the baseline-pair-time axis, weighted by
     each spectrum's integration time.
@@ -291,6 +294,9 @@ def average_spectra(uvp_in, blpair_groups=None, time_avg=False,
     inplace : bool, optional
         If True, edit data in self, else make a copy and return. Default:
         True.
+
+    add_to_history : str, optional
+        Added text to add to file history.
 
     Notes
     -----
@@ -579,12 +585,16 @@ def average_spectra(uvp_in, blpair_groups=None, time_avg=False,
     elif hasattr(uvp, "stats_array"):
         delattr(uvp, "stats_array")
 
+    # Add to history
+    uvp.history = "Spectra averaged with hera_pspec [{}]\n{}\n{}\n{}".format(version.git_hash[:15], add_to_history, '-'*40, uvp.history)
+
     # Validity check
     uvp.check()
 
     # Return
     if inplace == False:
         return uvp
+
 
 def fold_spectra(uvp):
     """
@@ -732,14 +742,16 @@ def bootstrap_average_blpairs(uvp_list, blpair_groups, time_avg=False,
     """
     # Validate input data
     from hera_pspec import UVPSpec
-    if isinstance(uvp_list, UVPSpec): uvp_list = [uvp_list,]
+    single_uvp = False
+    if isinstance(uvp_list, UVPSpec):
+        single_uvp = True
+        uvp_list = [uvp_list,]
     assert isinstance(uvp_list, list), \
            "uvp_list must be a list of UVPSpec objects"
 
     # Check that uvp_list contains UVPSpec objects with the correct dimensions
-    for uvp in uvp_list:
-        assert isinstance(uvp, UVPSpec), \
-               "uvp_list must be a list of UVPSpec objects"
+    assert np.all([isinstance(uvp, UVPSpec) for uvp in uvp_list]), \
+           "uvp_list must be a list of UVPSpec objects"
 
     # Check for same length of time axis if no time averaging will be done
     if not time_avg:
@@ -760,7 +772,7 @@ def bootstrap_average_blpairs(uvp_list, blpair_groups, time_avg=False,
                         for blpg in blpair_groups]
         blpair_groups = new_blp_grps
 
-    # Homogenise input UVPSpec objects in terms of available polarizations
+    # Homogenise input UVPSpec objects in terms of available polarizations 
     # and spectral windows
     if len(uvp_list) > 1:
         uvp_list = select_common(uvp_list, spws=True, pols=True, inplace=False)
@@ -783,8 +795,8 @@ def bootstrap_average_blpairs(uvp_list, blpair_groups, time_avg=False,
     # Set random seed if specified
     if seed is not None: np.random.seed(seed)
 
-    # Sample with replacement from the full list of available baseline-pairs
-    # in each group, and create a blpair_group and blpair_weights entry for
+    # Sample with replacement from the full list of available baseline-pairs 
+    # in each group, and create a blpair_group and blpair_weights entry for 
     # each UVPSpec object
     blpair_grps_list = [[] for uvp in uvp_list]
     blpair_wgts_list = [[] for uvp in uvp_list]
@@ -797,7 +809,7 @@ def bootstrap_average_blpairs(uvp_list, blpair_groups, time_avg=False,
         avail_flat = [blp for lst in avail for blp in lst]
         num_avail = len(avail_flat)
 
-        # Draw set of random integers (with replacement) and convert into
+        # Draw set of random integers (with replacement) and convert into 
         # list of weights for each blpair in each UVPSpec
         draw = np.random.randint(low=0, high=num_avail, size=num_avail)
         wgt = np.array([(draw == i).sum() for i in range(num_avail)])
@@ -811,7 +823,7 @@ def bootstrap_average_blpairs(uvp_list, blpair_groups, time_avg=False,
             blpair_wgts_list[i].append( list(_wgts) )
             j += n_blps
 
-    # Loop over UVPSpec objects and calculate averages in each blpair group,
+    # Loop over UVPSpec objects and calculate averages in each blpair group, 
     # using the bootstrap-sampled blpair weights
     uvp_avg = []
     for i, uvp in enumerate(uvp_list):
@@ -821,4 +833,265 @@ def bootstrap_average_blpairs(uvp_list, blpair_groups, time_avg=False,
         uvp_avg.append(_uvp)
 
     # Return list of averaged spectra for now
-    return uvp_avg, blpair_wgts_list
+    if single_uvp:
+        return uvp_avg[0], blpair_wgts_list[0]
+    else:
+        return uvp_avg, blpair_wgts_list
+
+
+def bootstrap_resampled_error(uvp, blpair_groups=None, time_avg=False, Nsamples=1000, seed=0,
+                              normal_std=True, robust_std=True, conf_ints=None, bl_error_tol=1.0,
+                              add_to_history='', verbose=False):
+    """
+    Given a UVPSpec object, generate bootstrap resamples of its average
+    and calculate their spread as an estimate of the errorbar on the
+    uniformly averaged data.
+
+    Parameters:
+    -----------
+    uvp : UVPSpec object
+        A UVPSpec object from which to bootstrap resample & average.
+
+    blpair_groups : list
+        A list of baseline-pair groups to bootstrap resample over. Default
+        behavior is to calculate and use redundant baseline groups.
+
+    time_avg : boolean
+        If True, average spectra before bootstrap resampling
+
+    Nsamples : int
+        Number of times to perform bootstrap resample in estimating errorbar.
+
+    seed : int
+        Random seed to use in bootstrap resampling.
+    
+    normal_std : bool
+        If True, calculate an error estimate from numpy.std
+
+    robust_std : bool
+        If True, calculate an error estimate from astropy.stats.biweight_midvariance
+
+    conf_ints : list
+        A list of integer confidence interval percentages (0 < conf_int < 100) to use
+        as an error estimate, using numpy.percentile
+
+    bl_error_tol : float
+        Redundancy error tolerance of redundant groups if blpair_groups is None.
+
+    add_to_history : str
+        String to add to history of output uvp_avg object.
+
+    verbose : bool
+        If True, report feedback to stdout.
+    
+    Returns:
+    --------
+    uvp_avg : UVPSpec object
+        A uvp holding the uniformaly averaged data in data_array, and the various error
+        estimates calculated from the bootstrap resampling.
+    """
+    from hera_pspec import UVPSpec
+    # type check
+    assert isinstance(uvp, (UVPSpec, str, np.str)), "uvp must be fed as a UVPSpec object or filepath"
+    if isinstance(uvp, (str, np.str)):
+        _uvp = UVPSpec()
+        _uvp.read_hdf5(uvp)
+        uvp = _uvp
+
+    # Check for blpair_groups
+    if blpair_groups is None:
+        blpair_groups, _, _, _ = utils.get_blvec_reds(uvp, bl_error_tol=bl_error_tol)
+
+    # Uniform average
+    uvp_avg = average_spectra(uvp, blpair_groups=blpair_groups, time_avg=time_avg, inplace=False)
+
+    # Iterate over Nsamples and create bootstrap resamples
+    uvp_boots = []
+    uvp_wgts = []
+    for i in range(Nsamples):
+        # resample
+        boot, wgt = bootstrap_average_blpairs(uvp, blpair_groups=blpair_groups, time_avg=time_avg, seed=seed)
+        uvp_boots.append(boot)
+        uvp_wgts.append(wgt)
+
+    # get all keys in uvp_avg and get data from each uvp_boot
+    keys = uvp_avg.get_all_keys()
+    uvp_boot_data = odict([(k, np.array(map(lambda u: u.get_data(k), uvp_boots))) for k in keys])
+
+    # calculate various error estimates
+    stats_array = odict()
+    if normal_std:
+        stats_array["normal_std"] = odict()
+        for k in keys:
+            stats_array["normal_std"][k] = np.std(uvp_boot_data[k].real, axis=0) \
+                                            + 1j*np.std(uvp_boot_data[k].imag, axis=0)
+    if robust_std:
+        stats_array["robust_std"] = odict()
+        for k in keys:
+            stats_array["robust_std"][k] = np.sqrt(astats.biweight_midvariance(uvp_boot_data[k].real, axis=0)) \
+                                            + 1j*np.sqrt(astats.biweight_midvariance(uvp_boot_data[k].imag, axis=0))
+    if conf_ints is not None:
+        for ci in conf_ints:
+            ci_tag = "conf_int_{:05.2f}".format(ci)
+            stats_array[ci_tag]
+            for k in keys:
+                stats_array[ci_tag][k] = np.percentile(uvp_boot_data[k].real, ci, axis=0) \
+                                            + 1j*np.percentile(uvp_boot_data[k].imag, ci, axis=0)
+
+    # Set stats array in uvp_avg
+
+    # Update history
+    uvp_avg.history = "Bootstrap errors estimated w/ hera_pspec [{}], {} samples, {} seed\n{}\n{}\n{}" \
+                      "".format(version.git_hash[:15], Nsamples, seed, add_to_history, '-'*40, uvp_avg.history)
+
+    return uvp_avg, uvp_boots, uvp_wgts
+
+
+def bootstrap_run(filename, spectra=None, blpair_groups=None, time_avg=False, Nsamples=1000, seed=0,
+                  normal_std=True, robust_std=True, conf_ints=None, keep_samples=False,
+                  bl_error_tol=1.0, overwrite=False, add_to_history='', verbose=True):
+    """
+    Run bootstrap resampling on a PSpecContainer object to estimate errorbars.
+    For each group/spectrum specified in the PSpecContainer, this function produces
+        1. uniform average of UVPSpec objects in the group
+        2. various error estimates from the bootstrap resamples
+       (3.) series of bootstrap resamples of UVPSpec average (optional)
+
+    The output of 1. and 2. are placed in a *_avg spectrum, while the output of 3.
+    is placed in *_bs0, *_bs1, *_bs2 etc. objects. 
+
+    Parameters:
+    -----------
+    filename : str or PSpecContainer object
+        PSpecContainer object to run bootstrapping on.
+
+    spectra : list
+        A list of power spectra names (with group prefix) to run bootstrapping on.
+        Default is all spectra in object. Ex. ["group1/psname1", "group1/psname2", ...]
+
+    blpair_groups : list
+        A list of baseline-pair groups to bootstrap over. Default is to solve for and use
+        redundant baseline groups. Ex: [ [((1, 2), (2, 3)), ((1, 2), (3, 4))], 
+                                         [((1, 3), (2, 4)), ((1, 3), (3, 5))],
+                                         ...
+                                        ]
+
+    time_avg : bool
+        If True, perform time-average of power spectra in averaging step.
+
+    Nsamples : int
+        The number of samples in bootstrap resampling to generate.
+
+    seed : int
+        The random seed to initialize with before drwaing bootstrap samples.
+
+    normal_std : bool
+        If True, use np.std to calculate a "normal" standard deviation of BS samples.
+
+    robust_std : bool
+        If True, use astropy.stats.biweight_midvariance(..., c=9.0) to get a "robust"
+        standard deviation of the BS samples.
+
+    conf_ints : list
+        A list of confidence interval percentages (0 < ci < 100) to calculate from
+        BS samples using np.percentile.
+
+    keep_samples : bool
+        If True, store each bootstrap resample in PSpecContainer object with *_bs# suffix.
+
+    bl_error_tol : float
+        If calculating redundant baseline groups, this is the redundancy tolerance in meters.
+
+    overwrite : bool
+        If True, overwrite output files if they already exist.
+
+    add_to_history : str
+        String to append to history in bootstrap_resample_error() call.
+
+    verbose : bool
+        If True, report feedback to stdout.
+    """
+    from hera_pspec import uvpspec
+    from hera_pspec import PSpecContainer
+    # type check
+    if isinstance(filename, (str, np.str)):
+        psc = PSpecContainer(filename)
+    elif isinstance(filename, PSpecContainer):
+        psc = filename
+    else:
+        raise AssertionError("filename must be a PSpecContainer or filepath to one")
+
+    # get groups in psc
+    groups = psc.groups()
+    assert len(groups) > 0, "No groups exist in PSpecContainer"
+
+    # get spectra if not fed
+    all_spectra = utils.flatten([map(lambda s: os.path.join(grp, s), psc.spectra(grp)) for grp in groups])
+    if spectra is None:
+        spectra = all_spectra
+    else:
+        spectra = [spc for spc in spectra if spc in all_spectra]
+        assert len(spectra) > 0, "no specified spectra exist in PSpecContainer"
+
+    # iterate over spectra
+    for spc_name in spectra:
+        # split group and spectra names
+        grp, spc = spc_name.split('/')
+
+        # run boostrap_resampled_error
+        uvp = psc.get_pspec(grp, spc)
+        (uvp_avg, uvp_boots,
+         uvp_wgts) = bootstrap_resampled_error(uvp, blpair_groups=blpair_groups, time_avg=time_avg,
+                                              Nsamples=Nsamples, seed=seed, normal_std=normal_std,
+                                              robust_std=robust_std, conf_ints=conf_ints,
+                                              bl_error_tol=bl_error_tol, add_to_history=add_to_history,
+                                              verbose=verbose)
+
+        # set averaged uvp
+        psc.set_pspec(grp, spc+"_avg", uvp_avg, overwrite=overwrite)
+
+        # if keep_samples write uvp_boots
+        if keep_samples:
+            for i, uvpb in enumerate(uvp_boots):
+                psc.set_pspec(grp, spc+"_bs{}".format(i), uvpb, overwrite=overwrite)
+                
+
+def get_bootstrap_run_argparser():
+    a = argparse.ArgumentParser(
+           description="argument parser for grouping.bootstrap_run()")
+    
+    def list_of_lists_of_tuples(s):
+        s = map(lambda x: map(int, x.split()), s.split(','))
+        return s
+
+    # Add list of arguments
+    a.add_argument("filename", type=str, 
+                   help="Filename of HDF5 container (PSpecContainer) containing "
+                        "input power spectra.")
+    a.add_argument("--spectra", default=None, type=str, nargs='+',
+                   help="List of power spectra names (with group prefix) to bootstrap over.")
+    a.add_argument("--blpair_groups", default=None, type=list_of_lists_of_tuples,
+                   help="List of baseline-pair groups (must be space-delimited blpair integers) "
+                        "wrapped in quotes to use in resampling. Default is to solve for and use redundant groups (recommended)."
+                        "Ex: --blpair_groups '101102103104 102103014015, 101013102104' --> "
+                        "[ [((1, 2), (3, 4)), ((2, 3), (4, 5))], [((1, 3), (2, 4))], ...]")
+    a.add_argument("--time_avg", default=False, type=bool, help="Perform time-average in averaging step.")
+    a.add_argument("--Nsamples", default=100, type=int, help="Number of bootstrap resamples to generate.")
+    a.add_argument("--seed", default=0, type=int, help="random seed to initialize bootstrap resampling with.")
+    a.add_argument("--normal_std", default=True, type=bool,
+                    help="Whether to calculate a 'normal' standard deviation (np.std).")
+    a.add_argument("--robust_std", default=False, type=bool,
+                    help="Whether to calculate a 'robust' standard deviation (astropy.stats.biweight_midvariance).")
+    a.add_argument("--conf_ints", default=None, type=float, nargs='+',
+                    help="Confidence intervals (precentage from 0 < ci < 100) to calculate.")
+    a.add_argument("--keep_samples", default=False, action='store_true', type=bool,
+                    help="If True, store bootstrap resamples in PSpecContainer object with *_bs# extension.")
+    a.add_argument("--bl_error_tol", type=float, default=1.0,
+                    help="Baseline redudancy tolerance if calculating redundant groups.")
+    a.add_argument("--overwrite", default=False, action='store_true', type=bool, help="overwrite outputs if they exist.")
+    a.add_argument("--add_to_history", default='', type=str, help="String to add to history of power spectra.")
+    a.add_argument("--verbose", default=False, action='store_true', help="report feedback to stdout.")
+    
+    return a
+
+>>>>>>> first round of code edits for grouping.bootstrap_run function

--- a/hera_pspec/grouping.py
+++ b/hera_pspec/grouping.py
@@ -425,13 +425,13 @@ def average_spectra(uvp_in, blpair_groups=None, time_avg=False,
                 for k, blp in enumerate(blpg):
 
                     # Get no. samples and construct integration weight
-                    nsmp = uvp.get_nsamples(spw, blp, p)[:, None]
-                    data = uvp.get_data(spw, blp, p)
-                    wgts = uvp.get_wgts(spw, blp, p)
-                    ints = uvp.get_integrations(spw, blp, p)[:, None]
+                    nsmp = uvp.get_nsamples((spw, blp, p))[:, None]
+                    data = uvp.get_data((spw, blp, p))
+                    wgts = uvp.get_wgts((spw, blp, p))
+                    ints = uvp.get_integrations((spw, blp, p))[:, None]
                     w = (ints * np.sqrt(nsmp))
                     if store_cov:
-                        cov = uvp.get_cov(spw,blp,p)
+                        cov = uvp.get_cov((spw, blp, p))
                     # Get error bar weights and set invalid ones to zero.
                     errws = {}
                     for stat in stat_l:

--- a/hera_pspec/grouping.py
+++ b/hera_pspec/grouping.py
@@ -926,26 +926,24 @@ def bootstrap_resampled_error(uvp, blpair_groups=None, time_avg=False, Nsamples=
     uvp_boot_data = odict([(k, np.array(map(lambda u: u.get_data(k), uvp_boots))) for k in keys])
 
     # calculate various error estimates
-    stats_array = odict()
     if normal_std:
-        stats_array["normal_std"] = odict()
         for k in keys:
-            stats_array["normal_std"][k] = np.std(uvp_boot_data[k].real, axis=0) \
-                                            + 1j*np.std(uvp_boot_data[k].imag, axis=0)
+            nstd = np.std(uvp_boot_data[k].real, axis=0) + 1j*np.std(uvp_boot_data[k].imag, axis=0)
+            uvp_avg.set_stats("normal_std", k, nstd)
+
     if robust_std:
-        stats_array["robust_std"] = odict()
         for k in keys:
-            stats_array["robust_std"][k] = np.sqrt(astats.biweight_midvariance(uvp_boot_data[k].real, axis=0)) \
-                                            + 1j*np.sqrt(astats.biweight_midvariance(uvp_boot_data[k].imag, axis=0))
+            rstd = np.sqrt(astats.biweight_midvariance(uvp_boot_data[k].real, axis=0)) \
+                    + 1j*np.sqrt(astats.biweight_midvariance(uvp_boot_data[k].imag, axis=0))
+            uvp_avg.set_stats("robust_std", k, rstd)
+
     if cintervals is not None:
         for ci in cintervals:
             ci_tag = "cinterval_{:05.2f}".format(ci)
-            stats_array[ci_tag] = odict()
             for k in keys:
-                stats_array[ci_tag][k] = np.percentile(uvp_boot_data[k].real, ci, axis=0) \
-                                            + 1j*np.percentile(uvp_boot_data[k].imag, ci, axis=0)
-
-    # Set stats array in uvp_avg
+                cint = np.percentile(uvp_boot_data[k].real, ci, axis=0) \
+                        + 1j*np.percentile(uvp_boot_data[k].imag, ci, axis=0)
+                uvp_avg.set_stats(ci_tag, k, cint)
 
     # Update history
     uvp_avg.history = "Bootstrap errors estimated w/ hera_pspec [{}], {} samples, {} seed\n{}\n{}\n{}" \

--- a/hera_pspec/grouping.py
+++ b/hera_pspec/grouping.py
@@ -232,7 +232,8 @@ def select_common(uvp_list, spws=True, blpairs=True, times=True, pols=True,
 
 
 def average_spectra(uvp_in, blpair_groups=None, time_avg=False, 
-                    blpair_weights=None, normalize_weights=True, inplace=True,
+                    blpair_weights=None, error_field=None,
+                    normalize_weights=True, inplace=True,
                     add_to_history=''):
     """
     Average power spectra across the baseline-pair-time axis, weighted by
@@ -1101,5 +1102,3 @@ def get_bootstrap_run_argparser():
     a.add_argument("--verbose", default=False, action='store_true', help="report feedback to stdout.")
     
     return a
-
->>>>>>> first round of code edits for grouping.bootstrap_run function

--- a/hera_pspec/pspecdata.py
+++ b/hera_pspec/pspecdata.py
@@ -2772,6 +2772,7 @@ def get_pspec_run_argparser():
 
     a.add_argument("dsets", nargs='*', help="List of UVData objects or miriad filepaths.")
     a.add_argument("filename", type=str, help="Output filename of HDF5 container.")
+    a.add_argument("--dsets_std", nargs='*', default=None, type=str, help="List of miriad filepaths to visibility standard deviations.")
     a.add_argument("--groupname", default=None, type=str, help="Groupname for the UVPSpec objects in the HDF5 container.")
     a.add_argument("--dset_pairs", default=None, type=list_of_int_tuples, help="List of dset pairings for OQE wrapped in quotes. Ex: '0 0, 1 1' --> [(0, 0), (1, 1), ...]")
     a.add_argument("--dset_labels", default=None, type=str, nargs='*', help="List of string labels for each input dataset.")
@@ -2795,6 +2796,7 @@ def get_pspec_run_argparser():
     a.add_argument("--bl_len_range", default=(0, 1e10), nargs='+', type=float, help="If blpairs is not provided, limit the baselines used based on their minimum and maximum length in meters.")
     a.add_argument("--bl_deg_range", default=(0, 180), nargs='+', type=float, help="If blpairs is not provided, limit the baseline used based on a min and max angle cut in ENU frame in degrees.")
     a.add_argument("--bl_error_tol", default=1.0, type=float, help="If blpairs is not provided, this is the error tolerance in forming redundant baseline groups in meters.")
+    a.add_argument("--store_cov", default=False, action='store_true', type=bool, help="Compute and store covariance of bandpowers given dsets_std files.")
     a.add_argument("--overwrite", default=False, action='store_true', help="Overwrite output if it exists.")
     a.add_argument("--psname_ext", default='', type=str, help="Extension for pspectra name in PSpecContainer.")
     a.add_argument("--verbose", default=False, action='store_true', help="Report feedback to standard output.")

--- a/hera_pspec/pspecdata.py
+++ b/hera_pspec/pspecdata.py
@@ -2778,7 +2778,7 @@ def pspec_run(dsets, filename, dsets_std=None, groupname=None, dset_labels=None,
 
         # Run OQE
         uvp = ds.pspec(bls1_list[i], bls2_list[i], dset_idxs, pol_pairs, spw_ranges=spw_ranges, n_dlys=n_dlys,
-                       input_data_weight=input_data_weight, norm=norm, taper=taper, history=history)
+                       input_data_weight=input_data_weight, norm=norm, taper=taper, history=history, verbose=verbose)
 
         # Store output
         psname = '{}_x_{}{}'.format(dset_labels[dset_idxs[0]], dset_labels[dset_idxs[1]], psname_ext)

--- a/hera_pspec/pspecdata.py
+++ b/hera_pspec/pspecdata.py
@@ -173,7 +173,7 @@ class PSpecData(object):
         # Check for repeated labels, and make them unique
         for i, l in enumerate(self.labels):
             ext = 1
-            while True:
+            while ext < 1e5:
                 if l in self.labels[:i]:
                     l = self.labels[i] + ".{:d}".format(ext)
                     ext += 1
@@ -1840,8 +1840,9 @@ class PSpecData(object):
             (None) is to use the entire band provided in each dataset.
 
         store_cov : boolean, optional
-            If True, solve for covariance between bandpowers and store in
-            output UVPSpec object.
+            If True, calculate an analytic covariance between bandpowers
+            given an input visibility noise model, and store the output
+            in the UVPSpec object.
 
         verbose : bool, optional
             If True, print progress, warnings and debugging info to stdout.
@@ -2378,7 +2379,7 @@ class PSpecData(object):
                 print "Warning: feeding a beam model when self.primary_beam already exists..."
 
         # Check beam is not None
-        assert beam is not None, "Beam object is None but attempting to convert Jy -> mK"
+        assert beam is not None, "Cannot convert Jy --> mK b/c beam object is not defined..."
 
         # assert type of beam
         assert isinstance(beam, pspecbeam.PSpecBeamBase), "beam model must be a subclass of pspecbeam.PSpecBeamBase"
@@ -2529,15 +2530,15 @@ def pspec_run(dsets, filename, dsets_std=None, groupname=None, dset_labels=None,
 
     Nblps_per_group : integer
         If blpairs is None, group blpairs into sub-groups of baseline-pairs
-        of this size. See utils.calc_reds() for details. Default: None
+        of this size. See utils.calc_blpair_reds() for details. Default: None
 
     bl_len_range : len-2 float tuple
         A tuple containing the minimum and maximum baseline length to use
-        in utils.calc_reds call. Only used if blpairs is None.
+        in utils.calc_blpair_reds call. Only used if blpairs is None.
 
     bl_deg_range : len-2 float tuple
         A tuple containing the min and max baseline angle (ENU frame in degrees)
-        to use in utils.calc_reds. Total range is between 0 and 180 degrees.
+        to use in utils.calc_blpair_reds. Total range is between 0 and 180 degrees.
 
     bl_error_tol : float
         Baseline vector error tolerance when constructing redundant groups.
@@ -2716,13 +2717,13 @@ def pspec_run(dsets, filename, dsets_std=None, groupname=None, dset_labels=None,
         # get bls if blpairs not fed
         if blpairs is None:
             (bls1, bls2, blps, xants1,
-             xants2) = utils.calc_reds(dsets[dsetp[0]], dsets[dsetp[1]],
-                                       filter_blpairs=True,
-                                       exclude_auto_bls=exclude_auto_bls,
-                                       exclude_permutations=exclude_permutations,
-                                       Nblps_per_group=Nblps_per_group,
-                                       bl_len_range=bl_len_range,
-                                       bl_deg_range=bl_deg_range)
+             xants2) = utils.calc_blpair_reds(dsets[dsetp[0]], dsets[dsetp[1]],
+                                              filter_blpairs=True,
+                                              exclude_auto_bls=exclude_auto_bls,
+                                              exclude_permutations=exclude_permutations,
+                                              Nblps_per_group=Nblps_per_group,
+                                              bl_len_range=bl_len_range,
+                                              bl_deg_range=bl_deg_range)
             bls1_list.append(bls1)
             bls2_list.append(bls2)
 

--- a/hera_pspec/pspecdata.py
+++ b/hera_pspec/pspecdata.py
@@ -11,6 +11,7 @@ import datetime
 import time
 import argparse
 import ast
+import glob
 
 
 class PSpecData(object):
@@ -2429,7 +2430,6 @@ def pspec_run(dsets, filename, dsets_std=None, groupname=None, dset_labels=None,
               beam=None, cosmo=None, rephase_to_dset=None, trim_dset_lsts=False, broadcast_dset_flags=True,
               time_thresh=0.2, Jy2mK=False, overwrite=True, verbose=True, store_cov=False, history=''):
     """
-
     Create a PSpecData object, run OQE delay spectrum estimation and write
     results to a PSpecContainer object.
 
@@ -2856,14 +2856,14 @@ def raise_warning(warning, verbose=True):
         print(warning)
 
 def _load_dsets(fnames, bls=None, pols=None, logf=None, verbose=True):
-    """ helper function for loading datasets in pspec_run """
+    """ helper function for loading Miriad datasets in pspec_run """
     dsets = []
     Ndsets = len(fnames)
     for i, dset in enumerate(fnames):
         utils.log("Reading {} / {} datasets...".format(i+1, Ndsets), f=logf, lvl=1, verbose=verbose)
         # read data
         uvd = UVData()
-        uvd.read_miriad(dset, bls=bls, polarizations=pols)
+        uvd.read_miriad(glob.glob(dset), bls=bls, polarizations=pols)
         dsets.append(uvd)
     return dsets
 

--- a/hera_pspec/pspecdata.py
+++ b/hera_pspec/pspecdata.py
@@ -2631,8 +2631,6 @@ def pspec_run(dsets, filename, dsets_std=None, groupname=None, dset_labels=None,
         dset_labels = ["dset{}".format(i) for i in range(Ndsets)]
     else:
         assert not np.any(['_' in dl for dl in dset_labels]), "cannot accept underscores in input dset_labels: {}".format(dset_labels)
-        # enforce unique dset labels
-        assert len(set(dset_labels)) == len(dset_labels), "Found repeated dest labels: each one must be unique"
 
     # load data if fed as filepaths
     if isinstance(dsets[0], (str, np.str)):

--- a/hera_pspec/pspecdata.py
+++ b/hera_pspec/pspecdata.py
@@ -1980,7 +1980,8 @@ class PSpecData(object):
         time2 = []
         lst1 = []
         lst2 = []
-        spws = []
+        dly_spws = []
+        freq_spws = []
         dlys = []
         freqs = []
         sclr_arr = []
@@ -2010,10 +2011,11 @@ class PSpecData(object):
             spw_cov = []
 
             d = self.delays() * 1e-9
+            f = dset1.freq_array.flatten()[spw_ranges[i][0]:spw_ranges[i][1]]
             dlys.extend(d)
-            spws.extend(np.ones_like(d, np.int) * i)
-            freqs.extend(
-                dset1.freq_array.flatten()[spw_ranges[i][0]:spw_ranges[i][1]] )
+            dly_spws.extend(np.ones_like(d, np.int16) * i)
+            freq_spws.extend(np.ones_like(f, np.int16) * i)
+            freqs.extend(f)
 
             # Loop over polarizations
             for j, p in enumerate(pols):
@@ -2198,12 +2200,15 @@ class PSpecData(object):
         antpos = dict(zip(dset1.antenna_numbers, dset1.antenna_positions))
         uvp.bl_vecs = np.array(map(lambda bl: antpos[bl[0]] - antpos[bl[1]], bls_arr))
         uvp.Nbls = len(uvp.bl_array)
-        uvp.spw_array = np.array(spws)
+        uvp.spw_dly_array = np.array(dly_spws)
+        uvp.spw_freq_array = np.array(freq_spws)
+        uvp.Nspws = len(np.unique(dly_spws))
+        uvp.spw_array = np.arange(uvp.Nspws, dtype=np.int16)
         uvp.freq_array = np.array(freqs)
         uvp.dly_array = np.array(dlys)
-        uvp.Nspws = len(np.unique(spws))
         uvp.Ndlys = len(np.unique(dlys))
-        uvp.Nspwdlys = len(spws)
+        uvp.Nspwdlys = len(uvp.spw_dly_array)
+        uvp.Nspwfreqs = len(uvp.spw_freq_array)
         uvp.Nfreqs = len(np.unique(freqs))
         uvp.pol_array = np.array(spw_pol, np.int)
         uvp.Npols = len(spw_pol)

--- a/hera_pspec/pspecdata.py
+++ b/hera_pspec/pspecdata.py
@@ -2762,8 +2762,8 @@ def pspec_run(dsets, filename, dsets_std=None, groupname=None, dset_labels=None,
                        history=history, verbose=verbose)
 
         # Store output
-        psname = '{}_x_{}'.format(dset_labels[dset_idxs[0]], 
-                                  dset_labels[dset_idxs[1]])
+        psname = '{}_x_{}{}'.format(dset_labels[dset_idxs[0]],
+                                    dset_labels[dset_idxs[1]], psname_ext)
         psc.set_pspec(group=groupname, psname=psname, pspec=uvp, 
                       overwrite=overwrite)
 

--- a/hera_pspec/pspecdata.py
+++ b/hera_pspec/pspecdata.py
@@ -15,7 +15,7 @@ import ast
 
 class PSpecData(object):
 
-    def __init__(self, dsets=[], wgts=[],dsets_std=None, labels=None, beam=None):
+    def __init__(self, dsets=[], wgts=[], dsets_std=None, labels=None, beam=None):
         """
         Object to store multiple sets of UVData visibilities and perform
         operations such as power spectrum estimation on them.
@@ -26,10 +26,12 @@ class PSpecData(object):
             Set of UVData objects containing the data that will be used to
             compute the power spectrum. If specified as a dict, the key names
             will be used to tag each dataset. Default: Empty list.
+
         dsets_std: list or dict of UVData objects, optional
             Set of UVData objects containing the standard deviations of each
             data point in UVData objects in dsets. If specified as a dict, the key names
             will be used to tag each dataset. Default: Empty list.
+
         wgts : list or dict of UVData objects, optional
             Set of UVData objects containing weights for the input data.
             Default: Empty list.
@@ -56,9 +58,10 @@ class PSpecData(object):
         # and taper to none by default
         self.data_weighting = 'identity'
         self.taper = 'none'
-        #set dsets_std to None if any are None.
+
+        # set dsets_std to None if any are None.
         if not dsets_std is None and None in dsets_std:
-            dsets_std=None
+            dsets_std = None
 
         # Store the input UVData objects if specified
         if len(dsets) > 0:
@@ -105,9 +108,9 @@ class PSpecData(object):
                 raise TypeError("If 'dsets' is a dict, 'wgts' must also be "
                                 "a dict")
 
-            if not isinstance(dsets_std,dict):
+            if not isinstance(dsets_std, dict):
                 if dsets_std is None:
-                    dsets_std=[None for m in range(len(dsets))]
+                    dsets_std = [None for m in range(len(dsets))]
                 else:
                     raise TypeError("If 'dsets' is a dict, 'dsets_std' must"
                                     "also be a dict")
@@ -123,21 +126,20 @@ class PSpecData(object):
             dsets = _dsets
             wgts = _wgts
 
-
         # Convert input args to lists if possible
         if isinstance(dsets, UVData): dsets = [dsets,]
         if isinstance(wgts, UVData): wgts = [wgts,]
         if isinstance(labels, str): labels = [labels,]
-        if isinstance(dsets_std,UVData): dsets_std=[dsets_std,]
+        if isinstance(dsets_std, UVData): dsets_std = [dsets_std,]
         if wgts is None: wgts = [wgts,]
-        if dsets_std is None: dsets_std=[dsets_std for m in range(len(dsets))]
+        if dsets_std is None: dsets_std = [dsets_std for m in range(len(dsets))]
         if isinstance(dsets, tuple): dsets = list(dsets)
         if isinstance(wgts, tuple): wgts = list(wgts)
-        if isinstance(dsets_std,tuple): dsets_std=list(dsets_std)
+        if isinstance(dsets_std, tuple): dsets_std = list(dsets_std)
 
         # Only allow UVData or lists
         if not isinstance(dsets, list) or not isinstance(wgts, list)\
-        or not isinstance(dsets_std,list):
+        or not isinstance(dsets_std, list):
             raise TypeError("dsets, dsets_std, and wgts must be UVData"
                             "or lists of UVData")
 
@@ -154,14 +156,14 @@ class PSpecData(object):
             if not isinstance(w, UVData) and w is not None:
                 raise TypeError("Only UVData objects (or None) can be used as "
                                 "weights.")
-            if not isinstance(s,UVData) and s is not None:
+            if not isinstance(s, UVData) and s is not None:
                 raise TypeError("Only UVData objects (or None) can be used as "
                                 "error sets")
 
         # Append to list
         self.dsets += dsets
         self.wgts += wgts
-        self.dsets_std+=dsets_std
+        self.dsets_std += dsets_std
 
         # Store labels (if they were set)
         if labels is None:
@@ -251,8 +253,6 @@ class PSpecData(object):
             max_diff_dec = np.max(map(lambda d: np.diff(d), itertools.combinations(phase_dec, 2)))
             max_diff = np.sqrt(max_diff_ra**2 + max_diff_dec**2)
             if max_diff > 0.15: raise_warning("Warning: maximum phase-center difference between datasets is > 10 arcmin", verbose=verbose)
-
-
 
     def check_key_in_dset(self, key, dset_ind):
         """
@@ -384,7 +384,6 @@ class PSpecData(object):
 
         return dset_idx, bl
 
-
     def x(self, key):
         """
         Get data for a given dataset and baseline, as specified in a standard
@@ -406,9 +405,7 @@ class PSpecData(object):
         spw = slice(self.spw_range[0], self.spw_range[1])
         return self.dsets[dset].get_data(bl).T[spw]
 
-
-
-    def dx(self,key):
+    def dx(self, key):
         """
         Get standard deviation of data for given dataset and baseline as
         pecified in standard key format.
@@ -428,8 +425,8 @@ class PSpecData(object):
         assert isinstance(key,tuple)
         dset,bl = self.parse_blkey(key)
         spw = slice(self.spw_range[0], self.spw_range[1])
-        return self.dsets_std[dset].get_data(bl).T[spw]
 
+        return self.dsets_std[dset].get_data(bl).T[spw]
 
     def w(self, key):
         """
@@ -451,7 +448,6 @@ class PSpecData(object):
         dset, bl = self.parse_blkey(key)
         spw = slice(self.spw_range[0], self.spw_range[1])
 
-
         if self.wgts[dset] is not None:
             return self.wgts[dset].get_data(bl).T[spw]
         else:
@@ -459,8 +455,6 @@ class PSpecData(object):
             # UVData dataset object
             wgts = (~self.dsets[dset].get_flags(bl)).astype(float).T[spw]
             return wgts
-
-
 
     def set_C(self, cov):
         """
@@ -515,7 +509,6 @@ class PSpecData(object):
                 self.set_C({Ckey: utils.cov(self.x(key), self.w(key))})
 
         return self._C[Ckey]
-
 
     def cross_covar_model(self, key1, key2, model='empirical', conj_1=False, conj_2=True):
         """
@@ -798,7 +791,7 @@ class PSpecData(object):
                 raise ValueError("Cannot estimate more delays than there are frequency channels")
             self.spw_Ndlys = ndlys
 
-    def cov_q_hat(self,key1,key2,time_indices=None):
+    def cov_q_hat(self, key1, key2, time_indices=None):
         """
         Compute the un-normalized covariance matrix for q_hat for a given pair
         of visibility vectors. Returns the following matrix:
@@ -812,79 +805,74 @@ class PSpecData(object):
 
         Parameters
         ----------
-        alpha,beta: integers for covariance index.
-
-        key1,key2: tuples or lists of tuples
+        key1, key2: tuples or lists of tuples
             Tuples containing the indices of the dataset and baselines for the
             two input datavectors. If a list of tuples is provided, the baselines
             in the list will be combined with inverse noise weights.
 
-        time_indices, list of indices of times to include or just a single time.
-        default, None -> compute covariance for all times.
-
+        time_indices: list of indices of times to include or just a single time.
+        default is None -> compute covariance for all times.
 
         Returns
         -------
-        cov_q_hat, matrix with covariances between un-normalized band powers
+        cov_q_hat: matrix with covariances between un-normalized band powers
         """
+        # type check
         if time_indices is None:
-            time_indices=[tind for tind in range(self.Ntimes)]
-        elif isinstance(time_indices,int):
-            time_indices=[time_indices]
-        if not isinstance(time_indices,list):
+            time_indices = [tind for tind in range(self.Ntimes)]
+        elif isinstance(time_indices, (int, np.integer)):
+            time_indices = [time_indices]
+        if not isinstance(time_indices, list):
             raise ValueError("time_indices must be an integer or list of integers.")
+
         #check time_indices
         for tind in time_indices:
-            if not (tind>=0 and tind<=self.Ntimes):
+            if not (tind >= 0 and tind <= self.Ntimes):
                 raise ValueError("Invalid time index provided.")
 
-        qc=np.zeros((len(time_indices),self.spw_Ndlys,self.spw_Ndlys),dtype=complex)
-        R1,R2=0,0
-        n1a,n2a,n1b,n2b=0,0,0,0
-        #compute noise covariance matrices. Assume diagonal!
-                    #compute E^alpha and E^beta
-        if isinstance(key1,list):
+        qc = np.zeros((len(time_indices), self.spw_Ndlys, self.spw_Ndlys), dtype=np.complex128)
+        R1, R2 = 0.0, 0.0
+        n1a, n2a, n1b, n2b=0.0, 0.0, 0.0, 0.0
+        # compute noise covariance matrices. Assume diagonal!
+        # compute E^alpha and E^beta
+        if isinstance(key1, list):
             for _key in key1:
-                R1+=self.R(_key)
-                n1a+=np.real(self.dx(_key))**2.
-                n1b+=np.imag(self.dx(_key))**2.
+                R1 += self.R(_key)
+                n1a += np.real(self.dx(_key))**2.
+                n1b += np.imag(self.dx(_key))**2.
         else:
-            R1=self.R(key1)
-            n1a=np.real(self.dx(key1))**2.
-            n1b=np.imag(self.dx(key1))**2.
+            R1 = self.R(key1)
+            n1a = np.real(self.dx(key1))**2.
+            n1b = np.imag(self.dx(key1))**2.
 
-        if isinstance(key2,list):
+        if isinstance(key2, list):
             for _key in key2:
-                R2+=self.R(_key)
-                n2a+=np.real(self.dx(_key))**2.
-                n2b+=np.imag(self.dx(_key))**2.
+                R2 += self.R(_key)
+                n2a += np.real(self.dx(_key))**2.
+                n2b += np.imag(self.dx(_key))**2.
         else:
-            R2=self.R(key2)
-            n2a=np.real(self.dx(key2)**2.)
-            n2b=np.imag(self.dx(key2)**2.)
+            R2 = self.R(key2)
+            n2a = np.real(self.dx(key2)**2.)
+            n2b = np.imag(self.dx(key2)**2.)
 
-        N1=np.zeros((self.spw_Nfreqs,self.spw_Nfreqs),dtype=complex)
-        N2=np.zeros_like(N1)
-        Qalphas=np.repeat(np.array([self.get_Q_alt(dly) for dly in range(self.spw_Ndlys)])[np.newaxis,:,:,:],self.spw_Ndlys,axis=0)
-        Qbetas=np.repeat(np.array([self.get_Q_alt(dly) for dly in range(self.spw_Ndlys)])[:,np.newaxis,:,:],self.spw_Ndlys,axis=1)
-        #Q_alpha/Q_beta are N_dlys x N_dlys x N_freq x N_freq
-        #taking advantage of broadcast rules!
-        #matmul only applies to the last two dimensions
-        #and stacks everything else!
-        Ealphas=np.matmul(R1.T.conj(),np.matmul(Qalphas,R2))
-        Ebetas=np.matmul(R1.T.conj(),np.matmul(Qbetas,R2))
-        #E_alpha/E_beta ar N_dlys x N_dlys x N_freq  x N_freq
-        for indnum,tind in enumerate(time_indices):
-            N1[:,:]=np.diag(n1a[:,tind]+n1b[:,tind])
-            N2[:,:]=np.diag(n2a[:,tind]+n2b[:,tind])
-            #total covariance is sum of real and imaginary covariances
-            qc[indnum]=np.trace(np.matmul(Ealphas,np.matmul(N1,np.matmul(Ebetas,N2))),axis1=2,axis2=3)
+        N1 = np.zeros((self.spw_Nfreqs, self.spw_Nfreqs), dtype=np.complex128)
+        N2 = np.zeros_like(N1)
+        Qalphas = np.repeat(np.array([self.get_Q_alt(dly) for dly in range(self.spw_Ndlys)])[np.newaxis, :, :, :], self.spw_Ndlys, axis=0)
+        Qbetas = np.repeat(np.array([self.get_Q_alt(dly) for dly in range(self.spw_Ndlys)])[:, np.newaxis, :, :], self.spw_Ndlys, axis=1)
+ 
+        # Q_alpha/Q_beta are N_dlys x N_dlys x N_freq x N_freq
+        # taking advantage of broadcast rules!
+        # matmul only applies to the last two dimensions
+        # and stacks everything else!
+        Ealphas = np.matmul(R1.T.conj(), np.matmul(Qalphas, R2))
+        Ebetas = np.matmul(R1.T.conj(), np.matmul(Qbetas, R2))
+        #E_alpha/E_beta ar N_dlys x N_dlys x N_freq x N_freq
+        for indnum, tind in enumerate(time_indices):
+            N1[:, :] = np.diag(n1a[:, tind] + n1b[:, tind])
+            N2[:, :] = np.diag(n2a[:, tind] + n2b[:, tind])
+            # total covariance is sum of real and imaginary covariances
+            qc[indnum] = np.trace(np.matmul(Ealphas, np.matmul(N1, np.matmul(Ebetas, N2))), axis1=2, axis2=3)
         return qc/4.
-
-
-
-
-
 
     def q_hat(self, key1, key2, allow_fft=False):
         """
@@ -915,9 +903,7 @@ class PSpecData(object):
             If a list of tuples is provided, the baselines
             in the list will be combined with inverse noise weights.
 
-
         allow_fft : bool, optional
-
             Whether to use a fast FFT summation trick to construct q_hat, or
             a simpler brute-force matrix multiplication. The FFT method assumes
             a delta-fn bin in delay space. It also only works if the number
@@ -928,7 +914,7 @@ class PSpecData(object):
         q_hat : array_like
             Unnormalized bandpowers
         """
-        Rx1, Rx2 = 0, 0
+        Rx1, Rx2 = 0.0, 0.0
 
         # Calculate R x_1
         if isinstance(key1, list):
@@ -983,7 +969,6 @@ class PSpecData(object):
         G : array_like, complex
             Fisher matrix, with dimensions (Nfreqs, Nfreqs).
         """
-
         if self.spw_Ndlys == None:
             raise ValueError("Number of delay bins should have been set"
                              "by now! Cannot be equal to None")
@@ -1067,7 +1052,6 @@ class PSpecData(object):
         H : array_like, complex
             Dimensions (Nfreqs, Nfreqs).
         """
-
         if self.spw_Ndlys == None:
             raise ValueError("Number of delay bins should have been set"
                              "by now! Cannot be equal to None")
@@ -1138,7 +1122,6 @@ class PSpecData(object):
             Set of E matrices, with dimensions (Ndlys, Nfreqs, Nfreqs).
 
         """
-
         if self.spw_Ndlys == None:
             raise ValueError("Number of delay bins should have been set"
                              "by now! Cannot be equal to None")
@@ -1211,7 +1194,6 @@ class PSpecData(object):
         V : array_like, complex
             Bandpower covariance matrix, with dimensions (Nfreqs, Nfreqs).
         """
-
         # Collect all the relevant pieces
         E_matrices = self.get_unnormed_E(key1, key2)
         C1 = self.C_model(key1)
@@ -1282,7 +1264,6 @@ class PSpecData(object):
             Window function matrix, W. (If G was passed in as a dict, a dict of
             array_like will be returned.)
         """
-
         ### Next few lines commented out because (while elegant), the situation
         ### here where G is a distionary is not supported by the rest of the code.
         # Recursive case, if many G's were specified at once
@@ -1438,21 +1419,22 @@ class PSpecData(object):
         """
         return np.dot(M, q)
 
-    def cov_p_hat(self,M,q_cov):
+    def cov_p_hat(self, M, q_cov):
         """
         Covariance estimate between two different band powers p_alpha and p_beta
         given by M_{alpha i} M^*_{beta,j} C_q^{ij} where C_q^{ij} is the q-covariance
 
         Parameters
         ----------
-        M: array_like
+        M : array_like
             Normalization matrix, M.
-        q_cov: array_like
+
+        q_cov : array_like
             covariance between bandpowers in q_alpha and q_beta
         """
-        p_cov=np.zeros_like(q_cov)
+        p_cov = np.zeros_like(q_cov)
         for tnum in range(len(p_cov)):
-            p_cov[tnum]=np.einsum('ab,cd,bd->ac',M,M,q_cov[tnum])
+            p_cov[tnum] = np.einsum('ab,cd,bd->ac', M, M, q_cov[tnum])
         return p_cov
 
     def broadcast_dset_flags(self, spw_ranges=None, time_thresh=0.2, unflag=False):
@@ -1775,7 +1757,7 @@ class PSpecData(object):
 
     def pspec(self, bls1, bls2, dsets, pols, n_dlys=None, input_data_weight='identity',
               norm='I', taper='none', sampling=False, little_h=True, spw_ranges=None,
-              verbose=True, history='',store_cov=False):
+              verbose=True, history='', store_cov=False):
         """
         Estimate the delay power spectrum from a pair of datasets contained in
         this object, using the optimal quadratic estimator of arXiv:1502.06016.
@@ -1820,8 +1802,6 @@ class PSpecData(object):
             to the order in spw_ranges.
             Default: None, which then sets n_dlys = number of frequencies.
 
-
-
         input_data_weight : str, optional
             String specifying which weighting matrix to apply to the input
             data. See the options in the set_R() method for details.
@@ -1851,7 +1831,9 @@ class PSpecData(object):
             channel used to index the `freq_array` of each dataset. The default
             (None) is to use the entire band provided in each dataset.
 
-
+        store_cov : boolean, optional
+            If True, solve for covariance between bandpowers and store in
+            output UVPSpec object.
 
         verbose : bool, optional
             If True, print progress, warnings and debugging info to stdout.
@@ -1903,10 +1885,12 @@ class PSpecData(object):
 
         """
         # set taper and data weighting
-        self.taper = taper
-        self.data_weighting = input_data_weight
+        self.set_taper(taper)
+        self.set_weighting(input_data_weight)
+
         # Validate the input data to make sure it's sensible
         self.validate_datasets(verbose=verbose)
+
         # Currently the "pspec normalization scalar" doesn't work if a
         # non-identity data weighting AND a non-trivial taper are used
         if taper != 'none' and input_data_weight != 'identity':
@@ -1922,6 +1906,7 @@ class PSpecData(object):
         assert isinstance(dsets[0], (int, np.int)) and isinstance(dsets[1], (int, np.int)), "dsets must contain integer indices"
         dset1 = self.dsets[self.dset_idx(dsets[0])]
         dset2 = self.dsets[self.dset_idx(dsets[1])]
+
         # assert form of bls1 and bls2
         assert isinstance(bls1, list), "bls1 and bls2 must be fed as a list of antpair tuples"
         assert isinstance(bls2, list), "bls1 and bls2 must be fed as a list of antpair tuples"
@@ -1945,6 +1930,7 @@ class PSpecData(object):
 
         # validate bl-pair redundancy
         validate_blpairs(bl_pairs, dset1, dset2, baseline_tol=1.0)
+
         # configure spectral window selections
         if spw_ranges is None:
             spw_ranges = [(0, self.Nfreqs)]
@@ -2015,7 +2001,6 @@ class PSpecData(object):
             spw_pol = []
             spw_cov = []
 
-
             d = self.delays() * 1e-9
             dlys.extend(d)
             spws.extend(np.ones_like(d, np.int) * i)
@@ -2060,7 +2045,6 @@ class PSpecData(object):
 
                 # Loop over baseline pairs
                 for k, blp in enumerate(bl_pairs):
-
                     # assign keys
                     if isinstance(blp, list):
                         # interpet blp as group of baseline-pairs
@@ -2076,7 +2060,6 @@ class PSpecData(object):
                         # interpret blp as baseline-pair
                         key1 = (dsets[0],) + blp[0] + (p_str[0],)
                         key2 = (dsets[1],) + blp[1] + (p_str[1],)
-
 
                     if verbose:
                         print("\n(bl1, bl2) pair: {}\npol: {}".format(blp, tuple(p)))
@@ -2114,13 +2097,13 @@ class PSpecData(object):
                     if norm == 'I':
                         pv *= self.scalar_delay_adjustment(Gv=Gv, Hv=Hv)
 
-                    #Generate the covariance matrix if error bars provided
+                    # Generate the covariance matrix if error bars provided
                     if store_cov:
                         if verbose: print(" Building q_hat covariance...")
-                        cov_qv=self.cov_q_hat(key1,key2)
-                        cov_pv=self.cov_p_hat(Mv,cov_qv)
+                        cov_qv = self.cov_q_hat(key1, key2)
+                        cov_pv = self.cov_p_hat(Mv, cov_qv)
                         if self.primary_beam != None:
-                            cov_pv*=\
+                            cov_pv *= \
                             (scalar * self.scalar_delay_adjustment(key1, key2,
                                                                    sampling=sampling))**2.
                         pol_cov.extend(cov_pv)
@@ -2172,11 +2155,12 @@ class PSpecData(object):
                 spw_wgts.append(pol_wgts)
                 spw_ints.append(pol_ints)
                 spw_cov.append(pol_cov)
+
             # insert into data and integration dictionaries
             spw_data = np.moveaxis(np.array(spw_data), 0, -1)
             spw_wgts = np.moveaxis(np.array(spw_wgts), 0, -1)
             spw_ints = np.moveaxis(np.array(spw_ints), 0, -1)
-            spw_cov = np.moveaxis(np.array(spw_cov),0 , -1)
+            spw_cov = np.moveaxis(np.array(spw_cov), 0, -1)
             data_array[i] = spw_data
             cov_array[i] = spw_cov
             wgt_array[i] = spw_wgts
@@ -2191,7 +2175,6 @@ class PSpecData(object):
         uvp = uvpspec.UVPSpec()
 
         # fill meta-data
-        uvp.store_cov=store_cov
         uvp.time_1_array = np.array(time1)
         uvp.time_2_array = np.array(time2)
         uvp.time_avg_array = np.mean([uvp.time_1_array, uvp.time_2_array], axis=0)
@@ -2257,8 +2240,10 @@ class PSpecData(object):
         uvp.integration_array = integration_array
         uvp.wgt_array = wgt_array
         uvp.nsample_array = dict(map(lambda k: (k, np.ones_like(uvp.integration_array[k], np.float)), uvp.integration_array.keys()))
+
         # run check
         uvp.check()
+
         return uvp
 
     def rephase_to_dset(self, dset_index=0, inplace=True):
@@ -2574,6 +2559,9 @@ def pspec_run(dsets, filename, dsets_std=None, groupname=None, dset_labels=None,
         dataset from Jy to milli-Kelvin. If the visibility data are not in Jy,
         this correction is not applied.
 
+    store_cov : boolean, optional
+        If True, solve for covariance between bandpowers and store in
+        output UVPSpec object.
 
     overwrite : boolean
         If True, overwrite outputs if they exist on disk.
@@ -2592,8 +2580,6 @@ def pspec_run(dsets, filename, dsets_std=None, groupname=None, dset_labels=None,
     """
     # type check
     err_msg = "dsets must be fed as a list of dataset string paths or UVData objects."
-    #if isinstance(dsets, (str, np.str, UVData)):
-    #    dsets = [dsets]      AEW: I've commented this out since the code below assumes >1 dataset.
     assert isinstance(dsets, (list, tuple, np.ndarray)), err_msg
 
     # parse psname
@@ -2637,14 +2623,7 @@ def pspec_run(dsets, filename, dsets_std=None, groupname=None, dset_labels=None,
         try:
             # load data into UVData objects if fed as list of strings
             t0 = time.time()
-            _dsets = []
-            for i, dset in enumerate(dsets):
-                utils.log("Reading {} / {} datasets...".format(i+1, Ndsets), lvl=1, verbose=verbose)
-                # read data
-                uvd = UVData()
-                uvd.read_miriad(dset, bls=bls, polarizations=pols)
-                _dsets.append(uvd)
-            dsets = _dsets
+            dsets = _load_dsets(dsets, bls=bls, pols=pols, verbose=verbose)
             utils.log("Loaded data in %1.1f sec." % (time.time() - t0),
                       lvl=1, verbose=verbose)
         except ValueError:
@@ -2655,30 +2634,31 @@ def pspec_run(dsets, filename, dsets_std=None, groupname=None, dset_labels=None,
     err_msg = "dsets must be fed as a list of dataset string paths or UVData objects."
     assert np.all([isinstance(d, UVData) for d in dsets]), err_msg
 
-    #check dsets_std input
+    # check dsets_std input
     if dsets_std is not None:
-        #if isinstance(dsets_std,(str,np.str,UVData)):
-        #    dsets_std=[dsets_std]
-        assert isinstance(dsets_std,(list,tuple,np.ndarray)),err_msg
-        assert len(dsets_std) == Ndsets
-        #if path strings provided, read in UVData objects.
-        if isinstance(dsets_std[0],(str,np.str)):
-            t0=time.time()
-            _dsets_std=[]
-            for d in dsets_std:
-                uvd=UVData()
-                uvd.read_miriad(d,bls=bls,polarizations=pols)
-                _dsets_std.append(uvd)
-            dsets_std = _dsets_std
-            utils.log("Loaded std data in %1.1f sec."%(time.time()-t0),lvl=1,verbose=verbose)
-        err_msg="dsets_std must be fed as a list of dataset string paths or UVData objects."
-        assert np.all([isinstance(d,UVData) for d in dsets]), err_msg
+        err_msg = "input dsets_std must be a list of UVData objects or filepaths to miriad files"
+        assert isinstance(dsets_std,(list, tuple, np.ndarray)), err_msg
+        assert len(dsets_std) == Ndsets, "len(dsets_std) must equal len(dsets)"
+
+        # if path strings provided, read in UVData objects.
+        if isinstance(dsets_std[0], (str, np.str)):
+            try:
+                # load data into UVData objects if fed as list of strings
+                t0 = time.time()
+                dsets_std = _load_dsets(dsets_std, bls=bls, pols=pols, verbose=verbose)
+                utils.log("Loaded data in %1.1f sec." % (time.time() - t0),
+                          lvl=1, verbose=verbose)
+            except ValueError:
+                # at least one of the dsets_std loads failed due to no data being present
+                utils.log("One of the dsets_std loads failed due to no data overlap given the bls and pols selection", verbose=verbose)
+                return
+
+        assert np.all([isinstance(d, UVData) for d in dsets]), err_msg
 
     # configure polarization
     if pol_pairs is None:
         unique_pols = reduce(operator.and_, [set(d.polarization_array) for d in dsets])
         pol_pairs = [(up, up) for up in unique_pols]
-
     assert len(pol_pairs) > 0, "no pol_pairs specified"
 
     # load beam
@@ -2692,7 +2672,7 @@ def pspec_run(dsets, filename, dsets_std=None, groupname=None, dset_labels=None,
             beam.cosmo = cosmo
 
     # package into PSpecData
-    ds = PSpecData(dsets=dsets, wgts=[None for d in dsets],dsets_std=dsets_std, beam=beam)
+    ds = PSpecData(dsets=dsets, wgts=[None for d in dsets], labels=dset_labels, dsets_std=dsets_std, beam=beam)
 
     # Rephase if desired
     if rephase_to_dset is not None:
@@ -2761,7 +2741,7 @@ def pspec_run(dsets, filename, dsets_std=None, groupname=None, dset_labels=None,
 
         # Run OQE
         uvp = ds.pspec(bls1_list[i], bls2_list[i], dset_idxs, pol_pairs,
-                       spw_ranges=spw_ranges, n_dlys=n_dlys,
+                       spw_ranges=spw_ranges, n_dlys=n_dlys, store_cov=store_cov,
                        input_data_weight=input_data_weight, norm=norm, taper=taper,
                        history=history, verbose=verbose)
 
@@ -2872,3 +2852,16 @@ def raise_warning(warning, verbose=True):
     '''warning function'''
     if verbose:
         print(warning)
+
+def _load_dsets(fnames, bls=None, pols=None, logf=None, verbose=True):
+    """ helper function for loading datasets in pspec_run """
+    dsets = []
+    Ndsets = len(fnames)
+    for i, dset in enumerate(fnames):
+        utils.log("Reading {} / {} datasets...".format(i+1, Ndsets), f=logf, lvl=1, verbose=verbose)
+        # read data
+        uvd = UVData()
+        uvd.read_miriad(dset, bls=bls, polarizations=pols)
+        dsets.append(uvd)
+    return dsets
+

--- a/hera_pspec/pspecdata.py
+++ b/hera_pspec/pspecdata.py
@@ -175,7 +175,7 @@ class PSpecData(object):
             ext = 1
             while True:
                 if l in self.labels[:i]:
-                    l = self.labels[i] + "_{:d}".format(ext)
+                    l = self.labels[i] + ".{:d}".format(ext)
                     ext += 1
                 else:
                     self.labels[i] = l
@@ -283,8 +283,6 @@ class PSpecData(object):
             True if the key exists, False otherwise
         """
         #FIXME: Fix this to enable label keys
-
-
         # get iterable
         key = uvutils.get_iterable(key)
         if isinstance(key, str):
@@ -2374,6 +2372,9 @@ class PSpecData(object):
             if self.primary_beam is not None:
                 print "Warning: feeding a beam model when self.primary_beam already exists..."
 
+        # Check beam is not None
+        assert beam is not None, "Beam object is None but attempting to convert Jy -> mK"
+
         # assert type of beam
         assert isinstance(beam, pspecbeam.PSpecBeamBase), "beam model must be a subclass of pspecbeam.PSpecBeamBase"
 
@@ -2859,10 +2860,12 @@ def validate_blpairs(blpairs, uvd1, uvd2, baseline_tol=1.0, verbose=True):
             if np.linalg.norm(bl1_vec - bl2_vec) >= baseline_tol:
                 raise_warning("blpair {} exceeds redundancy tolerance of {} m".format(blp, baseline_tol), verbose=verbose)
 
+
 def raise_warning(warning, verbose=True):
     '''warning function'''
     if verbose:
         print(warning)
+
 
 def _load_dsets(fnames, bls=None, pols=None, logf=None, verbose=True):
     """ helper function for loading Miriad datasets in pspec_run """

--- a/hera_pspec/pspecdata.py
+++ b/hera_pspec/pspecdata.py
@@ -2757,8 +2757,8 @@ def pspec_run(dsets, filename, dsets_std=None, groupname=None, dset_labels=None,
         # Run OQE
         uvp = ds.pspec(bls1_list[i], bls2_list[i], dset_idxs, pol_pairs,
                        spw_ranges=spw_ranges, n_dlys=n_dlys,
-                       input_data_weight=input_data_weight, norm=norm,
-                       taper=taper, history=history)
+                       input_data_weight=input_data_weight, norm=norm, taper=taper,
+                       history=history, verbose=verbose)
 
         # Store output
         psname = '{}_x_{}'.format(dset_labels[dset_idxs[0]], 

--- a/hera_pspec/pspecdata.py
+++ b/hera_pspec/pspecdata.py
@@ -10,6 +10,7 @@ from pyuvdata import utils as uvutils
 import datetime
 import time
 import argparse
+import ast
 
 
 class PSpecData(object):
@@ -2790,20 +2791,33 @@ def pspec_run(dsets, filename, dsets_std=None, groupname=None, dset_labels=None,
 def get_pspec_run_argparser():
     a = argparse.ArgumentParser(description="argument parser for pspecdata.pspec_run()")
 
+    def list_of_int_tuples(v):
+        v = map(lambda x: tuple(map(int, x.split())), v.split(","))
+        return v
+
+    def list_of_str_tuples(v):
+        v = map(lambda x: tuple(map(str, x.split())), v.split(","))
+        return v
+
+    def list_of_tuple_tuples(v):
+        v = map(lambda x: tuple(map(int, x.split())), v.split(","))
+        v = map(lambda x: (x[:2], x[2:]), v)
+        return v
+
     a.add_argument("dsets", nargs='*', help="List of UVData objects or miriad filepaths.")
     a.add_argument("filename", type=str, help="Output filename of HDF5 container.")
     a.add_argument("--groupname", default=None, type=str, help="Groupname for the UVPSpec objects in the HDF5 container.")
-    a.add_argument("--dset_pairs", default=None, type=tuple, nargs='*', help="List of len-2 integer tuples of dset pairings for OQE.")
+    a.add_argument("--dset_pairs", default=None, type=list_of_int_tuples, help="List of dset pairings for OQE wrapped in quotes. Ex: '0 0, 1 1' --> [(0, 0), (1, 1), ...]")
     a.add_argument("--dset_labels", default=None, type=str, nargs='*', help="List of string labels for each input dataset.")
-    a.add_argument("--spw_ranges", default=None, type=tuple, nargs='*', help="List of len-2 integer tuples of spectral window selections for OQE.")
-    a.add_argument("--n_dlys", default=None, type=int, nargs='*', help="List of integers specifying number of delays to use per spectral window selection.")
-    a.add_argument("--pol_pairs", default=None, type=tuple, nargs='*', help="List of len-2 integer of string tuples of polarization pairs for OQE.")
-    a.add_argument("--blpairs", default=None, type=tuple, nargs='*', help="List of integer tuples containing baseline pair to run OQE on. Ex: [((1, 2), (3, 4)), ((1, 2), (5, 6)), ...]")
+    a.add_argument("--spw_ranges", default=None, type=list_of_int_tuples, help="List of spw channel selections wrapped in quotes. Ex: '200 300, 500 650' --> [(200, 300), (500, 650), ...]")
+    a.add_argument("--n_dlys", default=None, type=int, nargs='+', help="List of integers specifying number of delays to use per spectral window selection.")
+    a.add_argument("--pol_pairs", default=None, type=list_of_str_tuples, help="List of pol-string pairs to use in OQE wrapped in quotes. Ex: 'xx xx, yy yy' --> [('xx', 'xx'), ('yy', 'yy'), ...]")
+    a.add_argument("--blpairs", default=None, type=list_of_tuple_tuples, help="List of baseline-pair antenna integers to run OQE on. Ex: '1 2 3 4, 5 6 7 8' --> [((1 2), (3, 4)), ((5, 6), (7, 8)), ...]")
     a.add_argument("--input_data_weight", default='identity', type=str, help="Data weighting for OQE. See PSpecData.pspec for details.")
     a.add_argument("--norm", default='I', type=str, help='M-matrix normalization type for OQE. See PSpecData.pspec for details.')
     a.add_argument("--taper", default='none', type=str, help="Taper function to use in OQE delay transform. See PSpecData.pspec for details.")
     a.add_argument("--beam", default=None, type=str, help="Filepath to UVBeam healpix map of antenna beam.")
-    a.add_argument("--cosmo", default=None, nargs='*', type=float, help="List of float values for [Om_L, Om_b, Om_c, H0, Om_M, Om_k].")
+    a.add_argument("--cosmo", default=None, nargs='+', type=float, help="List of float values for [Om_L, Om_b, Om_c, H0, Om_M, Om_k].")
     a.add_argument("--rephase_to_dset", default=None, type=int, help="dset integer index to phase all other dsets to. Default is no rephasing.")
     a.add_argument("--trim_dset_lsts", default=False, action='store_true', help="Trim non-overlapping dset LSTs.")
     a.add_argument("--broadcast_dset_flags", default=False, action='store_true', help="Broadcast dataset flags across time according to time_thresh.")
@@ -2812,8 +2826,8 @@ def get_pspec_run_argparser():
     a.add_argument("--exclude_auto_bls", default=False, action='store_true', help='If blpairs is not provided, exclude all baselines paired with itself.')
     a.add_argument("--exclude_permutations", default=False, action='store_true', help='If blpairs is not provided, exclude a basline-pair permutations. Ex: if (A, B) exists, exclude (B, A).')
     a.add_argument("--Nblps_per_group", default=None, type=int, help="If blpairs is not provided and group == True, set the number of blpairs in each group.")
-    a.add_argument("--bl_len_range", default=(0, 1e10), type=tuple, help="If blpairs is not provided, limit the baselines used based on their minimum and maximum length in meters.")
-    a.add_argument("--bl_deg_range", default=(0, 180), type=tuple, help="If blpairs is not provided, limit the baseline used based on a min and max angle cut in ENU frame in degrees.")
+    a.add_argument("--bl_len_range", default=(0, 1e10), nargs='+', type=float, help="If blpairs is not provided, limit the baselines used based on their minimum and maximum length in meters.")
+    a.add_argument("--bl_deg_range", default=(0, 180), nargs='+', type=float, help="If blpairs is not provided, limit the baseline used based on a min and max angle cut in ENU frame in degrees.")
     a.add_argument("--bl_error_tol", default=1.0, type=float, help="If blpairs is not provided, this is the error tolerance in forming redundant baseline groups in meters.")
     a.add_argument("--overwrite", default=False, action='store_true', help="Overwrite output if it exists.")
     a.add_argument("--verbose", default=False, action='store_true', help="Report feedback to standard output.")

--- a/hera_pspec/pspecdata.py
+++ b/hera_pspec/pspecdata.py
@@ -2476,7 +2476,8 @@ def pspec_run(dsets, filename, dsets_std=None, groupname=None, dset_labels=None,
         Default is to form all N_choose_2 pairs from input dsets.
 
     psname_ext : string
-        A string extension for the psname in the container object.
+        A string extension for the psname in the PSpecContainer object.
+        Example: 'group/psname{}'.format(psname_ext)
 
     spw_ranges : list of len-2 integer tuples
         List of tuples specifying the spectral window range. See
@@ -2564,8 +2565,9 @@ def pspec_run(dsets, filename, dsets_std=None, groupname=None, dset_labels=None,
         If True, broadcast dset flags across time using fractional time_thresh.
 
     time_thresh : float
-        Fractional flagging threshold to trigger broadcast across time if
-        broadcast_dset_flags is True.
+        Fractional flagging threshold, above which a broadcast of flags across
+        time is triggered (if broadcast_dset_flags == True). This is done
+        independently for each baseline's visibility waterfall.
 
     Jy2mK : boolean
         If True, use the beam model provided to convert the units of each
@@ -2627,6 +2629,8 @@ def pspec_run(dsets, filename, dsets_std=None, groupname=None, dset_labels=None,
         dset_labels = ["dset{}".format(i) for i in range(Ndsets)]
     else:
         assert not np.any(['_' in dl for dl in dset_labels]), "cannot accept underscores in input dset_labels: {}".format(dset_labels)
+        # enforce unique dset labels
+        assert len(set(dset_labels)) == len(dset_labels), "Found repeated dest labels: each one must be unique"
 
     # load data if fed as filepaths
     if isinstance(dsets[0], (str, np.str)):
@@ -2635,6 +2639,7 @@ def pspec_run(dsets, filename, dsets_std=None, groupname=None, dset_labels=None,
             t0 = time.time()
             _dsets = []
             for i, dset in enumerate(dsets):
+                utils.log("Reading {} / {} datasets...".format(i+1, Ndsets), lvl=1, verbose=verbose)
                 # read data
                 uvd = UVData()
                 uvd.read_miriad(dset, bls=bls, polarizations=pols)

--- a/hera_pspec/pspecdata.py
+++ b/hera_pspec/pspecdata.py
@@ -66,7 +66,7 @@ class PSpecData(object):
 
         # Store the input UVData objects if specified
         if len(dsets) > 0:
-            self.add(dsets, wgts,dsets_std=dsets_std, labels=labels)
+            self.add(dsets, wgts, dsets_std=dsets_std, labels=labels)
 
         # Store a primary beam
         self.primary_beam = beam
@@ -96,7 +96,6 @@ class PSpecData(object):
             standard deviations (real and imaginary) of data to add to the
             collection. If dsets is a dict, will assume dsets_std is a dict
             and if dsets is a list, will assume dsets_std is a list.
-
         """
         # Check for dicts and unpack into an ordered list if found
         if isinstance(dsets, dict):
@@ -118,7 +117,6 @@ class PSpecData(object):
             else:
                 _dsets_std = [dsets_std[key] for key in labels]
                 dsets_std = _dsets_std
-
 
             # Unpack dsets and wgts dicts
             labels = dsets.keys()
@@ -144,7 +142,6 @@ class PSpecData(object):
             raise TypeError("dsets, dsets_std, and wgts must be UVData"
                             "or lists of UVData")
 
-
         # Make sure enough weights were specified
         assert(len(dsets) == len(wgts))
         assert(len(dsets_std) == len(dsets))
@@ -161,16 +158,28 @@ class PSpecData(object):
                 raise TypeError("Only UVData objects (or None) can be used as "
                                 "error sets")
 
+        # Store labels (if they were set)
+        if self.labels is None:
+            self.labels = []
+        if labels is None:
+            labels = ["dset{:d}".format(i) for i in range(len(self.dsets), len(dsets)+len(self.dsets))]
+        self.labels += labels
+
         # Append to list
         self.dsets += dsets
         self.wgts += wgts
         self.dsets_std += dsets_std
 
-        # Store labels (if they were set)
-        if labels is None:
-            self.labels = [None for d in dsets]
-        else:
-            self.labels += labels
+        # Check for repeated labels, and make them unique
+        for i, l in enumerate(self.labels):
+            ext = 1
+            while True:
+                if l in self.labels[:i]:
+                    l = self.labels[i] + "_{:d}".format(ext)
+                    ext += 1
+                else:
+                    self.labels[i] = l
+                    break
 
         # Store no. frequencies and no. times
         self.Nfreqs = self.dsets[0].Nfreqs

--- a/hera_pspec/pspecdata.py
+++ b/hera_pspec/pspecdata.py
@@ -2183,9 +2183,9 @@ class PSpecData(object):
             integration_array[i] = spw_ints
             sclr_arr.append(spw_scalar)
 
-        # raise error if none of pols are consistent witht the UVData objects
-        if len(spw_pol)==0:
-            raise ValueError("None of the specified polarization pair match that of the UVData objects")
+            # raise error if none of pols are consistent witht the UVData objects
+            if len(spw_pol)==0:
+                raise ValueError("None of the specified polarization pair match that of the UVData objects")
 
         # fill uvp object
         uvp = uvpspec.UVPSpec()
@@ -2468,6 +2468,8 @@ def pspec_run(dsets, filename, dsets_std=None, groupname=None, dset_labels=None,
         List of strings to label the input datasets. These labels form
         the psname of each UVPSpec object. Default is "dset0_x_dset1"
         where 0 and 1 are replaced with the dset index in dsets.
+        Note: it is not advised to put underscores in the dset label names,
+        as some downstream functions assume this to be the case.
 
     dset_pairs : list of len-2 integer tuples
         List of tuples specifying the dset pairs to use in OQE estimation.
@@ -2623,6 +2625,8 @@ def pspec_run(dsets, filename, dsets_std=None, groupname=None, dset_labels=None,
 
     if dset_labels is None:
         dset_labels = ["dset{}".format(i) for i in range(Ndsets)]
+    else:
+        assert not np.any(['_' in dl for dl in dset_labels]), "cannot accept underscores in input dset_labels: {}".format(dset_labels)
 
     # load data if fed as filepaths
     if isinstance(dsets[0], (str, np.str)):
@@ -2830,6 +2834,7 @@ def get_pspec_run_argparser():
     a.add_argument("--bl_deg_range", default=(0, 180), nargs='+', type=float, help="If blpairs is not provided, limit the baseline used based on a min and max angle cut in ENU frame in degrees.")
     a.add_argument("--bl_error_tol", default=1.0, type=float, help="If blpairs is not provided, this is the error tolerance in forming redundant baseline groups in meters.")
     a.add_argument("--overwrite", default=False, action='store_true', help="Overwrite output if it exists.")
+    a.add_argument("--psname_ext", default='', type=str, help="Extension for pspectra name in PSpecContainer.")
     a.add_argument("--verbose", default=False, action='store_true', help="Report feedback to standard output.")
     return a
 

--- a/hera_pspec/pspecdata.py
+++ b/hera_pspec/pspecdata.py
@@ -2796,7 +2796,7 @@ def get_pspec_run_argparser():
     a.add_argument("--bl_len_range", default=(0, 1e10), nargs='+', type=float, help="If blpairs is not provided, limit the baselines used based on their minimum and maximum length in meters.")
     a.add_argument("--bl_deg_range", default=(0, 180), nargs='+', type=float, help="If blpairs is not provided, limit the baseline used based on a min and max angle cut in ENU frame in degrees.")
     a.add_argument("--bl_error_tol", default=1.0, type=float, help="If blpairs is not provided, this is the error tolerance in forming redundant baseline groups in meters.")
-    a.add_argument("--store_cov", default=False, action='store_true', type=bool, help="Compute and store covariance of bandpowers given dsets_std files.")
+    a.add_argument("--store_cov", default=False, action='store_true', help="Compute and store covariance of bandpowers given dsets_std files.")
     a.add_argument("--overwrite", default=False, action='store_true', help="Overwrite output if it exists.")
     a.add_argument("--psname_ext", default='', type=str, help="Extension for pspectra name in PSpecContainer.")
     a.add_argument("--verbose", default=False, action='store_true', help="Report feedback to standard output.")

--- a/hera_pspec/pspecdata.py
+++ b/hera_pspec/pspecdata.py
@@ -1,7 +1,7 @@
 import numpy as np
 import aipy
 from pyuvdata import UVData
-import copy, operator, itertools
+import copy, operator, itertools, sys
 from collections import OrderedDict as odict
 import hera_cal as hc
 from hera_pspec import uvpspec, utils, version, pspecbeam, container
@@ -2447,7 +2447,6 @@ def pspec_run(dsets, filename, dsets_std=None, groupname=None, dset_labels=None,
     Create a PSpecData object, run OQE delay spectrum estimation and write
     results to a PSpecContainer object.
 
-
     Parameters
     ----------
     dsets : list
@@ -2473,9 +2472,16 @@ def pspec_run(dsets, filename, dsets_std=None, groupname=None, dset_labels=None,
         List of tuples specifying the dset pairs to use in OQE estimation.
         Default is to form all N_choose_2 pairs from input dsets.
 
+    psname_ext : string
+        A string extension for the psname in the container object.
+
     spw_ranges : list of len-2 integer tuples
         List of tuples specifying the spectral window range. See
         PSpecData.pspec() for details. Default is the entire band.
+
+    n_dlys : list
+        List of integers denoting number of delays to use per spectral window.
+        Same length as spw_ranges.
 
     pol_pairs : list of len-2 tuples
         List of string or integer tuples specifying the polarization
@@ -2525,6 +2531,10 @@ def pspec_run(dsets, filename, dsets_std=None, groupname=None, dset_labels=None,
         A tuple containing the minimum and maximum baseline length to use
         in utils.calc_reds call. Only used if blpairs is None.
 
+    bl_deg_range : len-2 float tuple
+        A tuple containing the min and max baseline angle (ENU frame in degrees)
+        to use in utils.calc_reds. Total range is between 0 and 180 degrees.
+
     bl_error_tol : float
         Baseline vector error tolerance when constructing redundant groups.
 
@@ -2542,6 +2552,17 @@ def pspec_run(dsets, filename, dsets_std=None, groupname=None, dset_labels=None,
         This adds a phasor correction to all others dataset to phase the
         visibility data to the LST-grid of this dataset. Default behavior
         is no rephasing.
+
+    trim_dset_lsts : boolean
+        If True, look for constant offset in LST between all dsets, and trim
+        non-overlapping LSTs.
+
+    broadcast_dset_flags : boolean
+        If True, broadcast dset flags across time using fractional time_thresh.
+
+    time_thresh : float
+        Fractional flagging threshold to trigger broadcast across time if
+        broadcast_dset_flags is True.
 
     Jy2mK : boolean
         If True, use the beam model provided to convert the units of each
@@ -2569,7 +2590,12 @@ def pspec_run(dsets, filename, dsets_std=None, groupname=None, dset_labels=None,
     #if isinstance(dsets, (str, np.str, UVData)):
     #    dsets = [dsets]      AEW: I've commented this out since the code below assumes >1 dataset.
     assert isinstance(dsets, (list, tuple, np.ndarray)), err_msg
-    Ndsets = len(dsets)
+
+    # parse psname
+    if psname_ext is not None:
+        assert isinstance(psname_ext, (str, np.str))
+    else:
+        psname_ext = ''
 
     # polarizations check
     if pol_pairs is not None:
@@ -2589,8 +2615,17 @@ def pspec_run(dsets, filename, dsets_std=None, groupname=None, dset_labels=None,
         # get redundant baseline groups
         bls = None
 
+    # Construct dataset pairs to operate on
+    Ndsets = len(dsets)
+    if dset_pairs is None:
+        dset_pairs = list(itertools.combinations(range(Ndsets), 2))
+
+    if dset_labels is None:
+        dset_labels = ["dset{}".format(i) for i in range(Ndsets)]
+
     # load data if fed as filepaths
     if isinstance(dsets[0], (str, np.str)):
+<<<<<<< HEAD
         # load data into UVData objects if fed as list of strings
         t0 = time.time()
         _dsets = []
@@ -2601,6 +2636,24 @@ def pspec_run(dsets, filename, dsets_std=None, groupname=None, dset_labels=None,
         dsets = _dsets
         utils.log("Loaded data in %1.1f sec." % (time.time() - t0), 
                   lvl=1, verbose=verbose)
+=======
+        try:
+            # load data into UVData objects if fed as list of strings
+            t0 = time.time()
+            _dsets = []
+            for i, dset in enumerate(dsets):
+                # read data
+                uvd = UVData()
+                uvd.read_miriad(dset, bls=bls, polarizations=pols)
+                _dsets.append(uvd)
+            dsets = _dsets
+            utils.log("Loaded data in %1.1f sec." % (time.time() - t0), lvl=1, verbose=verbose)
+        except ValueError:
+            # at least one of the dset loads failed due to no data being present
+            utils.log("One of the dset loads failed due to no data overlap given the bls and pols selection", verbose=verbose)
+            return
+
+>>>>>>> updated pspec_run for better handling of dset loading
     err_msg = "dsets must be fed as a list of dataset string paths or UVData objects."
     assert np.all([isinstance(d, UVData) for d in dsets]), err_msg
 
@@ -2647,15 +2700,19 @@ def pspec_run(dsets, filename, dsets_std=None, groupname=None, dset_labels=None,
     if rephase_to_dset is not None:
         ds.rephase_to_dset(rephase_to_dset)
 
+    # trim dset LSTs
+    if trim_dset_lsts:
+        ds.trim_dset_lsts()
+
+    # broadcast flags
+    if broadcast_dset_flags:
+        ds.broadcast_dset_flags(time_thresh=time_thresh)
+
     # perform Jy to mK conversion if desired
     if Jy2mK:
         ds.Jy_to_mK()
 
-    # Construct dataset pairs to operate on
-    if dset_pairs is None:
-        dset_pairs = list(itertools.combinations(range(Ndsets), 2))
-    if dset_labels is None:
-        dset_labels = ["dset{}".format(i) for i in range(Ndsets)]
+    # check dset pair type
     err_msg = "dset_pairs must be fed as a list of len-2 integer tuples"
     assert isinstance(dset_pairs, list), err_msg
     assert np.all([isinstance(d, tuple) for d in dset_pairs]), err_msg
@@ -2671,7 +2728,8 @@ def pspec_run(dsets, filename, dsets_std=None, groupname=None, dset_labels=None,
                                        exclude_auto_bls=exclude_auto_bls,
                                        exclude_permutations=exclude_permutations,
                                        Nblps_per_group=Nblps_per_group,
-                                       bl_len_range=bl_len_range)
+                                       bl_len_range=bl_len_range,
+                                       bl_deg_range=bl_deg_range)
             bls1_list.append(bls1)
             bls2_list.append(bls2)
 
@@ -2699,6 +2757,7 @@ def pspec_run(dsets, filename, dsets_std=None, groupname=None, dset_labels=None,
     
     # Loop over dataset combinations
     for i, dset_idxs in enumerate(dset_pairs):
+<<<<<<< HEAD
         # Run OQE
         uvp = ds.pspec(bls1_list[i], bls2_list[i], dset_idxs, pol_pairs, 
                        spw_ranges=spw_ranges,
@@ -2710,6 +2769,20 @@ def pspec_run(dsets, filename, dsets_std=None, groupname=None, dset_labels=None,
                                   dset_labels[dset_idxs[1]])
         psc.set_pspec(group=groupname, psname=psname, pspec=uvp, 
                       overwrite=overwrite)
+=======
+
+        # check bls lists aren't empty
+        if len(bls1_list[i]) == 0 or len(bls2_list[i]) == 0:
+            continue
+
+        # Run OQE
+        uvp = ds.pspec(bls1_list[i], bls2_list[i], dset_idxs, pol_pairs, spw_ranges=spw_ranges, n_dlys=n_dlys,
+                       input_data_weight=input_data_weight, norm=norm, taper=taper, history=history)
+
+        # Store output
+        psname = '{}_x_{}{}'.format(dset_labels[dset_idxs[0]], dset_labels[dset_idxs[1]], psname_ext)
+        psc.set_pspec(group=groupname, psname=psname, pspec=uvp, overwrite=overwrite)
+>>>>>>> updated pspec_run for better handling of dset loading
 
     return psc
 
@@ -2723,6 +2796,7 @@ def get_pspec_run_argparser():
     a.add_argument("--dset_pairs", default=None, type=tuple, nargs='*', help="List of len-2 integer tuples of dset pairings for OQE.")
     a.add_argument("--dset_labels", default=None, type=str, nargs='*', help="List of string labels for each input dataset.")
     a.add_argument("--spw_ranges", default=None, type=tuple, nargs='*', help="List of len-2 integer tuples of spectral window selections for OQE.")
+    a.add_argument("--n_dlys", default=None, type=int, nargs='*', help="List of integers specifying number of delays to use per spectral window selection.")
     a.add_argument("--pol_pairs", default=None, type=tuple, nargs='*', help="List of len-2 integer of string tuples of polarization pairs for OQE.")
     a.add_argument("--blpairs", default=None, type=tuple, nargs='*', help="List of integer tuples containing baseline pair to run OQE on. Ex: [((1, 2), (3, 4)), ((1, 2), (5, 6)), ...]")
     a.add_argument("--input_data_weight", default='identity', type=str, help="Data weighting for OQE. See PSpecData.pspec for details.")
@@ -2731,11 +2805,15 @@ def get_pspec_run_argparser():
     a.add_argument("--beam", default=None, type=str, help="Filepath to UVBeam healpix map of antenna beam.")
     a.add_argument("--cosmo", default=None, nargs='*', type=float, help="List of float values for [Om_L, Om_b, Om_c, H0, Om_M, Om_k].")
     a.add_argument("--rephase_to_dset", default=None, type=int, help="dset integer index to phase all other dsets to. Default is no rephasing.")
+    a.add_argument("--trim_dset_lsts", default=False, action='store_true', help="Trim non-overlapping dset LSTs.")
+    a.add_argument("--broadcast_dset_flags", default=False, action='store_true', help="Broadcast dataset flags across time according to time_thresh.")
+    a.add_argument("--time_thresh", default=0.2, type=float, help="Fractional flagging threshold across time to trigger flag broadcast if broadcast_dset_flags is True")
     a.add_argument("--Jy2mK", default=False, action='store_true', help="Convert datasets from Jy to mK if a beam model is provided.")
     a.add_argument("--exclude_auto_bls", default=False, action='store_true', help='If blpairs is not provided, exclude all baselines paired with itself.')
     a.add_argument("--exclude_permutations", default=False, action='store_true', help='If blpairs is not provided, exclude a basline-pair permutations. Ex: if (A, B) exists, exclude (B, A).')
     a.add_argument("--Nblps_per_group", default=None, type=int, help="If blpairs is not provided and group == True, set the number of blpairs in each group.")
     a.add_argument("--bl_len_range", default=(0, 1e10), type=tuple, help="If blpairs is not provided, limit the baselines used based on their minimum and maximum length in meters.")
+    a.add_argument("--bl_deg_range", default=(0, 180), type=tuple, help="If blpairs is not provided, limit the baseline used based on a min and max angle cut in ENU frame in degrees.")
     a.add_argument("--bl_error_tol", default=1.0, type=float, help="If blpairs is not provided, this is the error tolerance in forming redundant baseline groups in meters.")
     a.add_argument("--overwrite", default=False, action='store_true', help="Overwrite output if it exists.")
     a.add_argument("--verbose", default=False, action='store_true', help="Report feedback to standard output.")

--- a/hera_pspec/pspecdata.py
+++ b/hera_pspec/pspecdata.py
@@ -2437,12 +2437,12 @@ class PSpecData(object):
 
 
 def pspec_run(dsets, filename, dsets_std=None, groupname=None, dset_labels=None, dset_pairs=None,
-              spw_ranges=None, pol_pairs=None, blpairs=None,
+              psname_ext=None, spw_ranges=None, n_dlys=None, pol_pairs=None, blpairs=None,
               input_data_weight='identity', norm='I', taper='none',
               exclude_auto_bls=True, exclude_permutations=True,
-              Nblps_per_group=None, bl_len_range=(0, 1e10), bl_error_tol=1.0,
-              beam=None, cosmo=None, rephase_to_dset=None, Jy2mK=True,
-              overwrite=True, verbose=True, store_cov=False, history=''):
+              Nblps_per_group=None, bl_len_range=(0, 1e10), bl_deg_range=(0, 180), bl_error_tol=1.0,
+              beam=None, cosmo=None, rephase_to_dset=None, trim_dset_lsts=False, broadcast_dset_flags=True,
+              time_thresh=0.2, Jy2mK=False, overwrite=True, verbose=True, store_cov=False, history=''):
     """
 
     Create a PSpecData object, run OQE delay spectrum estimation and write
@@ -2630,18 +2630,6 @@ def pspec_run(dsets, filename, dsets_std=None, groupname=None, dset_labels=None,
 
     # load data if fed as filepaths
     if isinstance(dsets[0], (str, np.str)):
-<<<<<<< HEAD
-        # load data into UVData objects if fed as list of strings
-        t0 = time.time()
-        _dsets = []
-        for d in dsets:
-            uvd = UVData()
-            uvd.read_miriad(d, bls=bls, polarizations=pols)
-            _dsets.append(uvd)
-        dsets = _dsets
-        utils.log("Loaded data in %1.1f sec." % (time.time() - t0), 
-                  lvl=1, verbose=verbose)
-=======
         try:
             # load data into UVData objects if fed as list of strings
             t0 = time.time()
@@ -2652,13 +2640,13 @@ def pspec_run(dsets, filename, dsets_std=None, groupname=None, dset_labels=None,
                 uvd.read_miriad(dset, bls=bls, polarizations=pols)
                 _dsets.append(uvd)
             dsets = _dsets
-            utils.log("Loaded data in %1.1f sec." % (time.time() - t0), lvl=1, verbose=verbose)
+            utils.log("Loaded data in %1.1f sec." % (time.time() - t0),
+                      lvl=1, verbose=verbose)
         except ValueError:
             # at least one of the dset loads failed due to no data being present
             utils.log("One of the dset loads failed due to no data overlap given the bls and pols selection", verbose=verbose)
             return
 
->>>>>>> updated pspec_run for better handling of dset loading
     err_msg = "dsets must be fed as a list of dataset string paths or UVData objects."
     assert np.all([isinstance(d, UVData) for d in dsets]), err_msg
 
@@ -2762,32 +2750,21 @@ def pspec_run(dsets, filename, dsets_std=None, groupname=None, dset_labels=None,
     
     # Loop over dataset combinations
     for i, dset_idxs in enumerate(dset_pairs):
-<<<<<<< HEAD
-        # Run OQE
-        uvp = ds.pspec(bls1_list[i], bls2_list[i], dset_idxs, pol_pairs, 
-                       spw_ranges=spw_ranges,
-                       input_data_weight=input_data_weight, 
-                       norm=norm, taper=taper, history=history)
-        
-        # Store output
-        psname = '{}_x_{}'.format(dset_labels[dset_idxs[0]], 
-                                  dset_labels[dset_idxs[1]])
-        psc.set_pspec(group=groupname, psname=psname, pspec=uvp, 
-                      overwrite=overwrite)
-=======
-
         # check bls lists aren't empty
         if len(bls1_list[i]) == 0 or len(bls2_list[i]) == 0:
             continue
 
         # Run OQE
-        uvp = ds.pspec(bls1_list[i], bls2_list[i], dset_idxs, pol_pairs, spw_ranges=spw_ranges, n_dlys=n_dlys,
-                       input_data_weight=input_data_weight, norm=norm, taper=taper, history=history, verbose=verbose)
+        uvp = ds.pspec(bls1_list[i], bls2_list[i], dset_idxs, pol_pairs,
+                       spw_ranges=spw_ranges, n_dlys=n_dlys,
+                       input_data_weight=input_data_weight, norm=norm,
+                       taper=taper, history=history)
 
         # Store output
-        psname = '{}_x_{}{}'.format(dset_labels[dset_idxs[0]], dset_labels[dset_idxs[1]], psname_ext)
-        psc.set_pspec(group=groupname, psname=psname, pspec=uvp, overwrite=overwrite)
->>>>>>> updated pspec_run for better handling of dset loading
+        psname = '{}_x_{}'.format(dset_labels[dset_idxs[0]], 
+                                  dset_labels[dset_idxs[1]])
+        psc.set_pspec(group=groupname, psname=psname, pspec=uvp, 
+                      overwrite=overwrite)
 
     return psc
 

--- a/hera_pspec/testing.py
+++ b/hera_pspec/testing.py
@@ -111,7 +111,8 @@ def build_vanilla_uvpspec(beam=None):
 
     return uvp, cosmo
 
-def uvpspec_from_data(data, bl_grps, spw_ranges=None, beam=None, taper='none', cosmo=None, verbose=False):
+
+def uvpspec_from_data(data, bl_grps, data_std=None, spw_ranges=None, beam=None, taper='none', cosmo=None, verbose=False):
     """
     Build an example UVPSpec object from a visibility file and PSpecData.
 

--- a/hera_pspec/testing.py
+++ b/hera_pspec/testing.py
@@ -23,9 +23,10 @@ def build_vanilla_uvpspec(beam=None):
 
     Ntimes = 10
     Nfreqs = 50
-    Ndlys = Nfreqs
+    Ndlys = 30
     Nspws = 1
-    Nspwdlys = Nspws * Nfreqs
+    Nspwfreqs = 1 * Nfreqs
+    Nspwdlys = 1 * Ndlys
 
     # [((1, 2), (1, 2)), ((2, 3), (2, 3)), ((1, 3), (1, 3))]
     blpairs = [1002001002, 2003002003, 1003001003]
@@ -47,10 +48,11 @@ def build_vanilla_uvpspec(beam=None):
     lst_2_array = lst_array
     time_avg_array = time_array
     lst_avg_array = lst_array
-    spws = np.arange(Nspws)
-    spw_array = np.tile(spws, Ndlys)
+    spw_freq_array = np.tile(np.arange(Nspws), Nfreqs)
+    spw_dly_array = np.tile(np.arange(Nspws), Ndlys)
+    spw_array = np.arange(Nspws)
     freq_array = np.repeat(np.linspace(100e6, 105e6, Nfreqs, endpoint=False), Nspws)
-    dly_array = np.fft.fftshift(np.repeat(np.fft.fftfreq(Nfreqs, np.median(np.diff(freq_array))), Nspws))
+    dly_array = np.repeat(utils.get_delays(freq_array, n_dlys=Ndlys), Nspws)
     pol_array = np.array([-5])
     Npols = len(pol_array)
     vis_units = 'unknown'
@@ -80,7 +82,7 @@ def build_vanilla_uvpspec(beam=None):
     cosmo = conversions.Cosmo_Conversions()
 
     data_array, wgt_array, integration_array, nsample_array, cov_array = {}, {}, {}, {}, {}
-    for s in spws:
+    for s in spw_array:
         data_array[s] = np.ones((Nblpairts, Ndlys, Npols), dtype=np.complex) \
                       * blpair_array[:, None, None] / 1e9
         wgt_array[s] = np.ones((Nblpairts, Ndlys, 2, Npols), dtype=np.float)
@@ -90,7 +92,7 @@ def build_vanilla_uvpspec(beam=None):
          for m in range(Nblpairts)] for n in range(Npols)]),0,-1)
 
 
-    params = ['Ntimes', 'Nfreqs', 'Nspws', 'Nspwdlys', 'Nblpairs', 'Nblpairts',
+    params = ['Ntimes', 'Nfreqs', 'Nspws', 'Nspwdlys', 'Nspwfreqs', 'Nspws', 'Nblpairs', 'Nblpairts',
               'Npols', 'Ndlys', 'Nbls', 'blpair_array', 'time_1_array',
               'time_2_array', 'lst_1_array', 'lst_2_array', 'spw_array',
               'dly_array', 'freq_array', 'pol_array', 'data_array', 'wgt_array',
@@ -98,7 +100,7 @@ def build_vanilla_uvpspec(beam=None):
               'vis_units', 'channel_width', 'weighting', 'history', 'taper', 'norm',
               'git_hash', 'nsample_array', 'time_avg_array', 'lst_avg_array',
               'cosmo', 'scalar_array', 'labels', 'norm_units', 'labels', 'label_1_array',
-              'label_2_array','store_cov','cov_array']
+              'label_2_array','store_cov','cov_array', 'spw_dly_array', 'spw_freq_array']
 
     if beam is not None:
         params += ['OmegaP', 'OmegaPP', 'beam_freqs']
@@ -154,17 +156,18 @@ def uvpspec_from_data(data, bl_grps, data_std=None, spw_ranges=None, beam=None, 
     elif isinstance(data, UVData):
         uvd = data
 
-    if isinstance(data_std,str):
-        uvd_std=UVData()
+    if isinstance(data_std, str):
+        uvd_std = UVData()
         uvd_std.read_miriad(data_std)
-    elif isinstance(data_std,UVData):
-        uvd_std=data_std
+    elif isinstance(data_std, UVData):
+        uvd_std = data_std
     else:
-        uvd_std=None
+        uvd_std = None
     if uvd_std is not None:
-        store_cov=True
+        store_cov = True
     else:
-        store_cov=False
+        store_cov = False
+
     # get pol
     pol = uvd.polarization_array[0]
 
@@ -175,7 +178,7 @@ def uvpspec_from_data(data, bl_grps, data_std=None, spw_ranges=None, beam=None, 
         beam.cosmo = cosmo
 
     # instantiate pspecdata
-    ds = pspecdata.PSpecData(dsets=[uvd, uvd], dsets_std=[uvd_std,uvd_std], wgts=[None, None], labels=['d1', 'd2'], beam=beam)
+    ds = pspecdata.PSpecData(dsets=[uvd, uvd], dsets_std=[uvd_std, uvd_std], wgts=[None, None], labels=['d1', 'd2'], beam=beam)
 
     # get blpair groups
     assert isinstance(bl_grps, list), "bl_grps must be a list"

--- a/hera_pspec/tests/test_container.py
+++ b/hera_pspec/tests/test_container.py
@@ -126,7 +126,7 @@ class Test_PSpecContainer(unittest.TestCase):
         ps_store.save()
         
 
-def test_merge_spectra():
+def test_combine_psc_spectra():
     fname = os.path.join(DATA_PATH, "zen.2458042.17772.xx.HH.uvXA")
     uvp1 = testing.uvpspec_from_data(fname, [(24, 25), (37, 38)], spw_ranges=[(10, 40)])
     uvp2 = testing.uvpspec_from_data(fname, [(38, 39), (52, 53)], spw_ranges=[(10, 40)])
@@ -137,7 +137,7 @@ def test_merge_spectra():
     psc = PSpecContainer("ex.h5", mode='rw')
     psc.set_pspec("grp1", "uvp_a", uvp1, overwrite=True)
     psc.set_pspec("grp1", "uvp_b", uvp2, overwrite=True)
-    container.merge_spectra(psc, dset_split_str=None, ext_split_str='_')
+    container.combine_psc_spectra(psc, dset_split_str=None, ext_split_str='_')
     nt.assert_equal(psc.spectra('grp1'), [u'uvp'])
 
     # test dset name handling
@@ -148,7 +148,7 @@ def test_merge_spectra():
     psc.set_pspec("grp1", "d1_x_d2_b", uvp2, overwrite=True)
     psc.set_pspec("grp1", "d2_x_d3_a", uvp1, overwrite=True)
     psc.set_pspec("grp1", "d2_x_d3_b", uvp2, overwrite=True)
-    container.merge_spectra('ex.h5', dset_split_str='_x_', ext_split_str='_')
+    container.combine_psc_spectra('ex.h5', dset_split_str='_x_', ext_split_str='_')
     nt.assert_equal(psc.spectra('grp1'), [u'd1_x_d2', u'd2_x_d3'])
 
     # test exceptions
@@ -156,18 +156,18 @@ def test_merge_spectra():
         os.remove('ex.h5')
     psc = PSpecContainer("ex.h5", mode='rw')
     # test no group exception
-    nt.assert_raises(AssertionError, container.merge_spectra, psc)
+    nt.assert_raises(AssertionError, container.combine_psc_spectra, psc)
     # test failed combine_uvpspec
     psc.set_pspec("grp1", "d1_x_d2_a", uvp1, overwrite=True)
     psc.set_pspec("grp1", "d1_x_d2_b", uvp1, overwrite=True)
-    container.merge_spectra(psc, dset_split_str='_x_', ext_split_str='_')
+    container.combine_psc_spectra(psc, dset_split_str='_x_', ext_split_str='_')
     nt.assert_equal(psc.spectra('grp1'), [u'd1_x_d2_a', u'd1_x_d2_b'])
 
     if os.path.exists("ex.h5"):
         os.remove("ex.h5")
 
-def test_merge_spectra_argparser():
-    args = container.get_merge_spectra_argparser()
+def test_combine_psc_spectra_argparser():
+    args = container.get_combine_psc_spectra_argparser()
     a = args.parse_args(["filename", "--dset_split_str", "_x_", "--ext_split_str", "_"])
     nt.assert_equal(a.filename, "filename")
     nt.assert_equal(a.dset_split_str, "_x_")

--- a/hera_pspec/tests/test_container.py
+++ b/hera_pspec/tests/test_container.py
@@ -1,9 +1,10 @@
 import unittest
 from nose.tools import assert_raises
+import nose.tools as nt
 import numpy as np
 import os, sys, copy
 from hera_pspec.data import DATA_PATH
-from hera_pspec import PSpecContainer, UVPSpec, testing
+from hera_pspec import container, PSpecContainer, UVPSpec, testing
 
 
 class Test_PSpecContainer(unittest.TestCase):
@@ -124,3 +125,51 @@ class Test_PSpecContainer(unittest.TestCase):
         # Check that save() can be called
         ps_store.save()
         
+
+def test_merge_spectra():
+    fname = os.path.join(DATA_PATH, "zen.2458042.17772.xx.HH.uvXA")
+    uvp1 = testing.uvpspec_from_data(fname, [(24, 25), (37, 38)], spw_ranges=[(10, 40)])
+    uvp2 = testing.uvpspec_from_data(fname, [(38, 39), (52, 53)], spw_ranges=[(10, 40)])
+
+    # test basic execution
+    if os.path.exists('ex.h5'):
+        os.remove('ex.h5')
+    psc = PSpecContainer("ex.h5", mode='rw')
+    psc.set_pspec("grp1", "uvp_a", uvp1, overwrite=True)
+    psc.set_pspec("grp1", "uvp_b", uvp2, overwrite=True)
+    container.merge_spectra(psc, dset_split_str=None, ext_split_str='_')
+    nt.assert_equal(psc.spectra('grp1'), [u'uvp'])
+
+    # test dset name handling
+    if os.path.exists('ex.h5'):
+        os.remove('ex.h5')
+    psc = PSpecContainer("ex.h5", mode='rw')
+    psc.set_pspec("grp1", "d1_x_d2_a", uvp1, overwrite=True)
+    psc.set_pspec("grp1", "d1_x_d2_b", uvp2, overwrite=True)
+    psc.set_pspec("grp1", "d2_x_d3_a", uvp1, overwrite=True)
+    psc.set_pspec("grp1", "d2_x_d3_b", uvp2, overwrite=True)
+    container.merge_spectra('ex.h5', dset_split_str='_x_', ext_split_str='_')
+    nt.assert_equal(psc.spectra('grp1'), [u'd1_x_d2', u'd2_x_d3'])
+
+    # test exceptions
+    if os.path.exists('ex.h5'):
+        os.remove('ex.h5')
+    psc = PSpecContainer("ex.h5", mode='rw')
+    # test no group exception
+    nt.assert_raises(AssertionError, container.merge_spectra, psc)
+    # test failed combine_uvpspec
+    psc.set_pspec("grp1", "d1_x_d2_a", uvp1, overwrite=True)
+    psc.set_pspec("grp1", "d1_x_d2_b", uvp1, overwrite=True)
+    container.merge_spectra(psc, dset_split_str='_x_', ext_split_str='_')
+    nt.assert_equal(psc.spectra('grp1'), [u'd1_x_d2_a', u'd1_x_d2_b'])
+
+    if os.path.exists("ex.h5"):
+        os.remove("ex.h5")
+
+def test_merge_spectra_argparser():
+    args = container.get_merge_spectra_argparser()
+    a = args.parse_args(["filename", "--dset_split_str", "_x_", "--ext_split_str", "_"])
+    nt.assert_equal(a.filename, "filename")
+    nt.assert_equal(a.dset_split_str, "_x_")
+    nt.assert_equal(a.ext_split_str, "_")
+

--- a/hera_pspec/tests/test_grouping.py
+++ b/hera_pspec/tests/test_grouping.py
@@ -213,5 +213,9 @@ class Test_grouping(unittest.TestCase):
                                times=True, pols=True, inplace=True)
         self.assertEqual(uvp1, uvp2)
         
+
+def test_get_pspec_bootstrap_argparser():
+    a = grouping.get_pspec_bootstrap_argparser()
+
 if __name__ == "__main__":
     unittest.main()

--- a/hera_pspec/tests/test_grouping.py
+++ b/hera_pspec/tests/test_grouping.py
@@ -279,7 +279,11 @@ def test_bootstrap_run():
     # assert original uvp is unchanged
     nt.assert_true(uvp == psc.get_pspec("grp1", 'uvp'))
     # check stats array
-    ## TODO
+    np.testing.assert_array_equal([u'cinterval_16.00', u'cinterval_84.00', u'normal_std', u'robust_std'], uvp_avg.stats_array.keys())
+    for stat in [u'cinterval_16.00', u'cinterval_84.00', u'normal_std', u'robust_std']:
+        nt.assert_equal(uvp_avg.get_stats(stat, (0, ((37, 38), (38, 39)), 'XX')).shape, (1, 50))
+        nt.assert_false(np.any(np.isnan(uvp_avg.get_stats(stat, (0, ((37, 38), (38, 39)), 'XX')))))
+        nt.assert_equal(uvp_avg.get_stats(stat, (0, ((37, 38), (38, 39)), 'XX')).dtype, np.complex128)
 
     # test exceptions
     del psc

--- a/hera_pspec/tests/test_grouping.py
+++ b/hera_pspec/tests/test_grouping.py
@@ -5,7 +5,10 @@ import os
 from hera_pspec.data import DATA_PATH
 from hera_pspec import uvpspec, conversions, parameter, pspecbeam, pspecdata, testing
 from hera_pspec import uvpspec_utils as uvputils
-from hera_pspec import grouping
+from hera_pspec import grouping, container
+from pyuvdata import UVData
+from hera_cal import redcal
+
 
 class Test_grouping(unittest.TestCase):
 
@@ -213,9 +216,96 @@ class Test_grouping(unittest.TestCase):
                                times=True, pols=True, inplace=True)
         self.assertEqual(uvp1, uvp2)
         
+def test_bootstrap_resampled_error():
+    # generate a UVPSpec
+    visfile = os.path.join(DATA_PATH, "zen.even.xx.LST.1.28828.uvOCRSA")
+    beamfile = os.path.join(DATA_PATH, "HERA_NF_dipole_power.beamfits")
+    cosmo = conversions.Cosmo_Conversions()
+    beam = pspecbeam.PSpecBeamUV(beamfile, cosmo=cosmo)
+    uvd = UVData()
+    uvd.read_miriad(visfile)
+    ap, a = uvd.get_ENU_antpos(pick_data_ants=True)
+    reds = redcal.get_pos_reds(dict(zip(a, ap)), low_hi=True, bl_error_tol=1.0)[:3]
+    uvp = testing.uvpspec_from_data(uvd, reds, spw_ranges=[(50, 100)], beam=beam, cosmo=cosmo)
 
-def test_get_pspec_bootstrap_argparser():
-    a = grouping.get_pspec_bootstrap_argparser()
+    # Lots of this function is already tested by bootstrap_run
+    # so only test the stuff not already tested
+    if os.path.exists("uvp.h5"):
+        os.remove("uvp.h5")
+    uvp.write_hdf5("uvp.h5", overwrite=True)
+    ua, ub, uw = grouping.bootstrap_resampled_error("uvp.h5", blpair_groups=None, Nsamples=10, seed=0, verbose=False)
+    # check number of boots
+    nt.assert_equal(len(ub), 10)
+    # check seed has been used properly
+    nt.assert_equal(uw[0][0][:5], [1.0, 1.0, 0.0, 2.0, 1.0])
+    nt.assert_equal(uw[0][1][:5], [2.0, 1.0, 1.0, 6.0, 1.0])
+    nt.assert_equal(uw[1][0][:5], [2.0, 2.0, 1.0, 1.0, 2.0])
+    nt.assert_equal(uw[1][1][:5], [1.0, 0.0, 1.0, 1.0, 4.0])
+
+    if os.path.exists("uvp.h5"):
+        os.remove("uvp.h5")
+
+def test_bootstrap_run():
+    # generate a UVPSpec and container
+    visfile = os.path.join(DATA_PATH, "zen.even.xx.LST.1.28828.uvOCRSA")
+    beamfile = os.path.join(DATA_PATH, "HERA_NF_dipole_power.beamfits")
+    cosmo = conversions.Cosmo_Conversions()
+    beam = pspecbeam.PSpecBeamUV(beamfile, cosmo=cosmo)
+    uvd = UVData()
+    uvd.read_miriad(visfile)
+    ap, a = uvd.get_ENU_antpos(pick_data_ants=True)
+    reds = redcal.get_pos_reds(dict(zip(a, ap)), low_hi=True, bl_error_tol=1.0)[:3]
+    uvp = testing.uvpspec_from_data(uvd, reds, spw_ranges=[(50, 100)], beam=beam, cosmo=cosmo)
+    if os.path.exists("ex.h5"):
+        os.remove("ex.h5")
+    psc = container.PSpecContainer("ex.h5", mode='rw')
+    psc.set_pspec("grp1", "uvp", uvp)
+
+    # Test basic bootstrap run
+    grouping.bootstrap_run(psc, time_avg=True, Nsamples=100, seed=0,
+                           normal_std=True, robust_std=True, conf_ints=[16, 84], keep_samples=True,
+                           bl_error_tol=1.0, overwrite=True, add_to_history='hello!', verbose=False)
+    spcs = psc.spectra("grp1")
+    # assert all bs samples were written
+    nt.assert_true(np.all(["uvp_bs{}".format(i) in spcs for i in range(100)]))
+    # assert average was written
+    nt.assert_true("uvp_avg" in spcs and "uvp" in spcs)
+    # assert average only has one time and 3 blpairs
+    uvp_avg = psc.get_pspec("grp1", "uvp_avg")
+    nt.assert_equal(uvp_avg.Ntimes, 1)
+    nt.assert_equal(uvp_avg.Nblpairs, 3)
+    # check avg file history
+    nt.assert_true("hello!" in uvp_avg.history)
+    # assert original uvp is unchanged
+    nt.assert_true(uvp == psc.get_pspec("grp1", 'uvp'))
+    # check stats array
+    ## TODO
+
+    # test exceptions
+    del psc
+    if os.path.exists("ex.h5"):
+        os.remove("ex.h5")
+    psc = container.PSpecContainer("ex.h5", mode='rw')
+    # test empty groups
+    nt.assert_raises(AssertionError, grouping.bootstrap_run, "ex.h5")
+    # test bad filename
+    nt.assert_raises(AssertionError, grouping.bootstrap_run, 1)
+    # test fed spectra doesn't exist
+    psc.set_pspec("grp1", "uvp", uvp)
+    nt.assert_raises(AssertionError, grouping.bootstrap_run, psc, spectra=['grp1/foo'])
+    if os.path.exists("ex.h5"):
+        os.remove("ex.h5")
+
+
+def test_get_bootstrap_run_argparser():
+    args = grouping.get_bootstrap_run_argparser()
+    a = args.parse_args(['fname', '--spectra', 'grp1/uvp1', 'grp1/uvp2', 'grp2/uvp1',
+                         '--blpair_groups', '101102103104 101102102103, 102103104105',
+                         '--time_avg', 'True', '--Nsamples', '100', '--conf_ints', '16', '84'])
+    nt.assert_equal(a.spectra, ['grp1/uvp1', 'grp1/uvp2', 'grp2/uvp1'])
+    nt.assert_equal(a.blpair_groups, [[101102103104, 101102102103], [102103104105]])
+    nt.assert_equal(a.conf_ints, [16.0, 84.0])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/hera_pspec/tests/test_grouping.py
+++ b/hera_pspec/tests/test_grouping.py
@@ -263,7 +263,7 @@ def test_bootstrap_run():
 
     # Test basic bootstrap run
     grouping.bootstrap_run(psc, time_avg=True, Nsamples=100, seed=0,
-                           normal_std=True, robust_std=True, conf_ints=[16, 84], keep_samples=True,
+                           normal_std=True, robust_std=True, cintervals=[16, 84], keep_samples=True,
                            bl_error_tol=1.0, overwrite=True, add_to_history='hello!', verbose=False)
     spcs = psc.spectra("grp1")
     # assert all bs samples were written
@@ -301,10 +301,10 @@ def test_get_bootstrap_run_argparser():
     args = grouping.get_bootstrap_run_argparser()
     a = args.parse_args(['fname', '--spectra', 'grp1/uvp1', 'grp1/uvp2', 'grp2/uvp1',
                          '--blpair_groups', '101102103104 101102102103, 102103104105',
-                         '--time_avg', 'True', '--Nsamples', '100', '--conf_ints', '16', '84'])
+                         '--time_avg', 'True', '--Nsamples', '100', '--cintervals', '16', '84'])
     nt.assert_equal(a.spectra, ['grp1/uvp1', 'grp1/uvp2', 'grp2/uvp1'])
     nt.assert_equal(a.blpair_groups, [[101102103104, 101102102103], [102103104105]])
-    nt.assert_equal(a.conf_ints, [16.0, 84.0])
+    nt.assert_equal(a.cintervals, [16.0, 84.0])
 
 
 if __name__ == "__main__":

--- a/hera_pspec/tests/test_pipes.py
+++ b/hera_pspec/tests/test_pipes.py
@@ -1,0 +1,182 @@
+"""
+Testing file for scripts in pipelines/ directory
+"""
+import unittest
+import nose.tools as nt
+import numpy as np
+import os, copy, sys
+from hera_pspec.data import DATA_PATH
+from pyuvdata import UVData
+import subprocess
+import hera_pspec as hp
+import yaml
+import shutil
+import fnmatch
+import glob
+
+
+class Test_PreProcess(unittest.TestCase):
+    """ Testing class for preprocess_data.py pipeline """
+
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        files = ["preproc.yaml", "log.out", "err.out"]
+        for f in files:
+            if os.path.exists(f):
+                try:
+                    os.remove(f)
+                except:
+                    shutil.rmtree(f)
+
+    def test_preprocess_run(self):
+        # load default config
+        cf = hp.utils.load_config(os.path.join(DATA_PATH, "../../pipelines/idr2_preprocessing/preprocess_params.yaml"))
+
+        # edit parameters
+        cf['analysis']['bl_reformat'] = False
+        cf['analysis']['rfi_flag'] = False
+        cf['analysis']['timeavg_sub'] = True
+        cf['analysis']['time_avg'] = True
+        cf['analysis']['form_pstokes'] = True
+        cf['analysis']['fg_filt'] = True
+        cf['analysis']['multiproc'] = False
+        cf['analysis']['maxiter'] = 1
+        cf['io']['joinlog'] = True
+        cf['io']['verbose'] = False
+        cf['io']['work_dir'] = "./"
+        cf['io']['out_dir'] = "./"
+        cf['io']['logfile'] = "log.out"
+        cf['io']['efffile'] = 'err.out'
+        cf['io']['overwrite'] = True
+        cf['data']['data_template'] = os.path.join(DATA_PATH, cf['data']['data_template'])
+
+        # write new config
+        config = "./preproc.yaml"
+        with open(config, "w") as f:
+            f.write(yaml.dump(cf))
+
+        # clean space
+        exts = ['T', 'TF', 'TFP', 'TFD']
+        pols = ['xx', 'yy']
+        stokes = ['pI', 'pQ']
+        files = []
+        for e in exts:
+            files += glob.glob("zen.all.??.*uvA{}".format(e))
+        files += glob.glob("zen.all.??.tavg.uvA")
+        for f in files:
+            if os.path.exists(f):
+                try:
+                    os.remove(f)
+                except:
+                    shutil.rmtree(f)
+
+        # run preprocess pipe
+        out = subprocess.call(["preprocess_data.py", "preproc.yaml"])
+        nt.assert_equal(out, 0)
+
+        # check time average (xtalk) subtraction step
+        for p in pols:
+            # check files exist
+            nt.assert_true(os.path.exists("zen.all.{}.tavg.uvA".format(p)))
+            nt.assert_true(os.path.exists("zen.all.{}.LST.1.06964.uvAT".format(p)))
+            uvd = UVData()
+            uvd.read_miriad("zen.all.{}.tavg.uvA".format(p))
+            nt.assert_equal(uvd.Ntimes, 1)
+            nt.assert_equal(uvd.Nbls, 3)
+
+        # check time averaging (FRF) & pstokes steps
+        for p in pols + stokes:
+            # check files exist: glob is used b/c starting LST changed slightly
+            nt.assert_true(len(glob.glob("zen.all.{}.LST.1.0696?.uvATF".format(p)))==1)
+
+        # check FG filtering step
+        for p in pols + stokes:
+            # check files exist: glob is used b/c starting LST changed slightly
+            nt.assert_true(len(glob.glob("zen.all.{}.LST.1.0696?.uvATFD".format(p)))==1)
+            nt.assert_true(len(glob.glob("zen.all.{}.LST.1.0696?.uvATFP".format(p)))==1)
+
+        # clean space
+        files = []
+        for e in exts:
+            files += glob.glob("zen.all.??.*uvA{}".format(e))
+        files += glob.glob("zen.all.??.tavg.uvA")
+        for f in files:
+            if os.path.exists(f):
+                try:
+                    os.remove(f)
+                except:
+                    shutil.rmtree(f)
+        os.remove("preproc.yaml")
+        os.remove("log.out")
+
+
+
+class Test_PspecPipe(unittest.TestCase):
+    """ Testing class for pspec_pipe.py pipeline """
+
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        files = ["pspec.h5", "pspec.yaml", "log.out", "err.out"]
+        for f in files:
+            if os.path.exists(f):
+                try:
+                    os.remove(f)
+                except:
+                    shutil.rmtree(f)
+
+    def test_pspec_run(self):
+        # load default config
+        cf = hp.utils.load_config(os.path.join(DATA_PATH, "../../pipelines/pspec_pipeline/pspec_pipe.yaml"))
+
+        # edit parameters
+        cf['analysis']['run_diff'] = False
+        cf['analysis']['run_pspec'] = True
+        cf['analysis']['run_bootstrap'] = True
+        cf['analysis']['multiproc'] = False
+        cf['data']['data_template'] = os.path.join(DATA_PATH, cf['data']['data_template'])
+        cf['io']['joinlog'] = True
+        cf['io']['verbose'] = False
+        cf['io']['work_dir'] = "./"
+        cf['io']['out_dir'] = "./"
+        cf['io']['logfile'] = "log.out"
+        cf['io']['efffile'] = 'err.out'
+        cf['io']['overwrite'] = True
+        cf['algorithm']['pspec']['beam'] = os.path.join(DATA_PATH, cf['algorithm']['pspec']['beam'])
+
+        # write new config
+        config = "./pspec.yaml"
+        with open(config, "w") as f:
+            f.write(yaml.dump(cf))
+
+        # clean space
+        if os.path.exists(cf['algorithm']['pspec']['outfname']):
+            os.remove(cf['algorithm']['pspec']['outfname'])
+
+        # run preprocess pipe
+        out = subprocess.call(["pspec_pipe.py", "pspec.yaml"])
+        nt.assert_equal(out, 0)
+
+        # check pspec and bootstrap steps
+        nt.assert_true(os.path.exists(cf['algorithm']['pspec']['outfname']))
+        psc = hp.PSpecContainer(cf['algorithm']['pspec']['outfname'], 'r')
+        groups = psc.groups()
+        nt.assert_true(len(groups) > 0)
+        for grp in groups:
+            spectra = psc.spectra(grp)
+            nt.assert_true(len(spectra), 2)
+            nt.assert_true("_avg" not in spectra[0])
+            nt.assert_true("_avg" in spectra[1])
+
+        # clean space
+        if os.path.exists(cf['algorithm']['pspec']['outfname']):
+            os.remove(cf['algorithm']['pspec']['outfname'])
+        os.remove("pspec.yaml")
+        os.remove("log.out")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/hera_pspec/tests/test_pipes.py
+++ b/hera_pspec/tests/test_pipes.py
@@ -14,7 +14,6 @@ import shutil
 import fnmatch
 import glob
 
-
 class Test_PreProcess(unittest.TestCase):
     """ Testing class for preprocess_data.py pipeline """
 
@@ -48,7 +47,7 @@ class Test_PreProcess(unittest.TestCase):
         cf['io']['work_dir'] = "./"
         cf['io']['out_dir'] = "./"
         cf['io']['logfile'] = "log.out"
-        cf['io']['efffile'] = 'err.out'
+        cf['io']['errfile'] = 'err.out'
         cf['io']['overwrite'] = True
         cf['data']['data_template'] = os.path.join(DATA_PATH, cf['data']['data_template'])
 
@@ -143,7 +142,7 @@ class Test_PspecPipe(unittest.TestCase):
         cf['io']['work_dir'] = "./"
         cf['io']['out_dir'] = "./"
         cf['io']['logfile'] = "log.out"
-        cf['io']['efffile'] = 'err.out'
+        cf['io']['errfile'] = 'err.out'
         cf['io']['overwrite'] = True
         cf['algorithm']['pspec']['beam'] = os.path.join(DATA_PATH, cf['algorithm']['pspec']['beam'])
 

--- a/hera_pspec/tests/test_pspecdata.py
+++ b/hera_pspec/tests/test_pspecdata.py
@@ -997,7 +997,7 @@ class Test_PSpecData(unittest.TestCase):
         nt.assert_equal(uvp.Nspws, 3)
         nt.assert_equal(uvp.Nspwdlys, 43)
         nt.assert_equal(uvp.data_array[0].shape, (240, 14, 1))
-        nt.assert_equal(uvp.get_data(0, 24025024025, 'xx').shape, (60, 14))
+        nt.assert_equal(uvp.get_data((0, 24025024025, 'xx')).shape, (60, 14))
 
         # check select
         uvp.select(spws=[1])
@@ -1090,7 +1090,7 @@ class Test_PSpecData(unittest.TestCase):
         # hera_pspec OQE
         ds = pspecdata.PSpecData(dsets=[d1, d2], wgts=[None, None], beam=beam)
         uvp = ds.pspec(bls1, bls2, (0, 1), pols=('xx','xx'), taper='none', input_data_weight='identity', norm='I', sampling=True)
-        oqe = uvp.get_data(0, ((24, 25), (37, 38)), 'xx')[0]
+        oqe = uvp.get_data((0, ((24, 25), (37, 38)), 'xx'))[0]
         # assert answers are same to within 3%
         nt.assert_true(np.isclose(np.real(oqe)/np.real(legacy), 1, atol=0.03, rtol=0.03).all())
         # taper
@@ -1103,7 +1103,7 @@ class Test_PSpecData(unittest.TestCase):
         # hera_pspec OQE
         ds = pspecdata.PSpecData(dsets=[d1, d2], wgts=[None, None], beam=beam)
         uvp = ds.pspec(bls1, bls2, (0, 1), ('xx','xx'), taper='blackman-harris', input_data_weight='identity', norm='I')
-        oqe = uvp.get_data(0, ((24, 25), (37, 38)), 'xx')[0]
+        oqe = uvp.get_data((0, ((24, 25), (37, 38)), 'xx'))[0]
         # assert answers are same to within 3%
         nt.assert_true(np.isclose(np.real(oqe)/np.real(legacy), 1, atol=0.03, rtol=0.03).all())
 
@@ -1143,9 +1143,9 @@ class Test_PSpecData(unittest.TestCase):
         uvp = ds.pspec([(24, 25), (37, 38), (38, 39)], [(24, 25), (37, 38), (38, 39)], (0, 1), ('xx', 'xx'),
                         spw_ranges=[(400, 450)], verbose=False)
         # assert flag broadcast above hits weight arrays in uvp
-        nt.assert_true(np.all(np.isclose(uvp.get_wgts(0, ((24, 25), (24, 25)), 'xx')[3], 0.0)))
+        nt.assert_true(np.all(np.isclose(uvp.get_wgts((0, ((24, 25), (24, 25)), 'xx'))[3], 0.0)))
         # assert flag broadcast above hits integration arrays
-        nt.assert_true(np.isclose(uvp.get_integrations(0, ((24, 25), (24, 25)), 'xx')[3], 0.0))
+        nt.assert_true(np.isclose(uvp.get_integrations((0, ((24, 25), (24, 25)), 'xx'))[3], 0.0))
         # average spectra
         avg_uvp = uvp.average_spectra(blpair_groups=[sorted(np.unique(uvp.blpair_array))], time_avg=True, inplace=False)
         # repeat but change data in flagged portion
@@ -1177,8 +1177,8 @@ class Test_PSpecData(unittest.TestCase):
         uvp_unflagged = ds.pspec(bls1, bls2, (0, 1), ('xx','xx'), input_data_weight='identity', norm='I', taper='none',
                                 little_h=True, verbose=False)
 
-        qe_unflagged = uvp_unflagged.get_data(0, ((24, 25), (37, 38)), 'xx')[0]
-        qe_flagged = uvp_flagged.get_data(0, ((24, 25), (37, 38)), 'xx')[0]
+        qe_unflagged = uvp_unflagged.get_data((0, ((24, 25), (37, 38)), 'xx'))[0]
+        qe_flagged = uvp_flagged.get_data((0, ((24, 25), (37, 38)), 'xx'))[0]
 
         # assert answers are same to within 0.1%
         nt.assert_true(np.isclose(np.real(qe_unflagged)/np.real(qe_flagged), 1, atol=0.001, rtol=0.001).all())
@@ -1195,8 +1195,8 @@ class Test_PSpecData(unittest.TestCase):
         uvp_flagged_mod = ds.pspec(bls1, bls2, (0, 1), ('xx','xx'), input_data_weight='identity', norm='I', taper='none',
                                 little_h=True, verbose=False)
 
-        qe_flagged_mod = uvp_flagged_mod.get_data(0, ((24, 25), (37, 38)), 'xx')[0]
-        qe_flagged = uvp_flagged.get_data(0, ((24, 25), (37, 38)), 'xx')[0]
+        qe_flagged_mod = uvp_flagged_mod.get_data((0, ((24, 25), (37, 38)), 'xx'))[0]
+        qe_flagged = uvp_flagged.get_data((0, ((24, 25), (37, 38)), 'xx'))[0]
 
         # assert answers are same to within 0.1%
         nt.assert_true(np.isclose(np.real(qe_flagged_mod), np.real(qe_flagged), atol=0.001, rtol=0.001).all())

--- a/hera_pspec/tests/test_pspecdata.py
+++ b/hera_pspec/tests/test_pspecdata.py
@@ -159,6 +159,18 @@ class Test_PSpecData(unittest.TestCase):
         key = (0, (24, 25), 'xx')
         nt.assert_true(np.all(np.isclose(ds.x(key), ds.w(key))))
 
+        # Test labels when adding dsets
+        uvd = self.uvd
+        ds = pspecdata.PSpecData()
+        nt.assert_equal(len(ds.labels), 0)
+        ds.add([uvd, uvd], [None, None])
+        nt.assert_equal(len(ds.labels), 2)
+        ds.add(uvd, None, labels='foo')
+        nt.assert_equal(len(ds.dsets), len(ds.labels), 3)
+        nt.assert_equal(ds.labels, ['dset0', 'dset1', 'foo'])
+        ds.add(uvd, None)
+        nt.assert_equal(ds.labels, ['dset0', 'dset1', 'foo', 'dset3'])
+
         # Test some exceptions
         ds = pspecdata.PSpecData()
         nt.assert_raises(ValueError, ds.get_G, key, key)
@@ -1312,7 +1324,6 @@ def test_pspec_run():
     nt.assert_raises(AssertionError, pspecdata.pspec_run, fnames, "./out.hdf5", blpairs=(1, 2), verbose=False)
     nt.assert_raises(AssertionError, pspecdata.pspec_run, fnames, "./out.hdf5", blpairs=[1, 2], verbose=False)
     nt.assert_raises(AssertionError, pspecdata.pspec_run, fnames, "./out.hdf5", beam=1, verbose=False)
-    nt.assert_raises(AssertionError, pspecdata.pspec_run, fnames, "./out.hdf5", dset_labels=['hi', 'hi'], verbose=False)
 
     if os.path.exists("./out.hdf5"):
         os.remove("./out.hdf5")

--- a/hera_pspec/tests/test_pspecdata.py
+++ b/hera_pspec/tests/test_pspecdata.py
@@ -154,6 +154,16 @@ class Test_PSpecData(unittest.TestCase):
         # Test exception when not a UVData instance
         self.assertRaises(TypeError, ds.add, [1], [None])
 
+        # Test get weights when fed a UVData for weights
+        ds = pspecdata.PSpecData(dsets=[self.uvd, self.uvd], wgts=[self.uvd, self.uvd])
+        key = (0, (24, 25), 'xx')
+        nt.assert_true(np.all(np.isclose(ds.x(key), ds.w(key))))
+
+        # Test some exceptions
+        ds = pspecdata.PSpecData()
+        nt.assert_raises(ValueError, ds.get_G, key, key)
+        nt.assert_raises(ValueError, ds.get_H, key, key)
+
     def test_add_data(self):
         """
         Test adding non UVData object.
@@ -1266,6 +1276,16 @@ def test_pspec_run():
                               blpairs=[((500, 501), (600, 601))])
     nt.assert_equal(psc, None)
     nt.assert_false(os.path.exists("./out.h5"))
+    uvds = []
+    for f in fnames:
+        uvd = UVData()
+        uvd.read_miriad(f)
+        uvds.append(uvd)
+    psc = pspecdata.pspec_run(uvds, "./out.hdf5", dsets_std=fnames_std, Jy2mK=False, verbose=False, overwrite=True,
+                              blpairs=[((500, 501), (600, 601))])
+    nt.assert_equal(psc, None)
+    nt.assert_false(os.path.exists("./out.h5"))
+
 
     # test when data is loaded, but no blpairs match
     if os.path.exists("./out.hdf5"):

--- a/hera_pspec/tests/test_pspecdata.py
+++ b/hera_pspec/tests/test_pspecdata.py
@@ -1286,8 +1286,12 @@ def test_pspec_run():
 
 def test_get_argparser():
     args = pspecdata.get_pspec_run_argparser()
-    a = args.parse_args([['foo'], 'bar'])
-
+    a = args.parse_args([['foo'], 'bar', '--dset_pairs', '0 0, 1 1', '--pol_pairs', 'xx xx, yy yy',
+                         '--spw_ranges', '300 400, 600 800', '--blpairs', '24 25 24 25, 37 38 37 38'])
+    nt.assert_equal(a.pol_pairs, [('xx', 'xx'), ('yy', 'yy')])
+    nt.assert_equal(a.dset_pairs, [(0, 0), (1, 1)])
+    nt.assert_equal(a.spw_ranges, [(300, 400), (600, 800)])
+    nt.assert_equal(a.blpairs, [((24, 25), (24, 25)), ((37, 38), (37, 38))])
 
 """
 # LEGACY MONTE CARLO TESTS

--- a/hera_pspec/tests/test_pspecdata.py
+++ b/hera_pspec/tests/test_pspecdata.py
@@ -1286,7 +1286,6 @@ def test_pspec_run():
     nt.assert_equal(psc, None)
     nt.assert_false(os.path.exists("./out.h5"))
 
-
     # test when data is loaded, but no blpairs match
     if os.path.exists("./out.hdf5"):
         os.remove("./out.hdf5")
@@ -1294,6 +1293,18 @@ def test_pspec_run():
                               blpairs=[((37, 38), (600, 601))])
     nt.assert_true(psc is not None)
     nt.assert_equal(len(psc.groups()), 0)
+
+    # test glob-parseable input dataset
+    dsets = [os.path.join(DATA_PATH, "zen.2458042.?????.xx.HH.uvXA"),
+             os.path.join(DATA_PATH, "zen.2458042.?????.xx.HH.uvXA")]
+    if os.path.exists("./out.hdf5"):
+        os.remove("./out.hdf5")
+    psc = pspecdata.pspec_run(dsets, "./out.hdf5", Jy2mK=False, verbose=True, overwrite=True,
+                              blpairs=[((24, 25), (37, 38))])
+    uvp = psc.get_pspec("dset0_dset1", "dset0_x_dset1")
+    nt.assert_equal(uvp.Ntimes, 120)
+    if os.path.exists("./out.hdf5"):
+        os.remove("./out.hdf5")
 
     # test exceptions
     nt.assert_raises(AssertionError, pspecdata.pspec_run, (1, 2), "./out.hdf5")
@@ -1305,6 +1316,7 @@ def test_pspec_run():
 
     if os.path.exists("./out.hdf5"):
         os.remove("./out.hdf5")
+
 
 def test_get_argparser():
     args = pspecdata.get_pspec_run_argparser()

--- a/hera_pspec/tests/test_pspecdata.py
+++ b/hera_pspec/tests/test_pspecdata.py
@@ -10,6 +10,7 @@ from pyuvdata import UVData
 from hera_cal import redcal
 from scipy.signal import windows
 from scipy.interpolate import interp1d
+from astropy.time import Time
 
 # Data files to use in tests
 dfiles = [
@@ -836,10 +837,10 @@ class Test_PSpecData(unittest.TestCase):
         # test phasing
         uvd = copy.deepcopy(self.d[0])
         uvd2 = copy.deepcopy(self.d[0])
-        uvd.phase_to_time(2458042)
+        uvd.phase_to_time(Time(2458042, format='jd'))
         ds = pspecdata.PSpecData(dsets=[uvd, uvd2], wgts=[None, None])
         nt.assert_raises(ValueError, ds.validate_datasets)
-        uvd2.phase_to_time(2458042.5)
+        uvd2.phase_to_time(Time(2458042.5, format='jd'))
         ds.validate_datasets()
 
     def test_rephase_to_dst(self):

--- a/hera_pspec/tests/test_pspecdata.py
+++ b/hera_pspec/tests/test_pspecdata.py
@@ -982,7 +982,7 @@ class Test_PSpecData(unittest.TestCase):
         uvp = ds.pspec(bls1, bls2, (0, 1), ('xx','xx'), spw_ranges=[(20,30), (30,40)], verbose=False)
         nt.assert_equal(uvp.Nblpairs, 16)
         nt.assert_equal(uvp.Nspws, 2)
-        uvp2 = uvp.select(spws=[0], bls=[(24, 25)], only_pairs_in_bls=False, inplace=False)
+        uvp2 = uvp.select(spws=0, bls=[(24, 25)], only_pairs_in_bls=False, inplace=False)
         nt.assert_equal(uvp2.Nspws, 1)
         nt.assert_equal(uvp2.Nblpairs, 7)
         uvp.select(spws=0, bls=(24, 25), only_pairs_in_bls=True, inplace=True)

--- a/hera_pspec/tests/test_pspecdata.py
+++ b/hera_pspec/tests/test_pspecdata.py
@@ -1229,21 +1229,24 @@ def test_pspec_run():
     fnames_std=[os.path.join(DATA_PATH,d) for d in ['zen.even.std.xx.LST.1.28828.uvOCRSA',
                                                     'zen.odd.std.xx.LST.1.28828.uvOCRSA']]
     # test basic execution
-    psc = pspecdata.pspec_run(fnames, "./out.hdf5", Jy2mK=False, verbose=False, overwrite=True)
-    nt.assert_true(isinstance(psc, container.PSpecContainer))
-    nt.assert_equal(psc.groups(), ['dset0_dset1'])
-    nt.assert_equal(psc.spectra(psc.groups()[0]), ['dset0_x_dset1'])
-    nt.assert_true(os.path.exists("./out.hdf5"))
     if os.path.exists("./out.hdf5"):
         os.remove("./out.hdf5")
+    psc = pspecdata.pspec_run(fnames, "./out.hdf5", Jy2mK=False, verbose=False, overwrite=True,
+                              bl_len_range=(14, 15), bl_deg_range=(50, 70), psname_ext='_0')
+    nt.assert_true(isinstance(psc, container.PSpecContainer))
+    nt.assert_equal(psc.groups(), ['dset0_dset1'])
+    nt.assert_equal(psc.spectra(psc.groups()[0]), ['dset0_x_dset1_0'])
+    nt.assert_true(os.path.exists("./out.hdf5"))
 
-    # test Jy2mK, rephase_to_dset, blpairs and dset_labels
+    # test Jy2mK, rephase_to_dset, trim_dset_lsts, broadcast_dset_flags, blpairs and dset_labels
     cosmo = conversions.Cosmo_Conversions(Om_L=0.0)
-    psc = pspecdata.pspec_run(fnames, "./out.hdf5",dsets_std=fnames_std, Jy2mK=True, beam=beamfile, verbose=False, overwrite=True,
+    if os.path.exists("./out.hdf5"):
+        os.remove("./out.hdf5")
+    psc = pspecdata.pspec_run(fnames, "./out.hdf5", dsets_std=fnames_std, Jy2mK=True, beam=beamfile, verbose=False, overwrite=True,
                               rephase_to_dset=0, blpairs=[((37, 38), (37, 38)), ((37, 38), (52, 53))],
                               pol_pairs=[('xx', 'xx'), ('xx', 'xx')], dset_labels=["foo", "bar"],
                               dset_pairs=[(0, 0), (0, 1)], spw_ranges=[(50, 75), (120, 140)],
-                              cosmo=cosmo)
+                              cosmo=cosmo, trim_dset_lsts=True, broadcast_dset_flags=True, time_thresh=0.1)
     nt.assert_true("foo_bar" in psc.groups())
     nt.assert_equal(psc.spectra('foo_bar'), [u'foo_x_bar', u'foo_x_foo'])
     uvp = psc.get_pspec("foo_bar", "foo_x_bar")
@@ -1253,6 +1256,22 @@ def test_pspec_run():
     nt.assert_equal(uvp.cosmo, cosmo)
     #nt.assert_equal(uvp.labels, [])
     #nt.assert_equal(uvp.get_spw_ranges, [])
+
+    # test when no data is loaded in dset
+    if os.path.exists("./out.hdf5"):
+        os.remove("./out.hdf5")
+    psc = pspecdata.pspec_run(fnames, "./out.hdf5", Jy2mK=False, verbose=False, overwrite=True,
+                              blpairs=[((500, 501), (600, 601))])
+    nt.assert_equal(psc, None)
+    nt.assert_false(os.path.exists("./out.h5"))
+
+    # test when data is loaded, but no blpairs match
+    if os.path.exists("./out.hdf5"):
+        os.remove("./out.hdf5")
+    psc = pspecdata.pspec_run(fnames, "./out.hdf5", Jy2mK=False, verbose=False, overwrite=True,
+                              blpairs=[((37, 38), (600, 601))])
+    nt.assert_true(psc is not None)
+    nt.assert_equal(len(psc.groups()), 0)
 
     # test exceptions
     nt.assert_raises(AssertionError, pspecdata.pspec_run, (1, 2), "./out.hdf5")

--- a/hera_pspec/tests/test_pspecdata.py
+++ b/hera_pspec/tests/test_pspecdata.py
@@ -1279,6 +1279,7 @@ def test_pspec_run():
     nt.assert_raises(AssertionError, pspecdata.pspec_run, fnames, "./out.hdf5", blpairs=(1, 2), verbose=False)
     nt.assert_raises(AssertionError, pspecdata.pspec_run, fnames, "./out.hdf5", blpairs=[1, 2], verbose=False)
     nt.assert_raises(AssertionError, pspecdata.pspec_run, fnames, "./out.hdf5", beam=1, verbose=False)
+    nt.assert_raises(AssertionError, pspecdata.pspec_run, fnames, "./out.hdf5", dset_labels=['hi', 'hi'], verbose=False)
 
     if os.path.exists("./out.hdf5"):
         os.remove("./out.hdf5")

--- a/hera_pspec/tests/test_testing.py
+++ b/hera_pspec/tests/test_testing.py
@@ -4,6 +4,7 @@ from hera_pspec import testing, uvpspec, conversions, pspecbeam, utils
 import os
 from pyuvdata import UVData
 import numpy as np
+from hera_cal import redcal
 
 
 def test_build_vanilla_uvpspec():
@@ -18,6 +19,7 @@ def test_build_vanilla_uvpspec():
     nt.assert_equal(beam_OP.tolist(), uvp.OmegaP.tolist())
 
 def test_uvpspec_from_data():
+    # get data
     fname = os.path.join(DATA_PATH, "zen.even.xx.LST.1.28828.uvOCRSA")
     fname_std = os.path.join(DATA_PATH, "zen.even.std.xx.LST.1.28828.uvOCRSA")
     uvd = UVData()
@@ -25,15 +27,30 @@ def test_uvpspec_from_data():
     beamfile = os.path.join(DATA_PATH, 'HERA_NF_dipole_power.beamfits')
     beam = pspecbeam.PSpecBeamUV(beamfile)
 
-    uvp = testing.uvpspec_from_data(fname, [(37, 38), (38, 39), (52, 53), (53, 54)], beam=beam)
-    nt.assert_equal(uvp.Nfreqs, 150)
-    nt.assert_equal(np.unique(uvp.blpair_array).tolist(), [37038038039, 37038052053, 37038053054, 38039037038,
-                                                            38039052053, 38039053054, 52053037038, 52053038039,
-                                                            52053053054, 53054037038, 53054038039, 53054052053])
-    uvp2 = testing.uvpspec_from_data(uvd, [(37, 38), (38, 39), (52, 53), (53, 54)], beam=beamfile)
+    # test basic execution
+    uvp = testing.uvpspec_from_data(fname, [(37, 38), (38, 39), (52, 53), (53, 54)], beam=beam, spw_ranges=[(50, 100)])
+    nt.assert_equal(uvp.Nfreqs, 50)
+    nt.assert_equal(np.unique(uvp.blpair_array).tolist(), [37038038039, 37038052053, 37038053054, 38039052053, 38039053054, 52053053054])
+    uvp2 = testing.uvpspec_from_data(uvd, [(37, 38), (38, 39), (52, 53), (53, 54)], beam=beamfile, spw_ranges=[(50, 100)])
     uvp.history = ''
     uvp2.history = ''
     nt.assert_equal(uvp, uvp2)
-    #test std
+
+    # test multiple bl groups
+    antpos, ants = uvd.get_ENU_antpos(pick_data_ants=True)
+    reds = redcal.get_pos_reds(dict(zip(ants, antpos)), low_hi=True)
+    uvp = testing.uvpspec_from_data(fname, reds[:3], beam=beam, spw_ranges=[(50, 100)])
+    nt.assert_equal(len(set(uvp.bl_array) - set([37038, 37051, 37052, 38039, 38052, 38053, 39053, 39054,
+                                                 51052, 51067, 52053, 52067, 52068, 53054, 53068, 53069,
+                                                 54069, 67068, 68069])), 0)
+    nt.assert_equal(uvp.Nblpairs, 51)
+
+    # test exceptions
+    nt.assert_raises(AssertionError, testing.uvpspec_from_data, fname, (37, 38))
+    nt.assert_raises(AssertionError, testing.uvpspec_from_data, fname, [([37, 38], [38, 39])])
+    nt.assert_raises(AssertionError, testing.uvpspec_from_data, fname, [[[37, 38], [38, 39]]])
+
+    # test std
     uvp = testing.uvpspec_from_data(fname, [(37, 38), (38, 39), (52, 53), (53, 54)],
                                     data_std=fname_std, beam=beam, spw_ranges=[(20,28)])
+

--- a/hera_pspec/tests/test_utils.py
+++ b/hera_pspec/tests/test_utils.py
@@ -189,13 +189,13 @@ class Test_Utils(unittest.TestCase):
         uv_template = os.path.join(DATA_PATH, "zen.{group}.{pol}.LST.1.28828.uvOCRSA")
         groupings = utils.config_pspec_blpairs(uv_template, [('xx', 'xx')], [('even', 'odd')], verbose=False)
         nt.assert_equal(len(groupings), 1)
-        nt.assert_equal(groupings.keys()[0], (('xx', 'even'), ('xx', 'odd')))
+        nt.assert_equal(groupings.keys()[0], (('even', 'odd'), ('xx', 'xx')))
         nt.assert_equal(len(groupings.values()[0]), 11833)
 
         # test multiple, some non-existant pairs
         groupings = utils.config_pspec_blpairs(uv_template, [('xx', 'xx'), ('yy', 'yy')], [('even', 'odd'), ('even', 'odd')], verbose=False)
         nt.assert_equal(len(groupings), 1)
-        nt.assert_equal(groupings.keys()[0], (('xx', 'even'), ('xx', 'odd')))
+        nt.assert_equal(groupings.keys()[0], (('even', 'odd'), ('xx', 'xx')))
 
         # test xants
         groupings = utils.config_pspec_blpairs(uv_template, [('xx', 'xx')], [('even', 'odd')], xants=[0, 1, 2], verbose=False)

--- a/hera_pspec/tests/test_utils.py
+++ b/hera_pspec/tests/test_utils.py
@@ -8,7 +8,6 @@ from collections import OrderedDict as odict
 from pyuvdata import UVData
 
 
-
 def test_cov():
     # load another data file
     uvd = UVData()
@@ -183,6 +182,27 @@ class Test_Utils(unittest.TestCase):
         uvd2 = copy.deepcopy(uvd)
         uvd2.antenna_positions[0] += 2
         nt.assert_raises(AssertionError, utils.calc_reds, uvd, uvd2)
+
+    def test_config_pspec_blpairs(self):
+        # test basic execution
+        uv_template = os.path.join(DATA_PATH, "zen.{group}.{pol}.LST.1.28828.uvOCRSA")
+        groupings = utils.config_pspec_blpairs(uv_template, [('xx', 'xx')], [('even', 'odd')], verbose=False)
+        nt.assert_equal(len(groupings), 1)
+        nt.assert_equal(groupings.keys()[0], (('xx', 'even'), ('xx', 'odd')))
+        nt.assert_equal(len(groupings.values()[0]), 11833)
+
+        # test multiple, some non-existant pairs
+        groupings = utils.config_pspec_blpairs(uv_template, [('xx', 'xx'), ('yy', 'yy')], [('even', 'odd'), ('even', 'odd')], verbose=False)
+        nt.assert_equal(len(groupings), 1)
+        nt.assert_equal(groupings.keys()[0], (('xx', 'even'), ('xx', 'odd')))
+
+        # test xants
+        groupings = utils.config_pspec_blpairs(uv_template, [('xx', 'xx')], [('even', 'odd')], xants=[0, 1, 2], verbose=False)
+        nt.assert_equal(len(groupings.values()[0]), 9735)
+
+        # test exceptions
+        nt.assert_raises(AssertionError, utils.config_pspec_blpairs, uv_template, [('xx', 'xx'), ('xx', 'xx')], [('even', 'odd')], verbose=False)
+        
 
 def test_log():
     """

--- a/hera_pspec/tests/test_utils.py
+++ b/hera_pspec/tests/test_utils.py
@@ -273,3 +273,42 @@ def test_get_blvec_reds():
      red_bl_tag) = utils.get_blvec_reds(uvp, bl_error_tol=0.0)
     nt.assert_equal(len(red_bl_grp), uvp.Nblpairs)
 
+
+def test_job_monitor():
+    # open empty files
+    datafiles = ["./{}".format(i) for i in ['a', 'b', 'c', 'd']]
+    for df in datafiles:
+        with open(df, 'w') as f:
+            pass
+
+    def run_func(i, datafiles=datafiles):
+        # open file, perform action, finish
+        # if rand_num is above 0.7, fail!
+        try:
+            rand_num = np.random.rand(1)[0]
+            if rand_num > 0.7:
+                raise ValueError
+            df = datafiles[i]
+            with open(df, 'a') as f:
+                f.write("Hello World")
+        except:
+            return 1
+
+        return 0
+
+    # set seed
+    np.random.seed(0)
+    # run over datafiles
+    failures = utils.job_monitor(run_func, range(len(datafiles)), "test", maxiter=1, verbose=False)
+    # assert job 1 failed
+    np.testing.assert_array_equal(failures, np.array([1]))
+    # try with reruns
+    np.random.seed(0)
+    failures = utils.job_monitor(run_func, range(len(datafiles)), "test", maxiter=10, verbose=False)
+    # assert no failures now
+    nt.assert_equal(len(failures), 0)
+
+    # remove files
+    for df in datafiles:
+        os.remove(df)
+

--- a/hera_pspec/tests/test_utils.py
+++ b/hera_pspec/tests/test_utils.py
@@ -51,6 +51,13 @@ def test_load_config():
     # Check that missing files cause an error
     nt.assert_raises(IOError, utils.load_config, "file_that_doesnt_exist")
 
+    # Check 'None' and list of lists become Nones and list of tuples
+    nt.assert_equal(cfg['data']['pairs'], [('xx', 'xx'), ('yy', 'yy')])
+    nt.assert_equal(cfg['pspec']['taper'], 'none')
+    nt.assert_equal(cfg['pspec']['groupname'], None)
+    nt.assert_equal(cfg['pspec']['options']['bar'], [('foo', 'bar')])
+    nt.assert_equal(cfg['pspec']['options']['foo'], None)
+
 
 class Test_Utils(unittest.TestCase):
 
@@ -225,8 +232,7 @@ def test_log():
     try:
         raise NameError
     except NameError:
-        err, _, tb = sys.exc_info()
-        utils.log("raised an exception", f=logf, tb=tb, verbose=False)
+        utils.log("raised an exception", f=logf, tb=sys.exc_info(), verbose=False)
     logf.close()
     with open("logf.log", "r") as f:
         log = ''.join(f.readlines())

--- a/hera_pspec/tests/test_utils.py
+++ b/hera_pspec/tests/test_utils.py
@@ -194,7 +194,7 @@ class Test_Utils(unittest.TestCase):
     def test_get_reds(self):
         fname = os.path.join(DATA_PATH, 'zen.all.xx.LST.1.06964.uvA')
         uvd = UVData()
-        uvd.read_miriad_metadata(fname)
+        uvd.read_miriad(fname, read_data=False)
         antpos, ants = uvd.get_ENU_antpos()
         antpos_d = dict(zip(ants, antpos))
 

--- a/hera_pspec/tests/test_uvpspec.py
+++ b/hera_pspec/tests/test_uvpspec.py
@@ -117,11 +117,11 @@ class Test_UVPSpec(unittest.TestCase):
 
         # test folding
         uvp = copy.deepcopy(self.uvp)
-        errs = np.repeat(np.arange(1, 51)[None], 10, axis=0)
+        errs = np.repeat(np.arange(1, 31)[None], 10, axis=0)
         uvp.set_stats("test", keys[0], errs)
         uvp.fold_spectra()
         # fold by summing in inverse quadrature
-        folded_errs = np.sum([1/errs[:, 1:25][:, ::-1]**2.0, 1/errs[:, 26:]**2.0], axis=0)**(-0.5)
+        folded_errs = np.sum([1/errs[:, 1:15][:, ::-1]**2.0, 1/errs[:, 16:]**2.0], axis=0)**(-0.5)
         np.testing.assert_array_almost_equal(uvp.get_stats("test", keys[0]), folded_errs)
 
     def test_convert_deltasq(self):

--- a/hera_pspec/tests/test_uvpspec.py
+++ b/hera_pspec/tests/test_uvpspec.py
@@ -417,7 +417,7 @@ class Test_UVPSpec(unittest.TestCase):
         # test concat across blpairts
         uvp2 = testing.uvpspec_from_data(uvd, [(53, 54), (67, 68)], spw_ranges=[(20, 30), (60, 90)], beam=beam)
         out = uvpspec.combine_uvpspec([uvp1, uvp2], verbose=False)
-        nt.assert_equal(out.Nblpairs, 8)
+        nt.assert_equal(out.Nblpairs, 4)
         nt.assert_equal(out.Nbls, 5)
 
         # test failure due to variable static metadata
@@ -487,7 +487,7 @@ class Test_UVPSpec(unittest.TestCase):
             # test concat across blpairts
             uvp2 = testing.uvpspec_from_data(uvd, [(53, 54), (67, 68)], spw_ranges=[(20, 24), (64, 68)], data_std=uvd_std, beam=beam)
             out = uvpspec.combine_uvpspec([uvp1, uvp2], verbose=False)
-            nt.assert_equal(out.Nblpairs, 8)
+            nt.assert_equal(out.Nblpairs, 4)
             nt.assert_equal(out.Nbls, 5)
 
             # test failure due to variable static metadata

--- a/hera_pspec/tests/test_uvpspec.py
+++ b/hera_pspec/tests/test_uvpspec.py
@@ -71,7 +71,7 @@ class Test_UVPSpec(unittest.TestCase):
         nt.assert_equal(len(k_para), 30)
         # test key expansion
         key = (0, ((1, 2), (1, 2)), 'xx')
-        d = self.uvp.get_data(*key)
+        d = self.uvp.get_data(key)
         nt.assert_equal(d.shape, (10, 30))
         # test key as dictionary
         key = {'spw':0, 'blpair':((1, 2), (1, 2)), 'pol': 'xx'}
@@ -84,6 +84,9 @@ class Test_UVPSpec(unittest.TestCase):
         keys = self.uvp.get_all_keys()
         nt.assert_equal(keys, [(0, ((1, 2), (1, 2)), 'XX'), (0, ((1, 3), (1, 3)), 'XX'),
                                (0, ((2, 3), (2, 3)), 'XX')])
+        # test omit_flags
+        self.uvp.integration_array[0][self.uvp.blpair_to_indices(((1, 2), (1, 2)))[:2]] = 0.0
+        nt.assert_equal(self.uvp.get_integrations((0, ((1, 2), (1, 2)), 'xx'), omit_flags=True).shape, (8,))
 
     def test_stats_array(self):
         # test get_data and set_data
@@ -296,8 +299,8 @@ class Test_UVPSpec(unittest.TestCase):
         blpairs = uvp.get_blpair_groups_from_bl_groups([[1002, 2003, 1003]], only_pairs_in_bls=False)
         uvp2 = uvp.average_spectra(blpair_groups=blpairs, time_avg=False, inplace=False)
         nt.assert_equal(uvp2.Nblpairs, 1)
-        nt.assert_true(np.isclose(uvp2.get_nsamples(0, 1002001002, 'xx'), 3.0).all())
-        nt.assert_equal(uvp2.get_data(0, 1002001002, 'xx').shape, (10, 30))
+        nt.assert_true(np.isclose(uvp2.get_nsamples((0, 1002001002, 'xx')), 3.0).all())
+        nt.assert_equal(uvp2.get_data((0, 1002001002, 'xx')).shape, (10, 30))
 
         # Test blpair averaging (with baseline-pair weights)
         # Results should be identical with different weights here, as the data
@@ -311,16 +314,16 @@ class Test_UVPSpec(unittest.TestCase):
                                    blpair_weights=blpair_wgts,
                                    inplace=False)
         #nt.assert_equal(uvp2.Nblpairs, 1)
-        nt.assert_true(np.isclose(uvp3a.get_data(0, 1002001002, 'xx'),
-                                  uvp3b.get_data(0, 1002001002, 'xx')).all())
-        #nt.assert_equal(uvp2.get_data(0, 1002001002, 'xx').shape, (10, 30))
+        nt.assert_true(np.isclose(uvp3a.get_data((0, 1002001002, 'xx')),
+                                  uvp3b.get_data((0, 1002001002, 'xx'))).all())
+        #nt.assert_equal(uvp2.get_data((0, 1002001002, 'xx')).shape, (10, 30))
 
 
         # test time averaging
         uvp2 = uvp.average_spectra(time_avg=True, inplace=False)
         nt.assert_true(uvp2.Ntimes, 1)
-        nt.assert_true(np.isclose(uvp2.get_nsamples(0, 1002001002, 'xx'), 10.0).all())
-        nt.assert_true(uvp2.get_data(0, 1002001002, 'xx').shape, (1, 30))
+        nt.assert_true(np.isclose(uvp2.get_nsamples((0, 1002001002, 'xx')), 10.0).all())
+        nt.assert_true(uvp2.get_data((0, 1002001002, 'xx')).shape, (1, 30))
         # ensure averaging works when multiple repeated baselines are present, but only
         # if time_avg = True
         uvp.blpair_array[uvp.blpair_to_indices(2003002003)] = 1002001002
@@ -345,8 +348,8 @@ class Test_UVPSpec(unittest.TestCase):
         bls = [(37, 38), (38, 39), (52, 53)]
         uvp1 = testing.uvpspec_from_data(uvd, bls, data_std=uvd_std, spw_ranges=[(0,17)], beam=beam)
         uvp1.fold_spectra()
-        cov_folded = uvp1.get_cov(0, ((37, 38), (38, 39)), 'xx')
-        data_folded = uvp1.get_data(0, ((37,38), (38, 39)), 'xx')
+        cov_folded = uvp1.get_cov((0, ((37, 38), (38, 39)), 'xx'))
+        data_folded = uvp1.get_data((0, ((37,38), (38, 39)), 'xx'))
 
 
     def test_str(self):

--- a/hera_pspec/utils.py
+++ b/hera_pspec/utils.py
@@ -828,6 +828,10 @@ def job_monitor(run_func, iterator, action_name, M=map, lf=None, maxiter=1, verb
     exit_codes = np.array(M(run_func, iterator))
     time = datetime.utcnow()
 
+    # check for len-0
+    if len(exit_codes) == 0:
+        raise ValueError("No output generated from run_func over iterator {}".format(iterator))
+
     # inspect for failures
     if np.all(exit_codes != 0):
         # everything failed, raise error

--- a/hera_pspec/utils.py
+++ b/hera_pspec/utils.py
@@ -552,8 +552,8 @@ def flatten(nested_list):
 
 
 def config_pspec_blpairs(uv_templates, pol_pairs, group_pairs, exclude_auto_bls=True, 
-                         exclude_permutations=True, bl_len_range=(0, 1e10), 
-                         bl_deg_range=(0, 180), xants=None, verbose=True):
+                        exclude_permutations=True, bl_len_range=(0, 1e10), bl_deg_range=(0, 180),
+                        xants=None, verbose=True):
     """
     Given a list of miriad file templates and selections for
     polarization and group labels, construct a master list of
@@ -754,3 +754,4 @@ def get_blvec_reds(blvecs, bl_error_tol=0):
     red_bl_tag = [red_bl_tag[i] for i in order]
 
     return red_bl_grp, red_bl_len, red_bl_ang, red_bl_tag
+

--- a/hera_pspec/utils.py
+++ b/hera_pspec/utils.py
@@ -844,9 +844,9 @@ def job_monitor(run_func, iterator, action_name, M=map, lf=None, maxiter=1, verb
 
     # print failures if they exist
     if len(failures) > 0:
-        log("\nSome {} jobs failed after {} tries:\n{}".format(action, maxiter, failures), f=lf, verbose=verbose)
+        log("\nSome {} jobs failed after {} tries:\n{}".format(action_name, maxiter, failures), f=lf, verbose=verbose)
     else:
-        log("\nAll {} jobs ran through".format(action), f=lf, verbose=verbose)
+        log("\nAll {} jobs ran through".format(action_name), f=lf, verbose=verbose)
 
     return failures
 

--- a/hera_pspec/utils.py
+++ b/hera_pspec/utils.py
@@ -552,8 +552,8 @@ def flatten(nested_list):
 
 
 def config_pspec_blpairs(uv_templates, pol_pairs, group_pairs, exclude_auto_bls=True, 
-                         exclude_permutations=True, bl_len_range=(0, 1e10), bl_deg_range=(0, 180),
-                         xants=None, verbose=True):
+                         exclude_permutations=True, bl_len_range=(0, 1e10), 
+                         bl_deg_range=(0, 180), xants=None, verbose=True):
     """
     Given a list of miriad file templates and selections for
     polarization and group labels, construct a master list of

--- a/hera_pspec/utils.py
+++ b/hera_pspec/utils.py
@@ -673,7 +673,7 @@ def config_pspec_blpairs(uv_templates, pol_pairs, group_pairs, exclude_auto_bls=
             if verbose:
                 print "pol_pair {} and group_pair {} not found in data files".format(pp, gp)
             continue
-        groupings[(gp, pp)] = blps
+        groupings[(tuple(gp), tuple(pp))] = blps
 
     return groupings
 

--- a/hera_pspec/utils.py
+++ b/hera_pspec/utils.py
@@ -673,7 +673,7 @@ def config_pspec_blpairs(uv_templates, pol_pairs, group_pairs, exclude_auto_bls=
             if verbose:
                 print "pol_pair {} and group_pair {} not found in data files".format(pp, gp)
             continue
-        groupings[tuple(zip(pp, gp))] = blps
+        groupings[(gp, pp)] = blps
 
     return groupings
 

--- a/hera_pspec/utils.py
+++ b/hera_pspec/utils.py
@@ -12,6 +12,7 @@ import os
 import aipy
 from collections import OrderedDict as odict
 from pyuvdata import utils as uvutils
+from pyuvdata import UVData
 
 
 def hash(w):
@@ -549,19 +550,14 @@ def flatten(nested_list):
     """
     return [item for sublist in nested_list for item in sublist]
 
+
 def config_pspec_blpairs(uv_templates, pol_pairs, group_pairs, exclude_auto_bls=True, 
-                         exclude_permutations=True, bl_len_range=(0, 1e10), bl_deg_range=(0, 180),
-                         xants=None, verbose=True):
+                         exclude_permutations=True, bl_len_range=(0, 1e10), 
+                         bl_deg_range=(0, 180), xants=None, verbose=True):
     """
     Given a list of miriad file templates and selections for
     polarization and group labels, construct a master list of
     blpair-group-pol pairs using utils.construct_reds().
-
-    Note: currently, each file to-be-searched for must contain a single
-    baseline type, and must have the baseline length and angle (ENU in meters)
-    in the filename separated by an underscore: 
-    e.g. "zen.{len:.0f}_{deg:.0f}.{pol}.{group}.HH.uv" There also must be only 
-    one underscore in the filename.
 
     A baseline-pair is formed by self-matching unique-files in the
     glob-parsed master list, and then string-formatting-in appropriate 
@@ -571,17 +567,50 @@ def config_pspec_blpairs(uv_templates, pol_pairs, group_pairs, exclude_auto_bls=
 
     Parameters
     ----------
+    uv_templates : list
+        List of glob-parseable string templates, each of which must have
+        a {pol} and {group} field.
 
+    pol_pairs : list
+        List of len-2 polarization tuples to use in forming cross spectra.
+        Ex: [('xx', 'xx'), ('yy', 'yy'), ...]
 
+    group_pairs : list
+        List of len-2 group tuples to use in forming cross spectra.
+        Ex: [('grp1', 'grp1'), ('grp2', 'grp2'), ...]
+
+    exclude_auto_bls : bool
+        If True, exclude all baselines paired with itself.
+
+    exclude_permutations : bool
+        If True, exclude baseline2_cross_baseline1 if
+        baseline1_cross_baseline2 exists.
+
+    bl_len_range : len-2 tuple
+        A len-2 integer tuple specifying the range of baseline lengths
+        (meters in ENU frame) to consider.
+
+    bl_deg_range : len-2 tuple
+        A len-2 integer tuple specifying the range of baseline angles
+        (degrees in ENU frame) to consider.
+
+    xants : list
+        A list of integer antenna numbers to exclude.
+
+    verbose : bool
+        If True, print feedback to stdout.
 
     Returns
     -------
-
+    groupings : dict
+        A dictionary holding pol and group pair (tuple) as keys
+        and a list of baseline-pairs as values.
     """
     # type check
     if isinstance(uv_templates, (str, np.str)):
         uv_templates = [uv_templates]
-    assert len(pol_pairs) == len(group_pairs), "len(pol_pairs) must equal len(group_pairs)"
+    assert len(pol_pairs) == len(group_pairs), "len(pol_pairs) must equal "\
+                                               "len(group_pairs)"
 
     # get unique pols and groups
     pols = sorted(set([item for sublist in pol_pairs for item in sublist]))
@@ -600,20 +629,16 @@ def config_pspec_blpairs(uv_templates, pol_pairs, group_pairs, exclude_auto_bls=
                     pol_grps.append((pol, group))
                 # insert into unique_files with {pol} and {group} re-inserted
                 for _file in files:
-                    _unique_file = _file.replace(".{pol}.".format(pol=pol), ".{pol}.").replace(".{group}.".format(group=group), ".{group}.")
+                    _unique_file = _file.replace(".{pol}.".format(pol=pol), 
+                        ".{pol}.").replace(".{group}.".format(group=group), ".{group}.")
                     if _unique_file not in unique_files:
                         unique_files.append(_unique_file)
     unique_files = sorted(unique_files)
 
-    # iterate over unique files and get their baseline length and angle
-    lens, angs = [], []
-    for uf in unique_files:
-        lens.append(float(uf.split('_')[0].split('.')[-1]))
-        angs.append(float(uf.split('_')[1].split('.')[0]))
-
     # use a single file from unique_files and a single pol-group combination to get antenna positions
     _file = unique_files[0].format(pol=pol_grps[0][0], group=pol_grps[0][1])
-    _, _, uvd = uvutils.get_miriad_antpos(_file)
+    uvd = UVData()
+    uvd.read_miriad_metadata(_file)
 
     # get baseline pairs
     (_bls1, _bls2, _, _, 
@@ -625,7 +650,7 @@ def config_pspec_blpairs(uv_templates, pol_pairs, group_pairs, exclude_auto_bls=
     if xants is not None:
         bls1, bls2 = [], []
         for bl1, bl2 in zip(_bls1, _bls2):
-            if bl1 not in xants and bl2 not in xants:
+            if bl1[0] not in xants and bl1[1] not in xants and bl2[0] not in xants and bl2[1] not in xants:
                 bls1.append(bl1)
                 bls2.append(bl2)
     else:
@@ -633,15 +658,15 @@ def config_pspec_blpairs(uv_templates, pol_pairs, group_pairs, exclude_auto_bls=
     blps = zip(bls1, bls2)
 
     # iterate over pol-group pairs that exist
-    keys = odict()
+    groupings = odict()
     for pp, gp in zip(pol_pairs, group_pairs):
         if (pp[0], gp[0]) not in pol_grps or (pp[1], gp[1]) not in pol_grps:
             if verbose:
                 print "pol_pair {} and group_pair {} not found in data files".format(pp, gp)
             continue
-        keys[(pp, gp)] = blps
+        groupings[tuple(zip(pp, gp))] = blps
 
-    return keys
+    return groupings
 
 
 

--- a/hera_pspec/utils.py
+++ b/hera_pspec/utils.py
@@ -559,6 +559,14 @@ def config_pspec_blpairs(uv_templates, pol_pairs, group_pairs, exclude_auto_bls=
     polarization and group labels, construct a master list of
     blpair-group-pol pairs using utils.construct_reds().
 
+    A group is a fieldname in the visibility files that denotes the
+    "type" of dataset. For example, the group field in the following files
+        zen.even.LST.1.01.xx.HH.uv
+        zen.odd.LST.1.01.xx.HH.uv
+    are the "even" and "odd" field, and specifies the two time binning groups.
+    To form cross spectra between these two files, one would feed a group_pair
+    of: group_pairs = [('even', 'odd'), ...].
+
     A baseline-pair is formed by self-matching unique-files in the
     glob-parsed master list, and then string-formatting-in appropriate 
     pol and group selections given pol_pairs and group_pairs. Those two
@@ -577,6 +585,7 @@ def config_pspec_blpairs(uv_templates, pol_pairs, group_pairs, exclude_auto_bls=
 
     group_pairs : list
         List of len-2 group tuples to use in forming cross spectra.
+        See top of doc-string for an explanation of a "group" in this context.
         Ex: [('grp1', 'grp1'), ('grp2', 'grp2'), ...]
 
     exclude_auto_bls : bool

--- a/hera_pspec/utils.py
+++ b/hera_pspec/utils.py
@@ -678,10 +678,11 @@ def config_pspec_blpairs(uv_templates, pol_pairs, group_pairs, exclude_auto_bls=
     return groupings
 
 
-def get_blvec_reds(blvecs, bl_error_tol=0):
+def get_blvec_reds(blvecs, bl_error_tol=1.0):
     """
     Given a blvecs dictionary, form groups of baseline-pair objects based on
-    redundancy in ENU coordinates.
+    redundancy in ENU coordinates. Note: this only uses the East-North components
+    of the baseline vectors to calculate redundancy.
 
     Parameters:
     -----------

--- a/hera_pspec/utils.py
+++ b/hera_pspec/utils.py
@@ -552,8 +552,8 @@ def flatten(nested_list):
 
 
 def config_pspec_blpairs(uv_templates, pol_pairs, group_pairs, exclude_auto_bls=True, 
-                        exclude_permutations=True, bl_len_range=(0, 1e10), bl_deg_range=(0, 180),
-                        xants=None, verbose=True):
+                         exclude_permutations=True, bl_len_range=(0, 1e10), bl_deg_range=(0, 180),
+                         xants=None, verbose=True):
     """
     Given a list of miriad file templates and selections for
     polarization and group labels, construct a master list of

--- a/hera_pspec/uvpspec.py
+++ b/hera_pspec/uvpspec.py
@@ -1847,19 +1847,13 @@ def combine_uvpspec(uvps, verbose=True):
 
     elif concat_ax == 'blpairts':
 
-        # Get mapping of blpair-time indices between old UVPSpec objects and 
-        # the new one
-        blpts_idxs = np.concatenate(
-                        [uvputils._fast_lookup_blpairts(_blpts, new_blpts)
-                         for _blpts in uvp_blpts] )
-
         is_in = [uvputils._fast_is_in(_blpts, new_blpts)
                  for _blpts in uvp_blpts]
 
         # Concatenate blpair-times
         for j, blpt in enumerate(new_blpts):
             l = [isn[j] for isn in is_in].index(True)
-            n = blpts_idxs[j]
+            n = uvp_blpts[l].index(blpt)
 
             # Loop over spectral windows
             for i, spw in enumerate(new_spws):

--- a/hera_pspec/uvpspec.py
+++ b/hera_pspec/uvpspec.py
@@ -128,6 +128,7 @@ class UVPSpec(object):
                             "OmegaP", "OmegaPP", "label_1_array",
                             "label_2_array"]
         self._meta_attrs = sorted(set(self._all_params) - set(self._dicts) - set(self._meta_dsets) - set(self._dicts_of_dicts))
+
         self._meta = sorted(set(self._meta_dsets).union(set(self._meta_attrs)))
 
         # check all params are covered
@@ -956,7 +957,6 @@ class UVPSpec(object):
 
         self.check(just_meta=just_meta)
 
-
     def read_hdf5(self, filepath, just_meta=False, spws=None, bls=None,
                   blpairs=None, times=None, pols=None,
                   only_pairs_in_bls=False):
@@ -1036,23 +1036,24 @@ class UVPSpec(object):
                 group.create_dataset(k, data=getattr(self, k))
 
         # Iterate over spectral windows and create datasets
+        store_cov = hasattr(self, 'cov_array')
         for i in np.unique(self.spw_array):
             group.create_dataset("data_spw{}".format(i),
                                  data=self.data_array[i],
-                                 dtype=np.complex)
+                                 dtype=np.complex128)
             group.create_dataset("wgt_spw{}".format(i),
                                  data=self.wgt_array[i],
-                                 dtype=np.float)
+                                 dtype=np.float64)
             group.create_dataset("integration_spw{}".format(i),
                                  data=self.integration_array[i],
-                                 dtype=np.float)
+                                 dtype=np.float64)
             group.create_dataset("nsample_spw{}".format(i),
                                  data=self.nsample_array[i],
                                  dtype=np.float)
             if hasattr(self, "cov_array"):
                 group.create_dataset("cov_spw{}".format(i),
                                      data=self.cov_array[i],
-                                     dtype=np.complex)
+                                     dtype=np.complex128)
 
         # Store any statistics arrays
         if hasattr(self, "stats_array"):
@@ -1762,7 +1763,7 @@ def combine_uvpspec(uvps, verbose=True):
                     u.label_1_array[i,j,k] = u_lbls[uvps[l].labels[lbl1]]
                     u.label_2_array[i,j,k] = u_lbls[uvps[l].labels[lbl2]]
                     if store_cov:
-                      u.cov_array[i][j, :, :, k]=uvps[l].cov_array[m][n, :, :, q]
+                      u.cov_array[i][j, :, :, k] = uvps[l].cov_array[m][n, :, :, q]
         # Populate new LST, time, and blpair arrays
         for j, blpt in enumerate(new_blpts):
             n = blpts_idxs0[j]
@@ -1801,7 +1802,7 @@ def combine_uvpspec(uvps, verbose=True):
 
                     u.data_array[i][j,:,k] = uvps[l].data_array[m][n,:,q]
                     if store_cov:
-                        u.cov_array[i][j, :, :, k]=uvps[l].cov_array[m][n, :, :, q]
+                        u.cov_array[i][j, :, :, k] = uvps[l].cov_array[m][n, :, :, q]
                     u.wgt_array[i][j,:,:,k] = uvps[l].wgt_array[m][n,:,:,q]
                     u.integration_array[i][j,k] = uvps[l].integration_array[m][n,q]
                     u.nsample_array[i][j,k] = uvps[l].integration_array[m][n,q]

--- a/hera_pspec/uvpspec.py
+++ b/hera_pspec/uvpspec.py
@@ -924,6 +924,10 @@ class UVPSpec(object):
             If True, keep only baseline-pairs whose first _and_ second baseline
             are found in the 'bls' list. Default: False.
         """
+        # Make sure the group is a UVPSpec object
+        assert 'pspec_type' in grp.attrs, "This object is not a UVPSpec object"
+        assert grp.attrs['pspec_type'] == 'UVPSpec', "This object is not a UVPSpec object"
+        
         # Clear all data in the current object
         self._clear()
 
@@ -1057,7 +1061,9 @@ class UVPSpec(object):
                 for i in np.unique(self.spw_array):
                     group.create_dataset("stats_{}_{}".format(s, i),
                                          data=data[i], dtype=data[i].dtype)
-
+    
+        # denote as a uvpspec object
+        group.attrs['pspec_type'] = group.__class__.__name__
 
     def write_hdf5(self, filepath, overwrite=False, run_check=True):
         """

--- a/hera_pspec/uvpspec.py
+++ b/hera_pspec/uvpspec.py
@@ -93,7 +93,7 @@ class UVPSpec(object):
 
         # Specify required params: these are required for read / write and
         # self.check()
-        self._req_params = ["Ntimes", "Nblpairts", "Nblpairs", "Nspwdlys",
+        self._req_params = ["Ntimes", "Nblpairts", "Nblpairs",
                             "Nspws", "Ndlys", "Npols", "Nfreqs", "history",
                             "Nspwdlys", "Nspwfreqs",
                             "data_array", "wgt_array", "integration_array",
@@ -110,7 +110,7 @@ class UVPSpec(object):
         # All parameters must fall into one and only one of the following
         # groups, which are used in __eq__
         self._immutables = ["Ntimes", "Nblpairts", "Nblpairs", "Nspwdlys",
-                            "Nspws", "Ndlys", "Npols", "Nfreqs", "history",
+                            "Nspwfreqs", "Nspws", "Ndlys", "Npols", "Nfreqs", "history",
                             "Nbls", "channel_width", "weighting", "vis_units",
                             "norm", "norm_units", "taper", "cosmo", "beamfile",
                             'folded']
@@ -120,7 +120,7 @@ class UVPSpec(object):
                           "blpair_array", "OmegaP", "OmegaPP", "beam_freqs",
                           "bl_vecs", "bl_array", "telescope_location",
                           "scalar_array", "labels", "label_1_array",
-                          "label_2_array"]
+                          "label_2_array", "spw_freq_array", "spw_dly_array"]
         self._dicts = ["data_array", "wgt_array", "integration_array",
                        "nsample_array", "cov_array"]
         self._dicts_of_dicts = ["stats_array"]

--- a/hera_pspec/uvpspec.py
+++ b/hera_pspec/uvpspec.py
@@ -1882,6 +1882,10 @@ def combine_uvpspec(uvps, verbose=True):
                     u.label_1_array[i, j, k] = u_lbls[uvps[l].labels[lbl1]]
                     u.label_2_array[i, j, k] = u_lbls[uvps[l].labels[lbl2]]
             
+                    # scalar array, only do once per spw and pol
+                    if j == 0:
+                        u.scalar_array[i, k] = uvps[l].scalar_array[m, q]
+
             # Populate new LST, time, and blpair arrays
             u.time_1_array[j] = uvps[l].time_1_array[n]
             u.time_2_array[j] = uvps[l].time_2_array[n]

--- a/hera_pspec/uvpspec.py
+++ b/hera_pspec/uvpspec.py
@@ -884,7 +884,6 @@ class UVPSpec(object):
                         (self.bl_vecs + self.telescope_location).T, \
                         *uvutils.LatLonAlt_from_XYZ(self.telescope_location)).T
 
-
     def read_from_group(self, grp, just_meta=False, spws=None, bls=None,
                         blpairs=None, times=None, pols=None,
                         only_pairs_in_bls=False):
@@ -1064,7 +1063,7 @@ class UVPSpec(object):
                                          data=data[i], dtype=data[i].dtype)
     
         # denote as a uvpspec object
-        group.attrs['pspec_type'] = group.__class__.__name__
+        group.attrs['pspec_type'] = self.__class__.__name__
 
     def write_hdf5(self, filepath, overwrite=False, run_check=True):
         """
@@ -1091,7 +1090,6 @@ class UVPSpec(object):
         # Write file
         with h5py.File(filepath, 'w') as f:
             self.write_to_group(f, run_check=run_check)
-
 
     def set_cosmology(self, new_cosmo, overwrite=False, new_beam=None,
                       verbose=True):

--- a/hera_pspec/uvpspec_utils.py
+++ b/hera_pspec/uvpspec_utils.py
@@ -1,4 +1,3 @@
-
 import numpy as np
 import copy, operator
 from collections import OrderedDict as odict
@@ -44,7 +43,8 @@ def _get_blpairs_from_bls(uvp, bls, only_pairs_in_bls=False):
     return blp_select
 
 
-def _select(uvp, spws=None, bls=None, only_pairs_in_bls=False, blpairs=None, times=None, pols=None, h5file=None):
+def _select(uvp, spws=None, bls=None, only_pairs_in_bls=False, blpairs=None, times=None,
+            pols=None, h5file=None):
 
     """
     Select function for selecting out certain slices of the data, as well as loading in data from HDF5 file.
@@ -162,8 +162,7 @@ def _select(uvp, spws=None, bls=None, only_pairs_in_bls=False, blpairs=None, tim
         ints = odict()
         nsmp = odict()
         cov = odict()
-        store_cov = hasattr(uvp, 'cov_array')
-
+        store_cov = 'cov_spw0' in h5file
         for s in np.unique(uvp.spw_array):
             if h5file is not None:
                 data[s] = h5file['data_spw{}'.format(s)][blp_select, :, pol_select]

--- a/hera_pspec/uvpspec_utils.py
+++ b/hera_pspec/uvpspec_utils.py
@@ -216,6 +216,7 @@ def _select(uvp, spws=None, bls=None, only_pairs_in_bls=False, blpairs=None, tim
         # load meta-data
         pass
 
+
 def _blpair_to_antnums(blpair):
     """
     Convert baseline-pair integer to nested tuple of antenna numbers.

--- a/hera_pspec/uvpspec_utils.py
+++ b/hera_pspec/uvpspec_utils.py
@@ -162,7 +162,10 @@ def _select(uvp, spws=None, bls=None, only_pairs_in_bls=False, blpairs=None, tim
         ints = odict()
         nsmp = odict()
         cov = odict()
-        store_cov = 'cov_spw0' in h5file
+        if h5file is not None:
+            store_cov = 'cov_spw0' in h5file
+        else:
+            store_cov = hasattr(uvp, 'cov_array')
         for s in np.unique(uvp.spw_array):
             if h5file is not None:
                 data[s] = h5file['data_spw{}'.format(s)][blp_select, :, pol_select]

--- a/pipelines/idr2_preprocessing/preprocess_data.py
+++ b/pipelines/idr2_preprocessing/preprocess_data.py
@@ -18,6 +18,7 @@ import numpy as np
 import hera_cal as hc
 import hera_pspec as hp
 import hera_qm as hq
+import pyuvdata
 from pyuvdata import UVData
 import pyuvdata.utils as uvutils
 import os
@@ -30,6 +31,8 @@ import json
 import itertools
 import aipy
 import shutil
+from collections import OrderedDict as odict
+
 
 #-------------------------------------------------------------------------------
 # Parse YAML Configuration File
@@ -38,92 +41,95 @@ import shutil
 config = sys.argv[1]
 cf = hp.utils.load_config(config)
 
-# update globals with IO params, data and analysis params
-globals().update(cf['io'])
-globals().update(cf['data'])
-globals().update(cf['analysis'])
+# consolidate IO, data and analysis parameter dictionaries
+params = odict(cf['io'].items() + cf['data'].items() + cf['analysis'].items())
+assert len(params) == len(cf['io']) + len(cf['data']) + len(cf['analysis']), ""\
+       "Repeated parameters found within the scope of io, data and analysis dicts"
+algs = cf['algorithm']
 
-# get common suffix
-data_suffix = os.path.splitext(input_data_template)[1][1:]
+# extract certain parameters used across the script
+verbose = params['verbose']
+overwrite = params['overwrite']
+pols = params['pols']
+data_template = params['data_template']
+data_suffix = os.path.splitext(data_template)[1][1:]
 
 # open logfile
-logfile = os.path.join(out_dir, logfile)
-if os.path.exists(logfile) and overwrite == False:
+logfile = os.path.join(params['out_dir'], params['logfile'])
+if os.path.exists(logfile) and params['overwrite'] == False:
     raise IOError("logfile {} exists and overwrite == False, quitting pipeline...".format(logfile))
 lf = open(logfile, "w")
-if joinlog:
+if params['joinlog']:
     ef = lf
 else:
-    ef = open(os.path.join(out_dir, errfile), "w")
+    ef = open(os.path.join(params['out_dir'], params['errfile']), "w")
 time = datetime.utcnow()
 hp.utils.log("Starting preprocess pipeline on {}\n{}\n".format(time, '-'*60), f=lf, verbose=verbose)
 hp.utils.log(json.dumps(cf, indent=1) + '\n', f=lf, verbose=verbose)
 
-# Create multiprocesses
-if multiproc:
-    pool = multiprocess.Pool(nproc)
+# change to working dir
+os.chdir(params['work_dir'])
+
+# define history prepend function
+def prepend_history(action, param_dict):
+    """ create a history string to prepend to data files """
+    dict_str = '\n'.join(["{} : {}".format(*_d) for _d in param_dict.items()])
+    time = datetime.utcnow()
+    hist = "\nRan preprocess_data.py {} step at\nUTC {} with \nhera_pspec [{}], "\
+           "hera_cal [{}],\nhera_qm [{}] and pyuvdata [{}]\nwith {} algorithm "\
+           "attrs:\n{}\n{}\n".format(action, time, hp.version.git_hash[:10],
+                                     hc.version.git_hash[:10], hq.version.git_hash[:10], 
+                                     pyuvdata.version.git_hash[:10], action, '-'*50, dict_str)
+    return hist
+
+# assign iterator function
+if params['multiproc']:
+    pool = multiprocess.Pool(params['nproc'])
     M = pool.map
 else:
     M = map
 
-# change to working dir
-os.chdir(work_dir)
-
 #-------------------------------------------------------------------------------
 # Reformat Data by Baseline Type
 #-------------------------------------------------------------------------------
-if reformat:
-    # get algorithm parameters
-    globals().update(cf['algorithm']['reformat'])
+if params['reformat']:
+    # start block
     time = datetime.utcnow()
     hp.utils.log("\n{}\nstarting baseline reformatting: {}\n".format("-"*60, time), f=lf, verbose=verbose)
 
     # get datafiles
-    datafiles, datapols = uvt.utils.search_data(input_data_template.format(group=groupname), pols, matched_pols=False, reverse_nesting=False, flatten=False)
+    datafiles, datapols = uvt.utils.search_data(data_template.format(group=params['groupname']), pols, matched_pols=False, reverse_nesting=False, flatten=False)
 
-    # choose first file and get all red baseline groups and their info
-    uvd = UVData()
-    uvd.read_miriad(datafiles[0][0])
-    antpos, ants = uvd.get_ENU_antpos()
-    antposd = dict(zip(ants, antpos))
-    reds = hc.redcal.get_pos_reds(antposd, bl_error_tol=bltol, low_hi=True)
-    blvs = [(antposd[r[0][0]] - antposd[r[0][1]])[:2] for r in reds]
-    lens = [np.linalg.norm(blv) for blv in blvs]
-    angs = [np.arctan2(*blv[::-1]) * 180 / np.pi for blv in blvs]
-    for i in range(len(angs)):
-        if angs[i] < 0:
-            angs[i] = (angs[i] + 180) % 360
-
-    # put in autocorrs
-    reds = [zip(uvd.antenna_numbers, uvd.antenna_numbers)] + reds
-    lens = [0] + lens
-    angs = [0] + angs
+    # get redundant groups as a good split for parallelization
+    reds, lens, angs = hp.utils.get_reds(datafiles[0][0], bl_error_tol=1.0, add_autos=True,
+                                         bl_len_range=params['bl_len_range'], bl_deg_range=params['bl_deg_range'])
 
     # iterate over polarization group
     for i, dfs in enumerate(datafiles):
 
         # setup bl reformat function
-        def bl_reformat(j, i=i, datapols=datapols, dfs=dfs, lens=lens, angs=angs, reds=reds, data_suffix=data_suffix, p=cf['algorithm']['reformat']):
+        def bl_reformat(j, i=i, datapols=datapols, dfs=dfs, lens=lens, angs=angs, reds=reds, data_suffix=data_suffix, p=algs['reformat'], params=params):
             try:
                 if not p['bl_len_range'][0] < lens[j] < p['bl_len_range'][1]:
                     return 0
                 outname = p['reformat_outfile'].format(len=int(round(lens[j])), deg=int(round(angs[j])), pol=datapols[i][0], suffix=data_suffix)
-                outname = os.path.join(out_dir, outname)
+                outname = os.path.join(params['out_dir'], outname)
                 if os.path.exists(outname) and overwrite == False:
                     return 1
                 uvd = UVData()
                 uvd.read_miriad(dfs, bls=reds[j])
                 uvd.write_miriad(outname, clobber=True)
+                uvd.history = "{}{}".format(prepend_history("BL REFORMAT", p), uvd.history)
             except:
                 hp.utils.log("\njob {} threw exception:".format(j), f=ef, tb=sys.exc_info(), verbose=verbose)
                 return 1
             return 0
 
         # launch jobs
-        failures = hp.utils.job_monitor(bl_reformat, range(len(reds)), "BL REFORMAT: pol {}".format(pol), M=M, lf=lf, maxiter=maxiter, verbose=verbose)
+        failures = hp.utils.job_monitor(bl_reformat, range(len(reds)), "BL REFORMAT: pol {}".format(pol), M=M, lf=lf, maxiter=params['maxiter'], verbose=verbose)
 
     # edit data template
-    input_data_template = os.path.join(out_dir, new_data_template.format(pol='{pol}', suffix=data_suffix))
+    data_template = os.path.join(params['out_dir'], algs['reformat']['new_data_template'].format(pol='{pol}', suffix=data_suffix))
 
     time = datetime.utcnow()
     hp.utils.log("\nfinished baseline reformatting: {}\n{}".format(time, "-"*60), f=lf, verbose=verbose)
@@ -131,17 +137,16 @@ if reformat:
 #-------------------------------------------------------------------------------
 # RFI-Flag
 #-------------------------------------------------------------------------------
-if rfi_flag:
-    # get algorithm parameters
-    globals().update(cf['algorithm']['xrfi'])
+if params['rfi_flag']:
+    # start block
     time = datetime.utcnow()
     hp.utils.log("\n{}\nstarting RFI flagging: {}\n".format("-"*60, time), f=lf, verbose=verbose)
 
     # get datafiles
-    datafiles, datapols = uvt.utils.search_data(input_data_template.format(group=groupname), pols, matched_pols=False, reverse_nesting=False, flatten=True)
+    datafiles, datapols = uvt.utils.search_data(data_template.format(group=params['groupname']), pols, matched_pols=False, reverse_nesting=False, flatten=True)
 
     # setup RFI function
-    def run_xrfi(i, datafiles=datafiles, p=cf['algorithm']['xrfi']):
+    def run_xrfi(i, datafiles=datafiles, p=cf['algorithm']['xrfi'], params=params):
         try:
             # setup delay filter class as container
             df = datafiles[i]
@@ -154,22 +159,22 @@ if rfi_flag:
                     new_f = hq.xrfi.xrfi(F.data[k], f=F.flags[k], **p['xrfi_params'])
                     F.flags[k] += new_f
             # write to file
-            outname = os.path.join(out_dir, os.path.basename(df) + p['file_ext'])
+            add_to_history = prepend_history("XRFI", p)
+            outname = os.path.join(params['out_dir'], os.path.basename(df) + p['file_ext'])
             hc.io.update_vis(df, outname, filetype_in='miriad', filetype_out='miriad', data=F.data, flags=F.flags,
-                             add_to_history='', clobber=overwrite)
+                             add_to_history=add_to_history, clobber=overwrite)
 
         except:
             hp.utils.log("\njob {} threw exception:".format(i), f=ef, tb=sys.exc_info(), verbose=verbose)
             return 1
-
         return 0
 
     # launch jobs
-    failures = hp.utils.job_monitor(run_xrfi, range(len(datafiles)), "XRFI", M=M, lf=lf, maxiter=maxiter, verbose=verbose)
+    failures = hp.utils.job_monitor(run_xrfi, range(len(datafiles)), "XRFI", M=M, lf=lf, maxiter=params['maxiter'], verbose=verbose)
 
     # update template
-    input_data_template = os.path.join(out_dir, os.path.basename(input_data_template) + file_ext)
-    data_suffix += file_ext
+    data_template = os.path.join(params['out_dir'], os.path.basename(data_template) + algs['rfi_flag']['file_ext'])
+    data_suffix += algs['rfi_flag']['file_ext']
 
     time = datetime.utcnow()
     hp.utils.log("\nfinished RFI flagging: {}\n{}".format(time, "-"*60), f=lf, verbose=verbose)
@@ -177,25 +182,24 @@ if rfi_flag:
 #-------------------------------------------------------------------------------
 # Time Average Subtraction
 #-------------------------------------------------------------------------------
-if timeavg_sub:
-    # get algorithm parameters
-    globals().update(cf['algorithm']['timeavg_sub'])
+if params['timeavg_sub']:
+    # start block
     time = datetime.utcnow()
     hp.utils.log("\n{}\nstarting full time-average spectra and subtraction: {}\n".format("-"*60, time), f=lf, verbose=verbose)
 
     # get datafiles
-    datafiles, datapols = uvt.utils.search_data(input_data_template.format(group=groupname, pol='{pol}'), pols, matched_pols=False, reverse_nesting=False, flatten=False)
+    datafiles, datapols = uvt.utils.search_data(data_template.format(group=params['groupname'], pol='{pol}'), pols, matched_pols=False, reverse_nesting=False, flatten=False)
 
     # get redundant groups as a good split for parallelization
     reds, lens, angs = hp.utils.get_reds(datafiles[0][0], bl_error_tol=1.0, add_autos=True,
-                                         bl_len_range=bl_len_range, bl_deg_range=bl_deg_range)
+                                         bl_len_range=params['bl_len_range'], bl_deg_range=params['bl_deg_range'])
 
     # iterate over pols
     for i, dfs in enumerate(datafiles):
         pol = datapols[i][0]
 
         # write full tavg function
-        def full_tavg(j, pol=pol, lens=lens, angs=angs, reds=reds, dfs=dfs, data_suffix=data_suffix, p=cf['algorithm']['timeavg_sub']):
+        def full_tavg(j, pol=pol, lens=lens, angs=angs, reds=reds, dfs=dfs, data_suffix=data_suffix, p=algs['timeavg_sub'], params=params):
             try:
                 # load data into uvdata
                 uvd = UVData()
@@ -234,30 +238,30 @@ if timeavg_sub:
                 # write timeavg specctrum
                 _len = lens[j]
                 _deg = angs[j]
-                tavg_file = "zen.{group}.{pol}.{len:03d}_{deg:03d}.{tavg_tag}.{suffix}".format(group=groupname, pol=pol, len=int(_len), deg=int(_deg), tavg_tag=p['tavg_tag'], suffix=data_suffix)
-                tavg_file = os.path.join(out_dir, tavg_file)
-                F.write_data(tavg_file, write_avg=True, overwrite=overwrite)
+                tavg_file = "zen.{group}.{pol}.{len:03d}_{deg:03d}.{tavg_tag}.{suffix}".format(group=params['groupname'], pol=pol, len=int(_len), deg=int(_deg), tavg_tag=p['tavg_tag'], suffix=data_suffix)
+                tavg_file = os.path.join(params['out_dir'], tavg_file)
+                add_to_history = prepend_history("FULL TIME AVG", p)
+                F.write_data(tavg_file, write_avg=True, overwrite=overwrite, add_to_history=add_to_history)
             except:
                 hp.utils.log("\njob {} threw exception:".format(j), f=ef, tb=sys.exc_info(), verbose=verbose)
                 return 1
-
             return 0
 
         # launch jobs
-        failures = hp.utils.job_monitor(full_tavg, range(len(reds)), "FULL TAVG: pol {}".format(pol), M=M, lf=lf, maxiter=maxiter, verbose=verbose)
+        failures = hp.utils.job_monitor(full_tavg, range(len(reds)), "FULL TAVG: pol {}".format(pol), M=M, lf=lf, maxiter=params['maxiter'], verbose=verbose)
 
         # collate tavg spectra into a single file
-        tavgfiles = sorted(glob.glob(os.path.join(out_dir, "zen.{group}.{pol}.*.{tavg_tag}.{suffix}".format(group=groupname, pol=pol, tavg_tag=tavg_tag, suffix=data_suffix))))
+        tavgfiles = sorted(glob.glob(os.path.join(params['out_dir'], "zen.{group}.{pol}.*.{tavg_tag}.{suffix}".format(group=params['groupname'], pol=pol, tavg_tag=algs['timeavg_sub']['tavg_tag'], suffix=data_suffix))))
         uvd = UVData()
         uvd.read_miriad(tavgfiles[::-1])
-        tavg_out = os.path.join(out_dir, "zen.{group}.{pol}.{tavg_tag}.{suffix}".format(group=groupname, pol=pol, tavg_tag=tavg_tag, suffix=data_suffix))
+        tavg_out = os.path.join(params['out_dir'], "zen.{group}.{pol}.{tavg_tag}.{suffix}".format(group=params['groupname'], pol=pol, tavg_tag=algs['timeavg_sub']['tavg_tag'], suffix=data_suffix))
         uvd.write_miriad(tavg_out, clobber=overwrite)
         for tf in tavgfiles:
             if os.path.exists(tf):
                 shutil.rmtree(tf)
 
         # write tavg subtraction function
-        def tavg_sub(j, dfs=dfs, pol=pol, tavg_file=tavg_out, p=cf['algorithm']['timeavg_sub']):
+        def tavg_sub(j, dfs=dfs, pol=pol, tavg_file=tavg_out, p=cf['algorithm']['timeavg_sub'], params=params):
             try:
                 # load data file
                 uvd = UVData()
@@ -282,45 +286,43 @@ if timeavg_sub:
                 if not uvd.extra_keywords.has_key('uniq_bls'):
                     uvd.extra_keywords['uniq_bls'] = json.dumps(np.unique(uvd.baseline_array).tolist())
                 # write tavg-subtracted data
-                out_df = os.path.join(out_dir, os.path.basename(df) + p['file_ext'])
-                uvd.history += "\nTime-Average subtracted."
+                out_df = os.path.join(params['out_dir'], os.path.basename(df) + p['file_ext'])
+                uvd.history = "{}{}".format(prepend_history("TAVG SUB", p), uvd.history)
                 uvd.write_miriad(out_df, clobber=overwrite)
             except:
                 hp.utils.log("\njob {} threw exception:".format(i), f=ef, tb=sys.exc_info(), verbose=verbose)
                 return 1
-
             return 0
 
         # launch jobs
-        failures = hp.utils.job_monitor(tavg_sub, range(len(dfs)), "TAVG SUB: pol {}".format(pol), M=M, lf=lf, maxiter=maxiter, verbose=verbose)
+        failures = hp.utils.job_monitor(tavg_sub, range(len(dfs)), "TAVG SUB: pol {}".format(pol), M=M, lf=lf, maxiter=params['maxiter'], verbose=verbose)
 
     time = datetime.utcnow()
     hp.utils.log("\nfinished full time-average spectra and subtraction: {}\n{}".format(time, "-"*60), f=lf, verbose=verbose)
 
-    input_data_template = os.path.join(out_dir, os.path.basename(input_data_template) + file_ext)
-    data_suffix += file_ext
+    data_template = os.path.join(params['out_dir'], os.path.basename(data_template) + algs['timeavg_sub']['file_ext'])
+    data_suffix += algs['timeavg_sub']['file_ext']
 
 #-------------------------------------------------------------------------------
 # Time Averaging (i.e. Fringe Rate Filtering)
 #-------------------------------------------------------------------------------
-if time_avg:
-    # get algorithm parameters
-    globals().update(cf['algorithm']['tavg'])
+if params['time_avg']:
+    # start block
     time = datetime.utcnow()
     hp.utils.log("\n{}\nstarting time averaging: {}\n".format("-"*60, time), f=lf, verbose=verbose)
 
     # get datafiles
-    datafiles, datapols = uvt.utils.search_data(input_data_template.format(group=groupname, pol='{pol}'), pols, matched_pols=False, reverse_nesting=False, flatten=False)
+    datafiles, datapols = uvt.utils.search_data(data_template.format(group=params['groupname'], pol='{pol}'), pols, matched_pols=False, reverse_nesting=False, flatten=False)
 
     # get redundant groups as a good split for parallelization
     reds, lens, angs = hp.utils.get_reds(datafiles[0][0], bl_error_tol=1.0, add_autos=True,
-                                         bl_len_range=bl_len_range, bl_deg_range=bl_deg_range)
+                                         bl_len_range=params['bl_len_range'], bl_deg_range=params['bl_deg_range'])
 
     # iterate over pol groups
     for i, dfs in enumerate(datafiles):
         pol = datapols[i][0]
 
-        def time_average(j, dfs=dfs, pol=pol, lens=lens, angs=angs, reds=reds, data_suffix=data_suffix, p=cf['algorithm']['tavg']):
+        def time_average(j, dfs=dfs, pol=pol, lens=lens, angs=angs, reds=reds, data_suffix=data_suffix, p=cf['algorithm']['tavg'], params=params):
             try:
                 # load data into uvdata
                 uvd = UVData()
@@ -339,20 +341,20 @@ if time_avg:
                 # write timeavg spectrum
                 _len = lens[j]
                 _deg = angs[j]
-                tavg_file = "zen.{group}.{pol}.{len:03d}_{deg:03d}.{suffix}".format(group=groupname, pol=pol, len=int(_len), deg=int(_deg), suffix=data_suffix)
-                tavg_file = os.path.join(out_dir, tavg_file + p['file_ext'])
-                F.write_data(tavg_file, write_avg=True, overwrite=overwrite)
+                tavg_file = "zen.{group}.{pol}.{len:03d}_{deg:03d}.{suffix}".format(group=params['groupname'], pol=pol, len=int(_len), deg=int(_deg), suffix=data_suffix)
+                tavg_file = os.path.join(params['out_dir'], tavg_file + p['file_ext'])
+                add_to_history = prepend_history("TIME AVERAGE", p)
+                F.write_data(tavg_file, write_avg=True, overwrite=overwrite, add_to_history=add_to_history)
             except:
                 hp.utils.log("\njob {} threw exception:".format(j), f=ef, tb=sys.exc_info(), verbose=verbose)
                 return 1
-
             return 0
 
         # launch jobs
-        failures = hp.utils.job_monitor(time_average, range(len(reds)), "TIME AVERAGE: pol {}".format(pol), M=M, lf=lf, maxiter=maxiter, verbose=verbose)
+        failures = hp.utils.job_monitor(time_average, range(len(reds)), "TIME AVERAGE: pol {}".format(pol), M=M, lf=lf, maxiter=params['maxiter'], verbose=verbose)
 
         # collate averaged data into time chunks
-        tavg_files = os.path.join(out_dir, "zen.{group}.{pol}.*.{suffix}".format(group=groupname, pol=pol, suffix=data_suffix + file_ext))
+        tavg_files = os.path.join(params['out_dir'], "zen.{group}.{pol}.*.{suffix}".format(group=params['groupname'], pol=pol, suffix=data_suffix + algs['tavg']['file_ext']))
         tavg_files = sorted(glob.glob(tavg_files))
         assert len(tavg_files) > 0, "len(tavg_files) == 0"
 
@@ -363,15 +365,15 @@ if time_avg:
         Ntimes = len(times)
 
         # break into subfiles
-        Nfiles = int(np.ceil(Ntimes / float(file_Ntimes)))
-        times = [times[i*file_Ntimes:(i+1)*file_Ntimes] for i in range(Nfiles)]
+        Nfiles = int(np.ceil(Ntimes / float(algs['tavg']['file_Ntimes'])))
+        times = [times[i*algs['tavg']['file_Ntimes']:(i+1)*algs['tavg']['file_Ntimes']] for i in range(Nfiles)]
 
-        def reformat_files(j, pol=pol, tavg_files=tavg_files, times=times, data_suffix=data_suffix, p=cf['algorithm']['tavg']):
+        def reformat_files(j, pol=pol, tavg_files=tavg_files, times=times, data_suffix=data_suffix, p=cf['algorithm']['tavg'], params=params):
             try:
                 uvd = UVData()
                 uvd.read_miriad(tavg_files[::-1], time_range=[times[j].min()-1e-8, times[j].max()+1e-8], polarizations=[pol])
-                lst = uvd.lst_array[0]
-                outfile = os.path.join(out_dir, "zen.{group}.{pol}.LST.{LST:.5f}.{suffix}".format(group=groupname, pol=pol, LST=lst, suffix=data_suffix + p['file_ext']))
+                lst = uvd.lst_array[0] - uvd.integration_time / 2.0 * 2 * np.pi / (3600. * 24)
+                outfile = os.path.join(params['out_dir'], "zen.{group}.{pol}.LST.{LST:.5f}.{suffix}".format(group=params['groupname'], pol=pol, LST=lst, suffix=data_suffix + p['file_ext']))
                 uvd.write_miriad(outfile, clobber=overwrite)
             except:
                 hp.utils.log("\njob {} threw exception:".format(j), f=ef, tb=sys.exc_info(), verbose=verbose)
@@ -380,15 +382,15 @@ if time_avg:
             return 0
 
         # launch jobs
-        failures = hp.utils.job_monitor(reformat_files, range(len(times)), "TAVG REFORMAT: pol {}".format(pol), M=M, lf=lf, maxiter=maxiter, verbose=verbose)
+        failures = hp.utils.job_monitor(reformat_files, range(len(times)), "TAVG REFORMAT: pol {}".format(pol), M=M, lf=lf, maxiter=params['maxiter'], verbose=verbose)
 
         # clean up time averaged files
         for f in tavg_files:
             if os.path.exists(f):
                 shutil.rmtree(f)
 
-    input_data_template = os.path.join(out_dir, os.path.basename(input_data_template) + file_ext)
-    data_suffix += file_ext
+    data_template = os.path.join(params['out_dir'], os.path.basename(data_template) + algs['tavg']['file_ext'])
+    data_suffix += algs['tavg']['file_ext']
 
     time = datetime.utcnow()
     hp.utils.log("\nfinished time averaging: {}\n{}".format(time, "-"*60), f=lf, verbose=verbose)
@@ -396,17 +398,16 @@ if time_avg:
 #-------------------------------------------------------------------------------
 # Form Pseudo-Stokes Visibilities
 #-------------------------------------------------------------------------------
-if form_pstokes:
-    # get algorithm parameters
-    globals().update(cf['algorithm']['pstokes'])
+if params['form_pstokes']:
+    # start block
     time = datetime.utcnow()
     hp.utils.log("\n{}\nstarting pseudo-stokes: {}\n".format("-"*60, time), f=lf, verbose=verbose)
 
     # get datafiles with reversed nesting
-    datafiles, datapols = uvt.utils.search_data(input_data_template.format(group=groupname, pol='{pol}'), pols, reverse_nesting=True)
+    datafiles, datapols = uvt.utils.search_data(data_template.format(group=params['groupname'], pol='{pol}'), pols, reverse_nesting=True)
 
     # write pseudo-Stokes function
-    def make_pstokes(i, datafiles=datafiles, datapols=datapols, p=cf['algorithm']['pstokes']):
+    def make_pstokes(i, datafiles=datafiles, datapols=datapols, p=cf['algorithm']['pstokes'], params=params):
         try:
             # get all pol files for unique datafile
             dfs = datafiles[i]
@@ -423,11 +424,12 @@ if form_pstokes:
                     ds = hp.pstokes.filter_dset_on_stokes_pol(dsets, pstokes)
                     ps = hp.pstokes.construct_pstokes(ds[0], ds[1], pstokes=pstokes)
                     outfile = os.path.basename(dfs[0]).replace(".{}.".format(dps[0]), ".{}.".format(pstokes))
-                    outfile = os.path.join(out_dir, outfile)
+                    outfile = os.path.join(params['out_dir'], outfile)
+                    ps.history = "{}{}".format(prepend_history("FORM PSTOKES", p), ps.history)
                     ps.write_miriad(outfile, clobber=overwrite)
                 except AssertionError:
-                    if verbose:
-                        print "failed to make pstokes {} for job {}".format(pstokes, i)
+                    hp.utils.log("failed to make pstokes {} for job {}:".format(pstokes, i), f=ef, tb=sys.exc_info(), verbose=verbose)
+
         except:
             hp.utils.log("job {} threw exception:".format(i), f=ef, tb=sys.exc_info(), verbose=verbose)
             return 1
@@ -435,28 +437,27 @@ if form_pstokes:
         return 0
 
     # launch jobs
-    failures = hp.utils.job_monitor(make_pstokes, range(len(datafiles)), "PSTOKES", M=M, lf=lf, maxiter=maxiter, verbose=verbose)
+    failures = hp.utils.job_monitor(make_pstokes, range(len(datafiles)), "PSTOKES", M=M, lf=lf, maxiter=params['maxiter'], verbose=verbose)
 
     # add pstokes pols to pol list for downstream calculations
-    pols += outstokes
+    pols += algs['pstokes']['outstokes']
 
     time = datetime.utcnow()
-    hp.utils.log("\nfinished pseudo-stokes: {}\n{}".format(time, "-"*60), f=lf, verbose=verbose)
+    hp.utils.log("\nFinished pseudo-stokes: {}\n{}".format(time, "-"*60), f=lf, verbose=verbose)
 
 #-------------------------------------------------------------------------------
 # Foreground Filtering (and data in-painting)
 #-------------------------------------------------------------------------------
-if fg_filt:
-    # get algorithm parameters
-    globals().update(cf['algorithm']['fg_filt'])
+if params['fg_filt']:
+    # start block
     time = datetime.utcnow()
     hp.utils.log("\n{}\nstarting foreground filtering: {}\n".format("-"*60, time), f=lf, verbose=verbose)
 
     # get flattened datafiles
-    datafiles, datapols = uvt.utils.search_data(input_data_template.format(group=groupname, pol='{pol}'), pols, matched_pols=False, reverse_nesting=False, flatten=True)
+    datafiles, datapols = uvt.utils.search_data(data_template.format(group=params['groupname'], pol='{pol}'), pols, matched_pols=False, reverse_nesting=False, flatten=True)
 
     # write fgfilt function
-    def fg_filter(i, datafiles=datafiles, p=cf['algorithm']['fg_filt']):
+    def fg_filter(i, datafiles=datafiles, p=cf['algorithm']['fg_filt'], params=params):
         try:
             # get datafile
             df = datafiles[i]
@@ -466,21 +467,21 @@ if fg_filt:
             # run filter
             DF.run_filter(**p['filt_params'])
             # write filtered term
-            outfile = os.path.join(out_dir, os.path.basename(df) + p['filt_file_ext'])
-            DF.write_filtered_data(outfile, filetype_out='miriad', clobber=overwrite, add_to_history="Foreground Filtered with: {}".format(json.dumps(p['filt_params'])))
+            outfile = os.path.join(params['out_dir'], os.path.basename(df) + p['filt_file_ext'])
+            add_to_history = prepend_history("FG FILTER", p)
+            DF.write_filtered_data(outfile, filetype_out='miriad', clobber=overwrite, add_to_history=add_to_history)
             # write original data with in-paint
-            outfile = os.path.join(out_dir, os.path.basename(df) + p['inpaint_file_ext'])
-            DF.write_filtered_data(outfile, filetype_out='miriad', clobber=overwrite, write_filled_data=True, add_to_history="FG model flag inpainted with: {}".format(json.dumps(p['filt_params'])))
+            outfile = os.path.join(params['out_dir'], os.path.basename(df) + p['inpaint_file_ext'])
+            add_to_history = prepend_history("DATA INPAINT", p)
+            DF.write_filtered_data(outfile, filetype_out='miriad', clobber=overwrite, write_filled_data=True, add_to_history=add_to_history)
         except:
             hp.utils.log("job {} threw exception:".format(i), f=ef, tb=sys.exc_info(), verbose=verbose)
-            return 1
-            
+            return 1            
         return 0
 
     # launch jobs
-    failures = hp.utils.job_monitor(fg_filter, range(len(datafiles)), "FG FILTER", M=M, lf=lf, maxiter=maxiter, verbose=verbose)
+    failures = hp.utils.job_monitor(fg_filter, range(len(datafiles)), "FG FILTER", M=M, lf=lf, maxiter=params['maxiter'], verbose=verbose)
 
     time = datetime.utcnow()
     hp.utils.log("\nfinished foreground-filtering: {}\n{}".format(time, "-"*60), f=lf, verbose=verbose)
-
 

--- a/pipelines/idr2_preprocessing/preprocess_data.py
+++ b/pipelines/idr2_preprocessing/preprocess_data.py
@@ -194,7 +194,8 @@ if timeavg_sub:
     datafiles, datapols = uvt.utils.search_data(input_data_template.format(group=groupname, pol='{pol}'), pols, matched_pols=False, reverse_nesting=False, flatten=False)
 
     # load a datafile and get antenna numbers
-    _, _, uvd = uvutils.get_miriad_antpos(datafiles[0][0])
+    uvd = UVData()
+    uvd.read_miriad_metadata(datafiles[0][0])
     antpos, ants = uvd.get_ENU_antpos()
     antpos_dict = dict(zip(ants, antpos))
 
@@ -296,6 +297,9 @@ if timeavg_sub:
                             print "baseline {} not found in time-averaged spectrum".format(bl)
                             uvd.flag_array[bl_inds, :, :, pol_ind] = True
 
+                # put uniq_bls in if it doesn't exist
+                if not uvd.extra_keywords.has_key('uniq_bls'):
+                    uvd.extra_keywords['uniq_bls'] = json.dumps(np.unique(uvd.baseline_array).tolist())
                 # write tavg-subtracted data
                 out_df = os.path.join(out_dir, os.path.basename(df) + p['file_ext'])
                 uvd.history += "\nTime-Average subtracted."
@@ -332,7 +336,8 @@ if time_avg:
     datafiles, datapols = uvt.utils.search_data(input_data_template.format(group=groupname, pol='{pol}'), pols, matched_pols=False, reverse_nesting=False, flatten=False)
 
     # load a datafile and get antenna numbers
-    _, _, uvd = uvutils.get_miriad_antpos(datafiles[0][0])
+    uvd = UVData()
+    uvd.read_miriad_metadata(datafiles[0][0])
     antpos, ants = uvd.get_ENU_antpos()
     antpos_dict = dict(zip(ants, antpos))
 

--- a/pipelines/idr2_preprocessing/preprocess_data.py
+++ b/pipelines/idr2_preprocessing/preprocess_data.py
@@ -115,8 +115,7 @@ if reformat:
                 uvd.read_miriad(dfs, ant_pairs_nums=reds[j])
                 uvd.write_miriad(outname, clobber=True)
             except:
-                err, _, tb = sys.exc_info()
-                hp.utils.log("\njob {} threw {} Exception with traceback:".format(j, err), f=ef, tb=tb, verbose=verbose)
+                hp.utils.log("\nBL_REFORMAT job {} errored:".format(j), f=ef, tb=sys.exc_info(), verbose=verbose)
                 return 1
             return 0
 
@@ -163,8 +162,7 @@ if rfi_flag:
                              add_to_history='', clobber=overwrite)
 
         except:
-            err, _, tb = sys.exc_info()
-            hp.utils.log("\n{} threw {} Exception with traceback:".format(outname, err), f=ef, tb=tb, verbose=verbose)
+            hp.utils.log("\nXRFI job {} errored:".format(outname,), f=ef, tb=sys.exc_info(), verbose=verbose)
             return 1
 
         return 0
@@ -253,8 +251,7 @@ if timeavg_sub:
                 tavg_file = os.path.join(out_dir, tavg_file)
                 F.write_data(tavg_file, write_avg=True, overwrite=overwrite)
             except:
-                err, _, tb = sys.exc_info()
-                hp.utils.log("\n{} threw {} Exception with traceback:".format(j, err), f=ef, tb=tb, verbose=verbose)
+                hp.utils.log("\nTAVG job {} errored:".format(j), f=ef, tb=sys.exc_info(), verbose=verbose)
                 return 1
 
             return 0
@@ -305,8 +302,7 @@ if timeavg_sub:
                 uvd.history += "\nTime-Average subtracted."
                 uvd.write_miriad(out_df, clobber=overwrite)
             except:
-                err, _, tb = sys.exc_info()
-                hp.utils.log("\n{} threw {} Exception with traceback:".format(i, err), f=ef, tb=tb, verbose=verbose)
+                hp.utils.log("\nTAVG_SUB job {} errored:".format(i), f=ef, tb=sys.exc_info(), verbose=verbose)
                 return 1
 
             return 0
@@ -375,7 +371,7 @@ if time_avg:
                 F.write_data(tavg_file, write_avg=True, overwrite=overwrite)
             except:
                 err, _, tb = sys.exc_info()
-                hp.utils.log("\n{} threw {} Exception with traceback:".format(i, err), f=ef, tb=tb, verbose=verbose)
+                hp.utils.log("\nTIME AVERAGE job {} errored:".format(i), f=ef, tb=sys.exc_info(), verbose=verbose)
                 return 1
 
             return 0
@@ -408,8 +404,7 @@ if time_avg:
                 outfile = os.path.join(out_dir, "zen.{group}.{pol}.LST.{LST:.5f}.{suffix}".format(group=groupname, pol=pol, LST=lst, suffix=data_suffix + p['file_ext']))
                 uvd.write_miriad(outfile, clobber=overwrite)
             except:
-                err, _, tb = sys.exc_info()
-                hp.utils.log("\n{} threw {} Exception with traceback:".format(i, err), f=ef, tb=tb, verbose=verbose)
+                hp.utils.log("\nTIME AVERAGE REFORMAT job {} errored:".format(i), f=ef, tb=sys.exc_info(), verbose=verbose)
                 return 1
 
             return 0
@@ -466,8 +461,7 @@ if form_pstokes:
                     if verbose:
                         print "failed to make pstokes {} for job {}".format(pstokes, i)
         except:
-            err, _, tb = sys.exc_info()
-            hp.utils.log("datafile {} threw {} Exception with traceback:".format(i, err), f=ef, tb=tb, verbose=verbose)
+            hp.utils.log("PSTOKES job {} errored:".format(i), f=ef, tb=sys.exc_info(), verbose=verbose)
             return 1
 
         return 0
@@ -513,8 +507,7 @@ if fg_filt:
             outfile = os.path.join(out_dir, os.path.basename(df) + p['inpaint_file_ext'])
             DF.write_filtered_data(outfile, filetype_out='miriad', clobber=overwrite, write_filled_data=True, add_to_history="FG model flag inpainted with: {}".format(json.dumps(p['filt_params'])))
         except:
-            err, _, tb = sys.exc_info()
-            hp.utils.log("datafile {} threw {} Exception with traceback:".format(i, err), f=ef, tb=tb, verbose=verbose)
+            hp.utils.log("FG FILTER job {} errored:".format(i), f=ef, tb=sys.exc_info(), verbose=verbose)
             return 1
         return 0
 

--- a/pipelines/idr2_preprocessing/preprocess_params.yaml
+++ b/pipelines/idr2_preprocessing/preprocess_params.yaml
@@ -39,6 +39,7 @@ data :
   groupname : "all"       # a single groupname
   # full path to a data template with {pol} and {group}
   input_data_template : '../../hera_pspec/data/zen.{group}.{pol}.LST.1.06964.uvA'
+  maxiter : 1             # number of maximum job retries
 
 #---------------------------------------------------------------
 # Algorithm Parameters

--- a/pipelines/idr2_preprocessing/preprocess_params.yaml
+++ b/pipelines/idr2_preprocessing/preprocess_params.yaml
@@ -28,6 +28,7 @@ analysis :
 
   multiproc : False    # use multiprocess module
   nproc : 8               # number of processes to spawn
+  maxiter : 1
 
 #---------------------------------------------------------------
 # Data Parameters
@@ -40,6 +41,8 @@ data :
   # full path to a data template with {pol} and {group}
   input_data_template : '../../hera_pspec/data/zen.{group}.{pol}.LST.1.06964.uvA'
   maxiter : 1             # number of maximum job retries
+  bl_len_range : [0, 20]  # data baseline length range [meters]
+  bl_deg_range : [0, 180] # data baseline angle cut [degrees ENU coords]
 
 #---------------------------------------------------------------
 # Algorithm Parameters
@@ -50,7 +53,6 @@ algorithm :
   reformat : 
     reformat_outfile : "zen.{group}.{len:03d}_{deg:03d}.{pol}.{suffix}"   # outfile template
     new_data_template : "zen.{group}.*.{pol}.{suffix}" # new data template to use        
-    bl_len_range : [0, 10000.0]  # [min, max] range of baseline lengths to extract [meters]
     bltol : 1.0   # baseline redundancy tolerance in meters
 
   # RFI Flagging

--- a/pipelines/idr2_preprocessing/preprocess_params.yaml
+++ b/pipelines/idr2_preprocessing/preprocess_params.yaml
@@ -34,15 +34,20 @@ analysis :
 # Data Parameters
 #---------------------------------------------------------------
 data :
-  pols :                  # list of linear polarizations of data
+  # list of linear polarizations of data to format data template with
+  pols :
     - 'xx'
     - 'yy'
-  groupname : "all"       # a single groupname
-  # full path to a data template with {pol} and {group}
-  input_data_template : '../../hera_pspec/data/zen.{group}.{pol}.LST.1.06964.uvA'
-  maxiter : 1             # number of maximum job retries
-  bl_len_range : [0, 20]  # data baseline length range [meters]
-  bl_deg_range : [0, 180] # data baseline angle cut [degrees ENU coords]
+
+  # a groupname to format data template with
+  groupname : "all"     
+
+  # a single, full path to a data template with {pol} and {group} fields
+  data_template : 'zen.{group}.{pol}.LST.1.?????.uvA'
+
+  # data baseline-type length range [meters] and angle range [degrees]
+  bl_len_range : [14, 16]  
+  bl_deg_range : [0, 1]
 
 #---------------------------------------------------------------
 # Algorithm Parameters
@@ -53,7 +58,6 @@ algorithm :
   reformat : 
     reformat_outfile : "zen.{group}.{len:03d}_{deg:03d}.{pol}.{suffix}"   # outfile template
     new_data_template : "zen.{group}.*.{pol}.{suffix}" # new data template to use        
-    bltol : 1.0   # baseline redundancy tolerance in meters
 
   # RFI Flagging
   rfi_flag :
@@ -78,7 +82,7 @@ algorithm :
     dly_params :       # if dly_filter, these are the delay filter params
       min_dly : 1500.0
       horizon : 0.0
-      tol : 0.000000001
+      tol : 0.0001
       maxiter : 100
       window : 'blackman-harris'
       flag_nchan_low : 25
@@ -104,7 +108,7 @@ algorithm :
       standoff : 50.0
       horizon : 1.0
       min_dly : 0.0
-      tol : 0.000000001
+      tol : 0.0001
       maxiter : 100
       window : 'tukey'
       skip_wgt : 0.5

--- a/pipelines/pspec_pipeline/pspec_batch.sh
+++ b/pipelines/pspec_pipeline/pspec_batch.sh
@@ -10,9 +10,13 @@
 # start script
 echo "starting power spectrum pipeline: $(date)"
 
-# put a lock on parameter file, run pspec_pipe.py, unlock file
+# put a lock on parameter files
 chmod 444 pspec_pipe.yaml
+
+# run scripts
 pspec_pipe.py pspec_pipe.yaml
+
+# unlock files
 chmod 775 pspec_pipe.yaml
 
 # end script

--- a/pipelines/pspec_pipeline/pspec_batch.sh
+++ b/pipelines/pspec_pipeline/pspec_batch.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+#PBS -q hera
+#PBS -V
+#PBS -j oe
+#PBS -o pspec_batch.out
+#PBS -l nodes=1:ppn=8
+#PBS -l walltime=24:00:00
+#PBS -l vmem=128gb, mem=128gb
+
+# start script
+echo "starting power spectrum pipeline: $(date)"
+
+# put a lock on parameter file, run pspec_pipe.py, unlock file
+chmod 444 pspec_pipe.yaml
+python pspec_pipe.py pspec_pipe.yaml
+chmod 775 pspec_pipe.yaml
+
+# end script
+echo "ending power spectrum pipeline: $(date)"

--- a/pipelines/pspec_pipeline/pspec_batch.sh
+++ b/pipelines/pspec_pipeline/pspec_batch.sh
@@ -12,7 +12,7 @@ echo "starting power spectrum pipeline: $(date)"
 
 # put a lock on parameter file, run pspec_pipe.py, unlock file
 chmod 444 pspec_pipe.yaml
-python pspec_pipe.py pspec_pipe.yaml
+pspec_pipe.py pspec_pipe.yaml
 chmod 775 pspec_pipe.yaml
 
 # end script

--- a/pipelines/pspec_pipeline/pspec_batch.sh
+++ b/pipelines/pspec_pipeline/pspec_batch.sh
@@ -10,14 +10,17 @@
 # start script
 echo "starting power spectrum pipeline: $(date)"
 
-# put a lock on parameter files
-chmod 444 pspec_pipe.yaml
+# copy parameter files to more discrete names
+# and put a readonly lock on them
+cp pspec_pipe.yaml .pspec_pipe.yaml
+chmod 444 .pspec_pipe.yaml
 
 # run scripts
-pspec_pipe.py pspec_pipe.yaml
+pspec_pipe.py .pspec_pipe.yaml
 
-# unlock files
-chmod 775 pspec_pipe.yaml
+# unlock and clean-up parameter files
+chmod 775 .pspec_pipe.yaml
+rm .pspec_pipe.yaml
 
 # end script
 echo "ending power spectrum pipeline: $(date)"

--- a/pipelines/pspec_pipeline/pspec_pipe.py
+++ b/pipelines/pspec_pipeline/pspec_pipe.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python2
+"""
+psepc_pipe.py
+-----------------------------------------
+Copyright (c) 2018 The HERA Collaboration
+
+This script is used as the IDR2.1 power
+spectrum pipeline.
+
+See pspec_pipe.yaml for relevant parameter selections.
+"""
+import multiprocess
+import numpy as np
+import hera_cal as hc
+import hera_pspec as hp
+import hera_qm as hq
+from pyuvdata import UVData
+import pyuvdata.utils as uvutils
+import os
+import sys
+import glob
+import yaml
+from datetime import datetime
+import uvtools as uvt
+import json
+import itertools
+import aipy
+import shutil
+from collections import OrderedDict as odict
+
+
+#-------------------------------------------------------------------------------
+# Parse YAML Configuration File
+#-------------------------------------------------------------------------------
+# get config and load dictionary
+config = sys.argv[1]
+cf = hp.utils.load_config(config)
+
+# update globals with IO params, data and analysis params
+globals().update(cf['io'])
+globals().update(cf['data'])
+globals().update(cf['analysis'])
+
+# get common suffix
+data_suffix = os.path.splitext(data_template)[1][1:]
+
+# open logfile
+logfile = os.path.join(out_dir, logfile)
+if os.path.exists(logfile) and overwrite == False:
+    raise IOError("logfile {} exists and overwrite == False, quitting pipeline...".format(logfile))
+lf = open(logfile, "w")
+if joinlog:
+    ef = lf
+else:
+    ef = open(os.path.join(out_dir, errfile), "w")
+time = datetime.utcnow()
+hp.utils.log("Starting pspec pipeline on {}\n{}\n".format(time, '-'*60), f=lf, verbose=verbose)
+hp.utils.log(json.dumps(cf, indent=1) + '\n', f=lf, verbose=verbose)
+
+# Create multiprocesses
+if multiproc:
+    pool = multiprocess.Pool(nproc)
+    M = pool.map
+else:
+    M = map
+
+# change to working dir
+os.chdir(work_dir)
+
+#-------------------------------------------------------------------------------
+# Run Jacknife Split
+#-------------------------------------------------------------------------------
+if run_split:
+    # get algorithm parameters
+    globals().update(cf['algorithm']['split'])
+    time = datetime.utcnow()
+    hp.utils.log("\n{}\nstarting {} jacknife split: {}\n".format("-"*60, split_type, time), f=lf, verbose=verbose)
+
+    raise NotImplementedError
+
+
+#-------------------------------------------------------------------------------
+# Run OQE Pipeline
+#-------------------------------------------------------------------------------
+if run_pspec:
+    # get algorithm parameters
+    globals().update(cf['algorithm']['pspec'])
+    time = datetime.utcnow()
+    hp.utils.log("\n{}\nstarting pspec OQE: {}\n".format("-"*60, time), f=lf, verbose=verbose)
+
+    # configure dataset groupings
+    groupings = hp.utils.config_pspec_blpairs(data_template, pol_pairs, group_pairs, exclude_auto_bls=exclude_auto_bls,
+                                              exclude_permutations=exclude_permutations, bl_len_range=bl_len_range,
+                                              bl_deg_range=bl_deg_range, xants=xants)
+
+    # create dictionary of individual jobs to launch
+    jobs = odict()
+    for pair in groupings:
+        # make Nblps / Nblps_per_job jobs for this pair
+        blps = groupings[pair]
+        Nblps = len(blps)
+        Njobs = Nblps // Nblps_per_job + 1
+        job_blps = [blps[i*Nblps_per_job:(i+1)*Nblps_per_job] for i in range(Njobs)]
+        for i, _blps in enumerate(job_blps):
+            key = tuple(hp.utils.flatten(pair) + [i])
+            jobs[key] = _blps
+
+    # create pspec worker function
+    def pspec(i, outfile=outfname, dt=data_template, st=std_template, jobs=jobs, pol_pairs=pol_pairs, p=cf['algorithm']['pspec']):
+        try:
+            # get key
+            key = jobs.keys()[i]
+            # parse dsets
+            dsets = [dt.format(group=key[0], pol=key[2]), dt.format(group=key[1], pol=key[3])]
+            dset_labels = [os.path.basename(d) for d in dsets]
+            if st is not None and st is not '' and st is not 'None':
+                dsets_std = [dt.format(group=key[0], pol=key[2]), dt.format(group=key[1], pol=key[3])]
+            else:
+                dsets_std = None
+
+            # pspec_run
+            hp.pspecdata.pspec_run(dsets, outfile, dsets_std=dsets_std, dset_labels=dset_labels,
+                                   dset_pairs=[(0, 1)], spw_ranges=p['spw_ranges'], n_dlys=p['n_dlys'],
+                                   pol_pairs=pol_pairs, blpairs=jobs[key], input_data_weight=p['input_data_weight'],
+                                   norm=p['norm'], taper=p['taper'], beam=p['beam'], cosmo=p['cosmo'],
+                                   rephase_to_dset=p['rephase_to_dset'], trim_dset_lsts=p['trim_dset_lsts'],
+                                   broadcast_dset_flags=p['broadcast_dset_flags'], time_thresh=p['time_thresh'],
+                                   Jy2mK=p['Jy2mK'], overwrite=overwrite, psname_ext="_{}".format(key[4]),
+                                   verbose=verbose)
+        except:
+            hp.utils.log("\nPSPEC job {} errored with:".format(i), f=ef, tb=sys.exc_info(), verbose=verbose)
+            return 1
+
+        return 0
+
+    # run function over jobs
+    exit_codes = np.array(M(pspec, range(len(jobs))))
+
+    # inspect for failures
+    if np.all(exit_codes != 0):
+        # everything failed, raise error
+        hp.utils.log("\n{}\nAll PSPEC jobs failed w/ exit codes\n {}: {}\n".format("-"*60, exit_codes, time), f=lf, verbose=verbose)
+        raise ValueError("All PSPEC jobs failed")
+
+    # if only a few, try re-run
+    failures = np.where(exit_codes != 0)[0]
+    counter = 1
+    while True:
+        if not np.all(exit_codes == 0):
+            if counter >= maxiter:
+                # break after certain number of tries
+                break
+            # run function over jobs that failed
+            exit_codes = np.array(M(pspec, failures))
+            # update counter
+            counter += 1
+            # update failures
+            failures = failures[exit_codes != 0]
+        else:
+            # all passed
+            break
+
+    # print failures if they exist
+    if len(failures) > 0:
+        hp.utils.log("\nSome PSPEC jobs failed after {} tries:\n{}".format(maxiter, '\n'.join(["job {}: {}".format(i, str(jobs.keys()[i])) for i in failures])), f=lf, verbose=verbose)
+
+    # print to log
+    time = datetime.utcnow()
+    hp.utils.log("\nFinished PSPEC pipeline: {}\n{}".format(time, "-"*60), f=lf, verbose=verbose)
+
+#-------------------------------------------------------------------------------
+# Run Bootstrap Pipeline
+#-------------------------------------------------------------------------------
+if run_bootstrap:
+    # get algorithm parameters
+    globals().update(cf['algorithm']['bootstrap'])
+    time = datetime.utcnow()
+    hp.utils.log("\n{}\nstarting bootstrap resampling: {}\n".format("-"*60, time), f=lf, verbose=verbose)
+
+    # get datafiles
+    datafiles, datapols = uvt.utils.search_data(input_data_template.format(group=groupname), pols, matched_pols=False, reverse_nesting=False, flatten=False)
+
+
+
+
+
+
+

--- a/pipelines/pspec_pipeline/pspec_pipe.py
+++ b/pipelines/pspec_pipeline/pspec_pipe.py
@@ -14,6 +14,7 @@ import numpy as np
 import hera_cal as hc
 import hera_pspec as hp
 import hera_qm as hq
+import hera_stats as hs
 from pyuvdata import UVData
 import pyuvdata.utils as uvutils
 import os
@@ -68,13 +69,13 @@ else:
 os.chdir(work_dir)
 
 #-------------------------------------------------------------------------------
-# Run Jacknife Split
+# Run Jacknife Data Difference
 #-------------------------------------------------------------------------------
-if run_split:
+if run_diff:
     # get algorithm parameters
-    globals().update(cf['algorithm']['split'])
+    globals().update(cf['algorithm']['diff'])
     time = datetime.utcnow()
-    hp.utils.log("\n{}\nstarting {} jacknife split: {}\n".format("-"*60, split_type, time), f=lf, verbose=verbose)
+    hp.utils.log("\n{}\nstarting {} visibility data difference: {}\n".format("-"*60, diff_type, time), f=lf, verbose=verbose)
 
     raise NotImplementedError
 
@@ -299,6 +300,30 @@ if run_bootstrap:
     # print to log
     time = datetime.utcnow()
     hp.utils.log("\nFinished BOOTSTRAP pipeline: {}\n{}".format(time, "-"*60), f=lf, verbose=verbose)
+
+
+#-------------------------------------------------------------------------------
+# Run Statistical Evaluation Pipeline
+#-------------------------------------------------------------------------------
+if run_stats:
+    # get algorithm parameters
+    globals().update(cf['algorithm']['stats'])
+    time = datetime.utcnow()
+    hp.utils.log("\n{}\nstarting statistical evaluation pipeline: {}\n".format("-"*60, time), f=lf, verbose=verbose)
+
+    raise NotImplementedError
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 

--- a/pipelines/pspec_pipeline/pspec_pipe.py
+++ b/pipelines/pspec_pipeline/pspec_pipe.py
@@ -102,7 +102,7 @@ if params['run_pspec']:
             jobs[key] = _blps
 
     # setup output
-    outfname = os.path.join(params['out_dir'], alg['outfname'])
+    outfname = os.path.join(params['out_dir'], algs['pspec']['outfname'])
 
     # create pspec worker function
     def pspec(i, outfname=outfname, jobs=jobs, params=params, alg=algs['pspec'], ef=ef):

--- a/pipelines/pspec_pipeline/pspec_pipe.py
+++ b/pipelines/pspec_pipeline/pspec_pipe.py
@@ -11,9 +11,7 @@ See pspec_pipe.yaml for relevant parameter selections.
 """
 import multiprocess
 import numpy as np
-import hera_cal as hc
 import hera_pspec as hp
-import hera_qm as hq
 from pyuvdata import UVData
 import pyuvdata.utils as uvutils
 import os
@@ -54,6 +52,17 @@ else:
 time = datetime.utcnow()
 hp.utils.log("Starting pspec pipeline on {}\n{}\n".format(time, '-'*60), f=lf, verbose=params['verbose'])
 hp.utils.log(json.dumps(cf, indent=1) + '\n', f=lf, verbose=params['verbose'])
+
+# define history prepend function
+def prepend_history(action, param_dict):
+    """ create a history string to prepend to data files """
+    dict_str = '\n'.join(["{} : {}".format(*_d) for _d in param_dict.items()])
+    time = datetime.utcnow()
+    hist = "\nRan pspec_pipe.py {} step at\nUTC {} with \nhera_pspec [{}], "\
+           "and pyuvdata [{}]\nwith {} algorithm "\
+           "attrs:\n{}\n{}\n".format(action, time, hp.version.git_hash[:10],
+                                     pyuvdata.version.git_hash[:10], action, '-'*50, dict_str)
+    return hist
 
 # Create multiprocesses
 if params['multiproc']:
@@ -139,12 +148,8 @@ if params['run_pspec']:
     if len(failures) > 0:
         hp.utils.log("\nSome PSPEC jobs failed after {} tries:\n{}".format(algs['pspec']['maxiter'], '\n'.join(["job {}: {}".format(i, str(jobs.keys()[i])) for i in failures])), f=lf, verbose=params['verbose'])
 
-    # print to log
-    time = datetime.utcnow()
-    hp.utils.log("\nFinished PSPEC pipeline: {}\n{}".format(time, "-"*60), f=lf, verbose=params['verbose'])
-
     # Merge power spectrum files from separate jobs
-    hp.utils.log("\nStarting power spectrum file merge: {}\n{}".format(time, '-'*60), f=lf, verbose=params['verbose'])
+    hp.utils.log("\nStarting power spectrum file merge: {}\n".format(time), f=lf, verbose=params['verbose'])
 
     # Get all groups
     psc = hp.PSpecContainer(outfname, 'r')

--- a/pipelines/pspec_pipeline/pspec_pipe.py
+++ b/pipelines/pspec_pipeline/pspec_pipe.py
@@ -115,7 +115,7 @@ if params['run_pspec']:
                 dsets_std = None
 
             # pspec_run
-            hp.pspecdata.pspec_run(dsets, alg['outfile'], dsets_std=dsets_std, dset_labels=dset_labels,
+            hp.pspecdata.pspec_run(dsets, alg['outfname'], dsets_std=dsets_std, dset_labels=dset_labels,
                                    dset_pairs=[(0, 1)], spw_ranges=alg['spw_ranges'], n_dlys=alg['n_dlys'],
                                    pol_pairs=params['pol_pairs'], blpairs=jobs[key], input_data_weight=alg['input_data_weight'],
                                    norm=alg['norm'], taper=alg['taper'], beam=alg['beam'], cosmo=alg['cosmo'],
@@ -153,7 +153,7 @@ if params['run_pspec']:
         try:
             psc = hp.PSpecContainer(filename, mode='rw')
             grp = groups[i]
-            hp.container.merge_spectra(psc, groups=[grp])
+            hp.container.combine_psc_spectra(psc, groups=[grp], overwrite=params['overwrite'])
         except:
             hp.utils.log("\nPSPEC MERGE job {} errored with:".format(i), f=ef, tb=sys.exc_info(), verbose=params['verbose'])
             return 1
@@ -204,7 +204,7 @@ if params['run_bootstrap']:
             # run bootstrap
             hp.grouping.bootstrap_run(psc, spectra=spectra, time_avg=alg['time_avg'], Nsamples=alg['Nsamples'],
                                       seed=alg['seed'], normal_std=alg['normal_std'], robust_std=alg['robust_std'],
-                                      conf_ints=alg['conf_ints'], keep_samples=alg['keep_samples'],
+                                      cintervals=alg['cintervals'], keep_samples=alg['keep_samples'],
                                       bl_error_tol=alg['bl_error_tol'], overwrite=params['overwrite'], verbose=params['verbose'])
 
 

--- a/pipelines/pspec_pipeline/pspec_pipe.py
+++ b/pipelines/pspec_pipeline/pspec_pipe.py
@@ -36,42 +36,42 @@ from collections import OrderedDict as odict
 config = sys.argv[1]
 cf = hp.utils.load_config(config)
 
-# update globals with IO params, data and analysis params
-globals().update(cf['io'])
-globals().update(cf['data'])
-globals().update(cf['analysis'])
+# consolidate IO, data and analysis paramemeter dictionaries
+params = odict(cf['io'].items() + cf['data'].items() + cf['analysis'].items())
+assert len(params) == len(cf['io']) + len(cf['data']) + len(cf['analysis']), ""\
+       "Repeated parameters found within the scope of io, data and analysis dicts"
+algs = cf['algorithm']
 
 # open logfile
-logfile = os.path.join(out_dir, logfile)
-if os.path.exists(logfile) and overwrite == False:
+logfile = os.path.join(params['out_dir'], params['logfile'])
+if os.path.exists(logfile) and params['overwrite'] == False:
     raise IOError("logfile {} exists and overwrite == False, quitting pipeline...".format(logfile))
 lf = open(logfile, "w")
-if joinlog:
+if params['joinlog']:
     ef = lf
 else:
-    ef = open(os.path.join(out_dir, errfile), "w")
+    ef = open(os.path.join(params['out_dir'], params['errfile']), "w")
 time = datetime.utcnow()
-hp.utils.log("Starting pspec pipeline on {}\n{}\n".format(time, '-'*60), f=lf, verbose=verbose)
-hp.utils.log(json.dumps(cf, indent=1) + '\n', f=lf, verbose=verbose)
+hp.utils.log("Starting pspec pipeline on {}\n{}\n".format(time, '-'*60), f=lf, verbose=params['verbose'])
+hp.utils.log(json.dumps(cf, indent=1) + '\n', f=lf, verbose=params['verbose'])
 
 # Create multiprocesses
-if multiproc:
-    pool = multiprocess.Pool(nproc)
+if params['multiproc']:
+    pool = multiprocess.Pool(params['nproc'])
     M = pool.map
 else:
     M = map
 
 # change to working dir
-os.chdir(work_dir)
+os.chdir(params['work_dir'])
 
 #-------------------------------------------------------------------------------
 # Run Visibility Data Difference
 #-------------------------------------------------------------------------------
-if run_diff:
-    # get algorithm parameters
-    globals().update(cf['algorithm']['diff'])
+if params['run_diff']:
+    # start block
     time = datetime.utcnow()
-    hp.utils.log("\n{}\nstarting {} visibility data difference: {}\n".format("-"*60, diff_type, time), f=lf, verbose=verbose)
+    hp.utils.log("\n{}\nstarting {} visibility data difference: {}\n".format("-"*60, algs['diff']['diff_type'], time), f=lf, verbose=params['verbose'])
 
     raise NotImplementedError
 
@@ -79,16 +79,15 @@ if run_diff:
 #-------------------------------------------------------------------------------
 # Run OQE Pipeline
 #-------------------------------------------------------------------------------
-if run_pspec:
-    # get algorithm parameters
-    globals().update(cf['algorithm']['pspec'])
+if params['run_pspec']:
+    # start block
     time = datetime.utcnow()
-    hp.utils.log("\n{}\nstarting pspec OQE: {}\n".format("-"*60, time), f=lf, verbose=verbose)
+    hp.utils.log("\n{}\nstarting pspec OQE: {}\n".format("-"*60, time), f=lf, verbose=params['verbose'])
 
     # configure dataset groupings
-    groupings = hp.utils.config_pspec_blpairs(data_template, pol_pairs, group_pairs, exclude_auto_bls=exclude_auto_bls,
-                                              exclude_permutations=exclude_permutations, bl_len_range=bl_len_range,
-                                              bl_deg_range=bl_deg_range, xants=xants)
+    groupings = hp.utils.config_pspec_blpairs(params['data_template'], params['pol_pairs'], params['group_pairs'], exclude_auto_bls=algs['pspec']['exclude_auto_bls'],
+                                              exclude_permutations=algs['pspec']['exclude_permutations'], bl_len_range=params['bl_len_range'],
+                                              bl_deg_range=params['bl_deg_range'], xants=params['xants'])
 
     # create dictionary of individual jobs to launch
     jobs = odict()
@@ -96,130 +95,133 @@ if run_pspec:
         # make Nblps / Nblps_per_job jobs for this pair
         blps = groupings[pair]
         Nblps = len(blps)
-        Njobs = Nblps // Nblps_per_job + 1
-        job_blps = [blps[i*Nblps_per_job:(i+1)*Nblps_per_job] for i in range(Njobs)]
+        Njobs = Nblps // algs['pspec']['Nblps_per_job'] + 1
+        job_blps = [blps[i*algs['pspec']['Nblps_per_job']:(i+1)*algs['pspec']['Nblps_per_job']] for i in range(Njobs)]
         for i, _blps in enumerate(job_blps):
             key = tuple(hp.utils.flatten(pair) + [i])
             jobs[key] = _blps
 
     # create pspec worker function
-    def pspec(i, outfile=outfname, dt=data_template, st=std_template, jobs=jobs, pol_pairs=pol_pairs, p=cf['algorithm']['pspec']):
+    def pspec(i, jobs=jobs, params=params, alg=algs['pspec'], ef=ef):
         try:
             # get key
             key = jobs.keys()[i]
             # parse dsets
-            dsets = [dt.format(group=key[0], pol=key[2]), dt.format(group=key[1], pol=key[3])]
+            dsets = [params['data_template'].format(group=key[0], pol=key[2]), params['data_template'].format(group=key[1], pol=key[3])]
             dset_labels = [os.path.basename(d) for d in dsets]
-            if st is not None:
-                dsets_std = [st.format(group=key[0], pol=key[2]), st.format(group=key[1], pol=key[3])]
+            if params['std_template'] is not None:
+                dsets_std = [params['std_template'].format(group=key[0], pol=key[2]), params['std_template'].format(group=key[1], pol=key[3])]
             else:
                 dsets_std = None
 
             # pspec_run
-            hp.pspecdata.pspec_run(dsets, outfile, dsets_std=dsets_std, dset_labels=dset_labels,
-                                   dset_pairs=[(0, 1)], spw_ranges=p['spw_ranges'], n_dlys=p['n_dlys'],
-                                   pol_pairs=pol_pairs, blpairs=jobs[key], input_data_weight=p['input_data_weight'],
-                                   norm=p['norm'], taper=p['taper'], beam=p['beam'], cosmo=p['cosmo'],
-                                   rephase_to_dset=p['rephase_to_dset'], trim_dset_lsts=p['trim_dset_lsts'],
-                                   broadcast_dset_flags=p['broadcast_dset_flags'], time_thresh=p['time_thresh'],
-                                   Jy2mK=p['Jy2mK'], overwrite=overwrite, psname_ext="_{}".format(key[4]),
-                                   verbose=verbose)
+            hp.pspecdata.pspec_run(dsets, alg['outfile'], dsets_std=dsets_std, dset_labels=dset_labels,
+                                   dset_pairs=[(0, 1)], spw_ranges=alg['spw_ranges'], n_dlys=alg['n_dlys'],
+                                   pol_pairs=params['pol_pairs'], blpairs=jobs[key], input_data_weight=alg['input_data_weight'],
+                                   norm=alg['norm'], taper=alg['taper'], beam=alg['beam'], cosmo=alg['cosmo'],
+                                   rephase_to_dset=alg['rephase_to_dset'], trim_dset_lsts=alg['trim_dset_lsts'],
+                                   broadcast_dset_flags=alg['broadcast_dset_flags'], time_thresh=alg['time_thresh'],
+                                   Jy2mK=alg['Jy2mK'], overwrite=params['overwrite'], psname_ext="_{}".format(key[4]),
+                                   verbose=params['verbose'])
         except:
-            hp.utils.log("\nPSPEC job {} errored with:".format(i), f=ef, tb=sys.exc_info(), verbose=verbose)
+            hp.utils.log("\nPSPEC job {} errored with:".format(i), f=ef, tb=sys.exc_info(), verbose=params['verbose'])
             return 1
 
         return 0
 
     # launch pspec jobs
-    failures = hp.utils.job_monitor(pspec, range(len(jobs)), "PSPEC", lf=lf, maxiter=maxiter, verbose=verbose)
+    failures = hp.utils.job_monitor(pspec, range(len(jobs)), "PSPEC", lf=lf, maxiter=algs['pspec']['maxiter'], verbose=params['verbose'])
 
     # print failures if they exist
     if len(failures) > 0:
-        hp.utils.log("\nSome PSPEC jobs failed after {} tries:\n{}".format(maxiter, '\n'.join(["job {}: {}".format(i, str(jobs.keys()[i])) for i in failures])), f=lf, verbose=verbose)
+        hp.utils.log("\nSome PSPEC jobs failed after {} tries:\n{}".format(algs['pspec']['maxiter'], '\n'.join(["job {}: {}".format(i, str(jobs.keys()[i])) for i in failures])), f=lf, verbose=params['verbose'])
 
     # print to log
     time = datetime.utcnow()
-    hp.utils.log("\nFinished PSPEC pipeline: {}\n{}".format(time, "-"*60), f=lf, verbose=verbose)
+    hp.utils.log("\nFinished PSPEC pipeline: {}\n{}".format(time, "-"*60), f=lf, verbose=params['verbose'])
 
     # Merge power spectrum files from separate jobs
-    hp.utils.log("\nStarting power spectrum file merge: {}\n{}".format(time, '-'*60), f=lf, verbose=verbose)
+    hp.utils.log("\nStarting power spectrum file merge: {}\n{}".format(time, '-'*60), f=lf, verbose=params['verbose'])
 
     # Get all groups
-    psc = hp.PSpecContainer(outfname, 'r')
+    psc = hp.PSpecContainer(algs['pspec']['outfname'], 'r')
     groups = psc.groups()
     del psc
 
     # Define merge function
-    def merge(i, groups=groups, filename=outfname):
+    def merge(i, groups=groups, filename=algs['pspec']['outfname'], ef=ef, params=params):
         try:
             psc = hp.PSpecContainer(filename, mode='rw')
             grp = groups[i]
             hp.container.merge_spectra(psc, groups=[grp])
         except:
-            hp.utils.log("\nPSPEC MERGE job {} errored with:".format(i), f=ef, tb=sys.exc_info(), verbose=verbose)
+            hp.utils.log("\nPSPEC MERGE job {} errored with:".format(i), f=ef, tb=sys.exc_info(), verbose=params['verbose'])
             return 1
 
         return 0
 
     # launch pspec merge jobs
-    failures = hp.utils.job_monitor(merge, range(len(groups)), "PSPEC MERGE", lf=lf, maxiter=maxiter, verbose=verbose)
+    failures = hp.utils.job_monitor(merge, range(len(groups)), "PSPEC MERGE", lf=lf, maxiter=algs['pspec']['maxiter'], verbose=params['verbose'])
 
     # print failures if they exist
     if len(failures) > 0:
-        hp.utils.log("\nSome PSPEC MERGE jobs failed after {} tries:\n{}".format(maxiter, '\n'.join(["group {}: {}".format(i, str(groups[i])) for i in failures])), f=lf, verbose=verbose)
+        hp.utils.log("\nSome PSPEC MERGE jobs failed after {} tries:\n{}".format(algs['pspec']['maxiter'], '\n'.join(["group {}: {}".format(i, str(groups[i])) for i in failures])), f=lf, verbose=params['verbose'])
 
     # print to log
     time = datetime.utcnow()
-    hp.utils.log("\nFinished PSPEC pipeline: {}\n{}".format(time, "-"*60), f=lf, verbose=verbose)
+    hp.utils.log("\nFinished PSPEC pipeline: {}\n{}".format(time, "-"*60), f=lf, verbose=params['verbose'])
 
 
 #-------------------------------------------------------------------------------
 # Run Bootstrap Pipeline
 #-------------------------------------------------------------------------------
-if run_bootstrap:
-    # get algorithm parameters
-    globals().update(cf['algorithm']['bootstrap'])
+if params['run_bootstrap']:
+    # start block
     time = datetime.utcnow()
-    hp.utils.log("\n{}\nStarting BOOTSTRAP resampling pipeline: {}\n".format("-"*60, time), f=lf, verbose=verbose)
+    hp.utils.log("\n{}\nStarting BOOTSTRAP resampling pipeline: {}\n".format("-"*60, time), f=lf, verbose=params['verbose'])
+
+    # ensure outfname is same as psepc
+    if params['run_pspec'] and (algs['pspec']['outfname'] != algs['bootstrap']['psc_name']):
+        raise ValueError("bootstrap psc_name {} doesn't equal pspec outfname {}".format(algs['bootstrap']['psc_name'], algs['pspec']['outfname']))
 
     # open container
-    psc = hp.PSpecContainer(outfname, mode='r')
+    psc = hp.PSpecContainer(algs['bootstrap']['psc_name'], mode='r')
 
     # get groups
     groups = psc.groups()
     del psc
 
     # define bootstrap function
-    def bootstrap(i, filename=outfname, groups=groups, p=cf['algorithm']['bootstrap']):
+    def bootstrap(i, groups=groups, ef=ef, alg=algs['bootstrap'], params=params):
         try:
             # get container
-            psc = hp.PSpecContainer(filename, mode='rw')
+            psc = hp.PSpecContainer(alg['psc_name'], mode='rw')
 
             # get spectra
             group = groups[i]
             spectra = [os.path.join(group, sp) for sp in psc.spectra(group)]
 
             # run bootstrap
-            hp.grouping.bootstrap_run(psc, spectra=spectra, time_avg=p['time_avg'], Nsamples=p['Nsamples'],
-                                      seed=p['seed'], normal_std=p['normal_std'], robust_std=p['robust_std'],
-                                      conf_ints=p['conf_ints'], keep_samples=p['keep_samples'],
-                                      bl_error_tol=p['bl_error_tol'], overwrite=overwrite, verbose=verbose)
+            hp.grouping.bootstrap_run(psc, spectra=spectra, time_avg=alg['time_avg'], Nsamples=alg['Nsamples'],
+                                      seed=alg['seed'], normal_std=alg['normal_std'], robust_std=alg['robust_std'],
+                                      conf_ints=alg['conf_ints'], keep_samples=alg['keep_samples'],
+                                      bl_error_tol=alg['bl_error_tol'], overwrite=params['overwrite'], verbose=params['verbose'])
 
 
         except:
-            hp.utils.log("\nBOOTSTRAP job {} errored with:".format(i), f=ef, tb=sys.exc_info(), verbose=verbose)
+            hp.utils.log("\nBOOTSTRAP job {} errored with:".format(i), f=ef, tb=sys.exc_info(), verbose=params['verbose'])
             return 1
 
         return 0
 
     # launch bootstrap jobs
-    failures = hp.utils.job_monitor(bootstrap, range(len(groups)), "BOOTSTRAP", lf=lf, maxiter=maxiter, verbose=verbose)
+    failures = hp.utils.job_monitor(bootstrap, range(len(groups)), "BOOTSTRAP", lf=lf, maxiter=algs['bootstrap']['maxiter'], verbose=params['verbose'])
 
     # print failures if they exist
     if len(failures) > 0:
-        hp.utils.log("\nSome BOOTSTRAP jobs failed after {} tries:\n{}".format(maxiter, '\n'.join(["group {}: {}".format(i, str(groups[i])) for i in failures])), f=lf, verbose=verbose)
+        hp.utils.log("\nSome BOOTSTRAP jobs failed after {} tries:\n{}".format(algs['bootstrap']['maxiter'], '\n'.join(["group {}: {}".format(i, str(groups[i])) for i in failures])), f=lf, verbose=params['verbose'])
 
     # print to log
     time = datetime.utcnow()
-    hp.utils.log("\nFinished BOOTSTRAP pipeline: {}\n{}".format(time, "-"*60), f=lf, verbose=verbose)
+    hp.utils.log("\nFinished BOOTSTRAP pipeline: {}\n{}".format(time, "-"*60), f=lf, verbose=params['verbose'])
 

--- a/pipelines/pspec_pipeline/pspec_pipe.py
+++ b/pipelines/pspec_pipeline/pspec_pipe.py
@@ -65,7 +65,7 @@ else:
 os.chdir(work_dir)
 
 #-------------------------------------------------------------------------------
-# Run Jacknife Data Difference
+# Run Visibility Data Difference
 #-------------------------------------------------------------------------------
 if run_diff:
     # get algorithm parameters
@@ -110,8 +110,8 @@ if run_pspec:
             # parse dsets
             dsets = [dt.format(group=key[0], pol=key[2]), dt.format(group=key[1], pol=key[3])]
             dset_labels = [os.path.basename(d) for d in dsets]
-            if st is not None and st is not '' and st is not 'None':
-                dsets_std = [dt.format(group=key[0], pol=key[2]), dt.format(group=key[1], pol=key[3])]
+            if st is not None:
+                dsets_std = [st.format(group=key[0], pol=key[2]), st.format(group=key[1], pol=key[3])]
             else:
                 dsets_std = None
 

--- a/pipelines/pspec_pipeline/pspec_pipe.py
+++ b/pipelines/pspec_pipeline/pspec_pipe.py
@@ -67,7 +67,6 @@ else:
 # change to working dir
 os.chdir(work_dir)
 
-
 #-------------------------------------------------------------------------------
 # Run Jacknife Data Difference
 #-------------------------------------------------------------------------------
@@ -149,15 +148,16 @@ if run_pspec:
     hp.utils.log("\nStarting power spectrum file merge: {}\n{}".format(time, '-'*60), f=lf, verbose=verbose)
 
     # Get all groups
+    psc = hp.PSpecContainer(outfname, 'r')
     groups = psc.groups()
+    del psc
 
     # Define merge function
-    def merge(i, filename=filename, groups=groups):
+    def merge(i, groups=groups, filename=outfname):
         try:
             psc = hp.PSpecContainer(filename, mode='rw')
             grp = groups[i]
-            spectra = [os.path.join(grp, sp) for sp in psc.get_spectra(grp)]
-            hp.utils.merge_pspec(psc, spectra=spectra)
+            hp.container.merge_spectra(psc, groups=[grp])
         except:
             hp.utils.log("\nPSPEC MERGE job {} errored with:".format(i), f=ef, tb=sys.exc_info(), verbose=verbose)
             return 1

--- a/pipelines/pspec_pipeline/pspec_pipe.py
+++ b/pipelines/pspec_pipeline/pspec_pipe.py
@@ -14,7 +14,6 @@ import numpy as np
 import hera_cal as hc
 import hera_pspec as hp
 import hera_qm as hq
-import hera_stats as hs
 from pyuvdata import UVData
 import pyuvdata.utils as uvutils
 import os
@@ -283,17 +282,4 @@ if run_bootstrap:
     # print to log
     time = datetime.utcnow()
     hp.utils.log("\nFinished BOOTSTRAP pipeline: {}\n{}".format(time, "-"*60), f=lf, verbose=verbose)
-
-
-#-------------------------------------------------------------------------------
-# Run Statistical Evaluation Pipeline
-#-------------------------------------------------------------------------------
-if run_stats:
-    # get algorithm parameters
-    globals().update(cf['algorithm']['stats'])
-    time = datetime.utcnow()
-    hp.utils.log("\n{}\nstarting statistical evaluation pipeline: {}\n".format("-"*60, time), f=lf, verbose=verbose)
-
-    raise NotImplementedError
-
 

--- a/pipelines/pspec_pipeline/pspec_pipe.py
+++ b/pipelines/pspec_pipeline/pspec_pipe.py
@@ -41,9 +41,6 @@ globals().update(cf['io'])
 globals().update(cf['data'])
 globals().update(cf['analysis'])
 
-# get common suffix
-data_suffix = os.path.splitext(data_template)[1][1:]
-
 # open logfile
 logfile = os.path.join(out_dir, logfile)
 if os.path.exists(logfile) and overwrite == False:
@@ -186,21 +183,21 @@ if run_bootstrap:
     hp.utils.log("\n{}\nStarting BOOTSTRAP resampling pipeline: {}\n".format("-"*60, time), f=lf, verbose=verbose)
 
     # open container
-    psc = hp.PSpecContainer(filename, mode='r')
+    psc = hp.PSpecContainer(outfname, mode='r')
 
     # get groups
-    groups = psc.get_groups()
+    groups = psc.groups()
     del psc
 
     # define bootstrap function
-    def bootstrap(i, filename=filename, groups=groups, p=cf['algorithm']['bootstrap']):
+    def bootstrap(i, filename=outfname, groups=groups, p=cf['algorithm']['bootstrap']):
         try:
             # get container
             psc = hp.PSpecContainer(filename, mode='rw')
 
             # get spectra
             group = groups[i]
-            spectra = psc.spectra(group)
+            spectra = [os.path.join(group, sp) for sp in psc.spectra(group)]
 
             # run bootstrap
             hp.grouping.bootstrap_run(psc, spectra=spectra, time_avg=p['time_avg'], Nsamples=p['Nsamples'],

--- a/pipelines/pspec_pipeline/pspec_pipe.yaml
+++ b/pipelines/pspec_pipeline/pspec_pipe.yaml
@@ -48,8 +48,8 @@ data :
   std_template : None
 
   # baseline type restriction in length (meters) and angle (degrees)
-  bl_len_range : [0, 20.0]
-  bl_deg_range : [0, 180]
+  bl_len_range : [0, 16.0]
+  bl_deg_range : [0, 0]
 
   # denote bad antennas
   xants : []

--- a/pipelines/pspec_pipeline/pspec_pipe.yaml
+++ b/pipelines/pspec_pipeline/pspec_pipe.yaml
@@ -86,6 +86,15 @@ algorithm :
 
   # bootstrap pipeline
   bootstrap :
+    time_avg : True
+    Nsamples : 100
+    seed : None
+    normal_std : True
+    robust_std : True
+    conf_ints : None
+    keep_samples : False
+    bl_error_tol : 1.0
+    maxiter : 1
 
 
 

--- a/pipelines/pspec_pipeline/pspec_pipe.yaml
+++ b/pipelines/pspec_pipeline/pspec_pipe.yaml
@@ -44,15 +44,15 @@ data :
     - ['xx', 'xx']
 
   # full path to data template with {pol} and {group} fields
-  data_template : './zen.{group}.?????.{pol}.HH.uvXA'
+  data_template : 'zen.{group}.?????.{pol}.HH.uvXA'
   std_template : None
 
   # baseline type restriction in length (meters) and angle (degrees)
-  bl_len_range : [0, 16.0]
-  bl_deg_range : [0, 0]
+  bl_len_range : [14.0, 16.0]
+  bl_deg_range : [0, 10]
 
   # denote bad antennas
-  xants : []
+  xants : [0, 1, 50, 98]
 
 #---------------------------------------------------------------
 # Algorithm Parameters

--- a/pipelines/pspec_pipeline/pspec_pipe.yaml
+++ b/pipelines/pspec_pipeline/pspec_pipe.yaml
@@ -47,6 +47,13 @@ data :
   data_template : './zen.{group}.?????.{pol}.HH.uvXA'
   std_template : None
 
+  # baseline type restriction in length (meters) and angle (degrees)
+  bl_len_range : [0, 10000.0]
+  bl_deg_range : [0, 180]
+
+  # denote bad antennas
+  xants : []
+
 #---------------------------------------------------------------
 # Algorithm Parameters
 #---------------------------------------------------------------
@@ -78,11 +85,11 @@ algorithm :
     exclude_permutations : True
     bl_len_range : [0, 20]
     bl_deg_range : [40, 80]
-    xants : [] 
     maxiter : 1
 
   # bootstrap pipeline
   bootstrap :
+    psc_name : "pspec.h5"
     time_avg : True
     Nsamples : 100
     seed : None

--- a/pipelines/pspec_pipeline/pspec_pipe.yaml
+++ b/pipelines/pspec_pipeline/pspec_pipe.yaml
@@ -1,0 +1,91 @@
+# pspec_pipe.yaml
+#
+# hera_pspec IDR2.1 pipeline
+# configuration file
+#
+# Note: only strings, booleans, integers, floats,
+# lists, and lists of lists may be specified here.
+# When PSpecData parameters have required type None
+# use 'None' here, and for list of tuples,
+# use list of lists here.
+
+#---------------------------------------------------------------
+# IO Parameters
+#---------------------------------------------------------------
+io :
+  work_dir : './'         # directory to work in
+  out_dir : './'          # directory to dump all output in
+  logfile : 'pspipe_out.log'  # logfile   
+  errfile : 'pspipe_err.log' # error file
+  joinlog : False       # redirect error output into logfile
+  overwrite : True     # overwrite
+  verbose : True        # report feedback to standard output
+
+#---------------------------------------------------------------
+# Analysis Parameters
+#---------------------------------------------------------------
+analysis : 
+  run_split       : False       # Run jacknife split
+  run_pspec       : False       # Run power spectrum estimation
+  run_bootstrap   : True        # Run bootstrapping for errorbars
+  multiproc       : False       # use multiprocess module
+  nproc           : 8           # number of processes to spawn
+
+#---------------------------------------------------------------
+# Data Parameters
+#---------------------------------------------------------------
+data :
+  # Datafile group pairs to search for
+  group_pairs :
+    - ['2458042', '2458042']
+
+  # Datafile pol pairs to search for
+  pol_pairs :
+    - ['xx', 'xx']
+
+  # Define groupnaming convention
+  group_split_str : "_x_"
+
+  # full path to data template with {pol} and {group} fields
+  data_template : './zen.{group}.?????.{pol}.HH.uvXA'
+  std_template : None
+
+#---------------------------------------------------------------
+# Algorithm Parameters
+#---------------------------------------------------------------
+algorithm :
+
+  # jacknife split
+  split :
+    split_type : "antenna"
+
+  # pspec pipeline
+  pspec : 
+    outfname : "pspec.h5"
+    input_data_weight : "identity"
+    norm : "I"
+    taper : "none"
+    beam : "HERA_NF_dipole_power.beamfits"
+    cosmo : "None"
+    spw_ranges :
+      - [10, 20]
+    n_dlys : 
+      - 5
+    Jy2mK : True
+    rephase_to_dset : "None"
+    trim_dset_lsts : False
+    broadcast_dset_flags : True
+    time_thresh : 0.2
+    Nblps_per_job : 100
+    exclude_auto_bls : True
+    exclude_permutations : True
+    bl_len_range : [0, 20]
+    bl_deg_range : [40, 80]
+    xants : [] 
+    maxiter : 1
+
+  # bootstrap pipeline
+  bootstrap :
+
+
+

--- a/pipelines/pspec_pipeline/pspec_pipe.yaml
+++ b/pipelines/pspec_pipeline/pspec_pipe.yaml
@@ -48,7 +48,7 @@ data :
   std_template : None
 
   # baseline type restriction in length (meters) and angle (degrees)
-  bl_len_range : [0, 10000.0]
+  bl_len_range : [0, 20.0]
   bl_deg_range : [0, 180]
 
   # denote bad antennas
@@ -80,7 +80,7 @@ algorithm :
     trim_dset_lsts : False
     broadcast_dset_flags : True
     time_thresh : 0.2
-    Nblps_per_job : 100
+    Nblps_per_job : 200
     exclude_auto_bls : True
     exclude_permutations : True
     bl_len_range : [0, 20]
@@ -95,7 +95,7 @@ algorithm :
     seed : None
     normal_std : True
     robust_std : True
-    conf_ints : None
+    cintervals : None
     keep_samples : False
     bl_error_tol : 1.0
     maxiter : 1

--- a/pipelines/pspec_pipeline/pspec_pipe.yaml
+++ b/pipelines/pspec_pipeline/pspec_pipe.yaml
@@ -43,9 +43,6 @@ data :
   pol_pairs :
     - ['xx', 'xx']
 
-  # Define groupnaming convention
-  group_split_str : "_x_"
-
   # full path to data template with {pol} and {group} fields
   data_template : './zen.{group}.?????.{pol}.HH.uvXA'
   std_template : None
@@ -72,7 +69,7 @@ algorithm :
     n_dlys : 
       - 5
     Jy2mK : True
-    rephase_to_dset : "None"
+    rephase_to_dset : None
     trim_dset_lsts : False
     broadcast_dset_flags : True
     time_thresh : 0.2

--- a/pipelines/pspec_pipeline/pspec_pipe.yaml
+++ b/pipelines/pspec_pipeline/pspec_pipe.yaml
@@ -28,7 +28,6 @@ analysis :
   run_diff        : False       # Run visibility data difference
   run_pspec       : True        # Run power spectrum estimation
   run_bootstrap   : True        # Run bootstrapping for errorbars
-  run_stats       : False       # Run statistical comparisons
   multiproc       : False       # use multiprocess module
   nproc           : 8           # number of processes to spawn
 
@@ -96,8 +95,5 @@ algorithm :
     keep_samples : False
     bl_error_tol : 1.0
     maxiter : 1
-
-  # statistical pipeline
-  stats :
 
 

--- a/pipelines/pspec_pipeline/pspec_pipe.yaml
+++ b/pipelines/pspec_pipeline/pspec_pipe.yaml
@@ -25,9 +25,10 @@ io :
 # Analysis Parameters
 #---------------------------------------------------------------
 analysis : 
-  run_split       : False       # Run jacknife split
-  run_pspec       : False       # Run power spectrum estimation
+  run_diff        : False       # Run visibility data difference
+  run_pspec       : True        # Run power spectrum estimation
   run_bootstrap   : True        # Run bootstrapping for errorbars
+  run_stats       : False       # Run statistical comparisons
   multiproc       : False       # use multiprocess module
   nproc           : 8           # number of processes to spawn
 
@@ -55,8 +56,8 @@ data :
 #---------------------------------------------------------------
 algorithm :
 
-  # jacknife split
-  split :
+  # jacknife data difference
+  diff :
     split_type : "antenna"
 
   # pspec pipeline
@@ -96,5 +97,7 @@ algorithm :
     bl_error_tol : 1.0
     maxiter : 1
 
+  # statistical pipeline
+  stats :
 
 

--- a/scripts/bootstrap_run.py
+++ b/scripts/bootstrap_run.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+"""
+Pipeline script to load a PSpecContainer and bootstrap over redundant baseline-
+pair groups to produce errorbars.
+"""
+import sys
+import os
+from hera_pspec import pspecdata, grouping
+from hera_pspec import uvpspec_utils as uvputils
+
+# Parse commandline args
+args = grouping.get_bootstrap_run_argparser()
+a = args.parse_args()
+kwargs = vars(a) # dict of args
+
+# Get arguments
+filename = kwargs.pop('filename')
+
+# Run bootstrap
+grouping.bootstrap_run(filename, **kwargs)
+

--- a/scripts/psc_merge_spectra.py
+++ b/scripts/psc_merge_spectra.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+"""
+Command-line script for merging UVPSpec power spectra
+within a PSpecContainer.
+"""
+from hera_pspec import container
+
+# Parse commandline args
+args = container.get_merge_spectra_argparser()
+a = args.parse_args()
+
+container.merge_spectra(a.filename, uvp_split_str=a.uvp_split_str, 
+                        ext_split_str=a.ext_split_str, verbose=a.verbose)

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,9 @@ setup_args = {
     'install_requires': ['numpy>=1.10', 'scipy>=0.19',],
     'include_package_data': True,
     'scripts': ['scripts/pspec_run.py', 'scripts/pspec_red.py',
-                'pipelines/idr2_preprocessing/preprocess_data.py']
+                'pipelines/idr2_preprocessing/preprocess_data.py',
+                'pipelines/pspec_pipeline/pspec_pipe.py'],
+    'zip_safe':     False,
 }
 
 if __name__ == '__main__':

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ def package_files(package_dir, subdirectory):
             path = path.replace(package_dir + '/', '')
             paths.append(os.path.join(path, filename))
     return paths
-data_files = package_files('hera_pspec', 'data')
+data_files = package_files('hera_pspec', 'data') + package_files('hera_pspec', '../pipelines')
 
 setup_args = {
     'name':         'hera_pspec',
@@ -34,7 +34,8 @@ setup_args = {
     'include_package_data': True,
     'scripts': ['scripts/pspec_run.py', 'scripts/pspec_red.py',
                 'pipelines/idr2_preprocessing/preprocess_data.py',
-                'pipelines/pspec_pipeline/pspec_pipe.py'],
+                'pipelines/pspec_pipeline/pspec_pipe.py',
+                'scripts/bootstrap_run.py'],
     'zip_safe':     False,
 }
 


### PR DESCRIPTION
This adds the
• `pipelines/pspec_pipeline/pspec_pipe.py` 
• `pipelines/pspec_pipeline/pspec_pipe.yaml`
• `pipelines/pspec_pipeline/pspec_batch.sh`
scripts as version 1 of the power spectrum pipeline, which goes through the analysis blocks in the following order:

1. Visibility data difference (e.g. for jacknives) [optional]
2. OQE pipeline
3. Bootstrap error pipeline

This branch should be merged __after__ the `stats_array` branch is merged in.

A statistical evaluation step seems appropriate for this script (after 3.) but due to circular dependency with `hera_stats` its not possible to add it in. We should make a `stats_pipe.py` script and `stats_pipe.yaml` script in `hera_stats/pipelines/stats_pipe` of similar format to perform this last step of the full power spectrum pipeline.

[UPDATE]
The #145 PR and #148 PR were merged into this PR because they were all inter-dependent. 