### PR TITLE
Filtering fix for utils.calc_blpair_reds

### DIFF
--- a/hera_pspec/tests/test_utils.py
+++ b/hera_pspec/tests/test_utils.py
@@ -186,6 +186,14 @@ class Test_Utils(unittest.TestCase):
         nt.assert_true(isinstance(blps[0], list))
         nt.assert_equal(blps[0], [((24, 37), (25, 38)), ((24, 37), (24, 37))])
 
+        # test baseline select on uvd
+        uvd2 = copy.deepcopy(uvd)
+        uvd2.select(bls=[(24, 25), (37, 38), (24, 39)])
+        (bls1, bls2, blps, xants1,
+         xants2) = utils.calc_blpair_reds(uvd2, uvd2, filter_blpairs=True, exclude_auto_bls=True, exclude_permutations=True,
+                                   bl_len_range=(10.0, 20.0))  
+        nt.assert_equal(blps, [((24, 25), (37, 38))])
+
         # test exceptions
         uvd2 = copy.deepcopy(uvd)
         uvd2.antenna_positions[0] += 2

--- a/hera_pspec/utils.py
+++ b/hera_pspec/utils.py
@@ -174,7 +174,7 @@ def calc_blpair_reds(uvd1, uvd2, bl_tol=1.0, filter_blpairs=True, xant_flag_thre
     
     filter_blpairs : bool, optional
         if True, calculate xants and filters-out baseline pairs based on xant lists
-        and baselines in the data.
+        and actual baselines in the data.
 
     xant_flag_thresh : float, optional
         Fraction of 2D visibility (per-waterfall) needed to be flagged to 
@@ -283,6 +283,21 @@ def calc_blpair_reds(uvd1, uvd2, bl_tol=1.0, filter_blpairs=True, xant_flag_thre
                                     exclude_permutations=exclude_permutations)
         if len(bls1) < 1:
             continue
+
+        # filter based on real baselines in data
+        if filter_blpairs:
+            uvd1_bls = uvd1.get_antpairs()
+            uvd2_bls = uvd2.get_antpairs()
+            _bls1, _bls2 = [], []
+            for blp in blps:
+                bl1 = blp[0]
+                bl2 = blp[1]
+                if ((bl1 in uvd1_bls) or (bl1[::-1] in uvd1_bls)) \
+                    and ((bl2 in uvd2_bls) or (bl2[::-1] in uvd2_bls)):
+                    _bls1.append(bl1)
+                    _bls2.append(bl2)
+            bls1, bls2 = _bls1, _bls2
+            blps = zip(bls1, bls2)
 
         # group if desired
         if Nblps_per_group is not None:


### PR DESCRIPTION
Now, `filter_blpairs` not only identifies flagged ants and filters them, but also looks at the actual `bls` in uvd1 and uvd2 and filters the output `blps` list on what's present before returning. This solves a bug for a special case where the user has selected out some of the baselines associated w/ an antenna, but not all. If the latter is done, than the xant filtering solves this issue up front.