### PR TITLE
Fixed baseline select

### DIFF
--- a/hera_pspec/tests/test_uvpspec.py
+++ b/hera_pspec/tests/test_uvpspec.py
@@ -199,6 +199,7 @@ class Test_UVPSpec(unittest.TestCase):
         nt.assert_equal(uvp2.Nblpairs, 1)
         nt.assert_equal(uvp2.data_array[0].shape, (10, 50, 1))
         nt.assert_almost_equal(uvp2.data_array[0][0,0,0], (1.0020010020000001+0j))
+        nt.assert_true(np.all(uvp2.bl_array == np.array([1002])))
         # blpair select
         uvp = copy.deepcopy(self.uvp)
         uvp2 = uvp.select(blpairs=[1002001002, 2003002003], inplace=False)

--- a/hera_pspec/uvpspec_utils.py
+++ b/hera_pspec/uvpspec_utils.py
@@ -125,8 +125,7 @@ def _select(uvp, spws=None, bls=None, only_pairs_in_bls=False, blpairs=None, tim
         uvp.Nblpairs = len(np.unique(uvp.blpair_array))
         uvp.Nblpairts = len(uvp.blpair_array)
         if bls is not None:
-            bl_array = np.unique(blpair_bls)
-            bl_select = reduce(operator.add, map(lambda b: uvp.bl_array==b, bl_array))
+            bl_select = [bl in bls for bl in uvp.bl_array]
             uvp.bl_array = uvp.bl_array[bl_select]
             uvp.bl_vecs = uvp.bl_vecs[bl_select]
             uvp.Nbls = len(uvp.bl_array)

--- a/hera_pspec/uvpspec_utils.py
+++ b/hera_pspec/uvpspec_utils.py
@@ -124,11 +124,17 @@ def _select(uvp, spws=None, bls=None, only_pairs_in_bls=False, blpairs=None, tim
         uvp.Ntimes = len(np.unique(uvp.time_avg_array))
         uvp.Nblpairs = len(np.unique(uvp.blpair_array))
         uvp.Nblpairts = len(uvp.blpair_array)
-        if bls is not None:
-            bl_select = [bl in bls for bl in uvp.bl_array]
-            uvp.bl_array = uvp.bl_array[bl_select]
-            uvp.bl_vecs = uvp.bl_vecs[bl_select]
-            uvp.Nbls = len(uvp.bl_array)
+
+        # Calculate unique baselines from new blpair_array
+        new_blpairs = np.unique(uvp.blpair_array)
+        bl1 = np.floor(new_blpairs / 1e6)
+        new_bls = np.unique([bl1, new_blpairs - bl1*1e6]).astype(np.int32)
+
+        # Set baseline attributes
+        bl_select = [bl in new_bls for bl in uvp.bl_array]
+        uvp.bl_array = uvp.bl_array[bl_select]
+        uvp.bl_vecs = uvp.bl_vecs[bl_select]
+        uvp.Nbls = len(uvp.bl_array)
 
     if pols is not None:
         # assert form


### PR DESCRIPTION
_select(uvp, bls=[...]) was returning a UVPSpec with the same bl_array as the original, even though it should have selected away baselines. Now it is selecting the right baselines from bl_array.

	modified:   hera_pspec/uvpspec_utils.py