### PR TITLE
fixed bug in pspec_run.broadcast_dset_flags and incr test cvrg

### DIFF
--- a/hera_pspec/pspecdata.py
+++ b/hera_pspec/pspecdata.py
@@ -2746,7 +2746,7 @@ def pspec_run(dsets, filename, dsets_std=None, groupname=None, dset_labels=None,
 
     # broadcast flags
     if broadcast_dset_flags:
-        ds.broadcast_dset_flags(time_thresh=time_thresh)
+        ds.broadcast_dset_flags(time_thresh=time_thresh, spw_ranges=spw_ranges)
 
     # perform Jy to mK conversion if desired
     if Jy2mK:


### PR DESCRIPTION
Fixed a minor bug where the `spw_ranges` kwarg of `pspec_run` wasn't being propagated to its call to `broadcast_dset_flags`. Added a test to ensure this is done correctly, and in general tidied up and clarified the various tests in `test_pspec_run` function.