### PR TITLE
Noise sim validation

### DIFF
--- a/hera_pspec/testing.py
+++ b/hera_pspec/testing.py
@@ -226,7 +226,7 @@ def uvpspec_from_data(data, bl_grps, data_std=None, spw_ranges=None,
 def noise_sim(data, Tsys, beam, Nextend=0, seed=None, inplace=False,
               whiten=False, run_check=True):
     """
-    Generate a simulated Gaussian noise realization.
+    Generate a simulated Gaussian noise realization in Jy.
 
     Parameters
     ----------

--- a/hera_pspec/testing.py
+++ b/hera_pspec/testing.py
@@ -223,8 +223,8 @@ def uvpspec_from_data(data, bl_grps, data_std=None, spw_ranges=None,
     return uvp
 
 
-def noise_sim(data, Tsys, beam, Nextend=0, seed=None, inplace=False, whiten=False,
-              run_check=True):
+def noise_sim(data, Tsys, beam, Nextend=0, seed=None, inplace=False,
+              whiten=False, run_check=True):
     """
     Generate a simulated Gaussian noise realization.
 

--- a/hera_pspec/testing.py
+++ b/hera_pspec/testing.py
@@ -5,6 +5,7 @@ from collections import OrderedDict as odict
 from hera_pspec import uvpspec, pspecdata, conversions, pspecbeam, utils
 from pyuvdata import UVData
 from hera_cal.utils import JD2LST
+from scipy import stats
 
 
 def build_vanilla_uvpspec(beam=None):
@@ -83,7 +84,7 @@ def build_vanilla_uvpspec(beam=None):
                                    2005235.09142983,
                                   -3239928.42475397])
 
-    store_cov=True
+    store_cov = True
     cosmo = conversions.Cosmo_Conversions()
 
     data_array, wgt_array = {}, {}
@@ -220,3 +221,106 @@ def uvpspec_from_data(data, bl_grps, data_std=None, spw_ranges=None,
                    spw_ranges=spw_ranges, taper=taper, verbose=verbose, 
                    store_cov=store_cov, n_dlys=n_dlys)
     return uvp
+
+
+def noise_sim(data, Tsys, beam, Nextend=0, seed=None, inplace=False, whiten=False,
+              run_check=True):
+    """
+    Generate a simulated Gaussian noise realization.
+
+    Parameters
+    ----------
+    data : str or UVData object
+        A UVData object or path to miriad file.
+
+    Tsys : float
+        System temperature in Kelvin.
+
+    beam : str or PSpecBeam object
+        A PSpecBeam object or path to beamfits file.
+
+    Nextend : int, optional
+        Number of times to extend time axis by default length
+        before creating noise sim. Can be used to increase
+        number statistics before forming noise realization.
+
+    seed : int, optional
+        Seed to set before forming noise realization.
+
+    inplace : bool, optional
+        If True, overwrite input data and return None, else
+        make a copy and return copy.
+
+    whiten : bool, optional
+        If True, clear input data of flags if they exist and set all nsamples
+        to 1.
+
+    run_check : bool, optional
+        If True, run UVData check before return.
+
+    Returns
+    -------
+    data : UVData with noise realizations.
+    """
+    # Read data files
+    if isinstance(data, (str, np.str)):
+        _data = UVData()
+        _data.read_miriad(data)
+        data = _data
+    elif isinstance(data, UVData):
+        if not inplace:
+            data = copy.deepcopy(data)
+    assert isinstance(data, UVData)
+
+    # whiten input data
+    if whiten:
+        data.flag_array[:] = False
+        data.nsample_array[:] = 1.0
+
+    # Configure beam
+    if isinstance(beam, (str, np.str)):
+        beam = pspecbeam.PSpecBeamUV(beam)
+    assert isinstance(beam, pspecbeam.PSpecBeamBase)    
+
+    # Extend times
+    Nextend = int(Nextend)
+    if Nextend > 0:
+        assert data.phase_type == 'drift', "data must be drift phased in order to extend along time axis"
+        data = copy.deepcopy(data)
+        _data = copy.deepcopy(data)
+        dt = np.median(np.diff(np.unique(_data.time_array)))
+        dl = np.median(np.diff(np.unique(_data.lst_array)))
+        for i in range(Nextend):
+            _data.time_array += dt * _data.Ntimes * (i+1)
+            _data.lst_array += dl * _data.Ntimes * (i+1)
+            _data.lst_array %= 2*np.pi
+            data += _data
+
+    # Get Trms
+    int_time = data.integration_time
+    if not isinstance(int_time, np.ndarray):
+        int_time = np.array([int_time])
+    Trms = Tsys / np.sqrt(int_time[:, None, None, None] * data.nsample_array * data.channel_width)
+
+    # Get Vrms
+    freqs = np.unique(data.freq_array)[None, None, :, None]
+    K_to_Jy = [1e3 / (beam.Jy_to_mK(freqs.squeeze(), pol=p)) for p in data.polarization_array]
+    K_to_Jy = np.array(K_to_Jy).T[None, None, :, :]
+    Vrms = K_to_Jy * Trms
+
+    # Generate noise
+    if seed is not None:
+        np.random.seed(seed)
+    data.data_array = (stats.norm.rvs(0, 1./np.sqrt(2), size=Vrms.size).reshape(Vrms.shape) \
+                       + 1j * stats.norm.rvs(0, 1./np.sqrt(2), size=Vrms.size).reshape(Vrms.shape) ) * Vrms
+    f = np.isnan(data.data_array) + np.isinf(data.data_array)
+    data.data_array[f] = np.nan
+    data.flag_array[f] = True
+    data.vis_units = 'Jy'
+
+    if run_check:
+        data.check()
+
+    if not inplace:
+        return data
+

--- a/hera_pspec/tests/test_grouping.py
+++ b/hera_pspec/tests/test_grouping.py
@@ -183,7 +183,7 @@ def test_bootstrap_resampled_error():
         os.remove("uvp.h5")
 
 
-def validate_bootstrap_errorbar():
+def test_validate_bootstrap_errorbar():
     """ This is used to test the bootstrapping code
     against the gaussian noise visibility simulator.
     The basic premise is that, if working properly,
@@ -197,13 +197,13 @@ def validate_bootstrap_errorbar():
     Tsys = 300.0  # Kelvin
 
     # generate complex gaussian noise
-    seed = 0
+    seed = 4
     uvd1 = testing.noise_sim(uvfile, Tsys, beam, seed=seed, whiten=True, inplace=False, Nextend=4)
-    seed = 1
+    seed = 5
     uvd2 = testing.noise_sim(uvfile, Tsys, beam, seed=seed, whiten=True, inplace=False, Nextend=4)
 
     # get redundant baseline group
-    reds, lens, angs = utils.get_reds(uvd, pick_data_ants=True, bl_len_range=(10, 20),
+    reds, lens, angs = utils.get_reds(uvd1, pick_data_ants=True, bl_len_range=(10, 20),
                                       bl_deg_range=(0, 1))
     bls1, bls2, blps = utils.construct_blpairs(reds[0], exclude_auto_bls=False, exclude_permutations=False)
 
@@ -219,11 +219,11 @@ def validate_bootstrap_errorbar():
                                                                       robust_std=True, cintervals=[16, 84],
                                                                       verbose=False)
 
-    # assert bs_std z-score has std of ~1.0 along time ax to within 1%
-    bs_std_zscr = uvp_avg.data_array[0].real / uvp_avg.stats_array['bs_std'][0].real
-    nt.assert_true(np.abs(1.0 - np.mean(np.std(bs_std_zscr, axis=0))) < 0.01)
-    bs_std_zscr = uvp_avg.data_array[0].imag / uvp_avg.stats_array['bs_std'][0].imag
-    nt.assert_true(np.abs(1.0 - np.mean(np.std(bs_std_zscr, axis=0))) < 0.01)
+    # assert z-score has std of ~1.0 along time ax to within 1%
+    bs_std_zscr_real = np.std(uvp_avg.data_array[0].real) / np.mean(uvp_avg.stats_array['bs_std'][0].real)
+    nt.assert_true(np.abs(1.0 - bs_std_zscr_real) < 0.01)
+    bs_std_zscr_imag = np.std(uvp_avg.data_array[0].imag) / np.mean(uvp_avg.stats_array['bs_std'][0].imag)
+    nt.assert_true(np.abs(1.0 - bs_std_zscr_imag) < 0.01)
 
 
 def test_bootstrap_run():

--- a/hera_pspec/tests/test_grouping.py
+++ b/hera_pspec/tests/test_grouping.py
@@ -3,11 +3,12 @@ import nose.tools as nt
 import numpy as np
 import os
 from hera_pspec.data import DATA_PATH
-from hera_pspec import uvpspec, conversions, parameter, pspecbeam, pspecdata, testing
+from hera_pspec import uvpspec, conversions, parameter, pspecbeam, pspecdata, testing, utils
 from hera_pspec import uvpspec_utils as uvputils
 from hera_pspec import grouping, container
 from pyuvdata import UVData
 from hera_cal import redcal
+import copy
 
 
 class Test_grouping(unittest.TestCase):
@@ -99,7 +100,7 @@ class Test_grouping(unittest.TestCase):
         # Check that returned length is the same for groups too
         samp = grouping.sample_baselines(g1)
         self.assertEqual(len(g1), len(samp))
-    
+
     def test_bootstrap_average_blpairs(self):
         """
         Test bootstrap averaging over power spectra.
@@ -151,7 +152,7 @@ class Test_grouping(unittest.TestCase):
             ps_avg = uvp_avg.get_data((0, blpair, 'xx'))
             ps_boot = uvp4[0].get_data((0, blpair, 'xx'))
             np.testing.assert_array_almost_equal(ps_avg, ps_boot)
-        
+
 def test_bootstrap_resampled_error():
     # generate a UVPSpec
     visfile = os.path.join(DATA_PATH, "zen.even.xx.LST.1.28828.uvOCRSA")
@@ -180,6 +181,50 @@ def test_bootstrap_resampled_error():
 
     if os.path.exists("uvp.h5"):
         os.remove("uvp.h5")
+
+
+def validate_bootstrap_errorbar():
+    """ This is used to test the bootstrapping code
+    against the gaussian noise visibility simulator.
+    The basic premise is that, if working properly,
+    gaussian noise pspectra divided by their bootstrapped
+    errorbars should have a standard deviation that
+    converges to 1. """
+    # get simulated noise in Jy
+    bfile = os.path.join(DATA_PATH, 'HERA_NF_dipole_power.beamfits')
+    beam = pspecbeam.PSpecBeamUV(bfile)
+    uvfile = os.path.join(DATA_PATH, "zen.even.xx.LST.1.28828.uvOCRSA")
+    Tsys = 300.0  # Kelvin
+
+    # generate complex gaussian noise
+    seed = 0
+    uvd1 = testing.noise_sim(uvfile, Tsys, beam, seed=seed, whiten=True, inplace=False, Nextend=4)
+    seed = 1
+    uvd2 = testing.noise_sim(uvfile, Tsys, beam, seed=seed, whiten=True, inplace=False, Nextend=4)
+
+    # get redundant baseline group
+    reds, lens, angs = utils.get_reds(uvd, pick_data_ants=True, bl_len_range=(10, 20),
+                                      bl_deg_range=(0, 1))
+    bls1, bls2, blps = utils.construct_blpairs(reds[0], exclude_auto_bls=False, exclude_permutations=False)
+
+    # setup PSpecData and form power psectra
+    ds = pspecdata.PSpecData(dsets=[copy.deepcopy(uvd1), copy.deepcopy(uvd2)], wgts=[None, None], beam=beam)
+    ds.Jy_to_mK()
+    uvp = ds.pspec(bls1, bls2, (0, 1), [('xx', 'xx')], input_data_weight='identity', norm='I',
+                   taper='none', sampling=False, little_h=True, spw_ranges=[(0, 50)], verbose=False)
+
+    # bootstrap resample
+    uvp_avg, uvp_boots, uvp_wgts = grouping.bootstrap_resampled_error(uvp, time_avg=False, Nsamples=200,
+                                                                      seed=seed, normal_std=True,
+                                                                      robust_std=True, cintervals=[16, 84],
+                                                                      verbose=False)
+
+    # assert bs_std z-score has std of ~1.0 along time ax to within 1%
+    bs_std_zscr = uvp_avg.data_array[0].real / uvp_avg.stats_array['bs_std'][0].real
+    nt.assert_true(np.abs(1.0 - np.mean(np.std(bs_std_zscr, axis=0))) < 0.01)
+    bs_std_zscr = uvp_avg.data_array[0].imag / uvp_avg.stats_array['bs_std'][0].imag
+    nt.assert_true(np.abs(1.0 - np.mean(np.std(bs_std_zscr, axis=0))) < 0.01)
+
 
 def test_bootstrap_run():
     # generate a UVPSpec and container

--- a/hera_pspec/tests/test_noise.py
+++ b/hera_pspec/tests/test_noise.py
@@ -4,7 +4,7 @@ import numpy as np
 import os
 import sys
 from hera_pspec.data import DATA_PATH
-from hera_pspec import uvpspec, conversions, parameter, pspecbeam, noise
+from hera_pspec import uvpspec, conversions, pspecdata, pspecbeam, noise, testing, utils
 import copy
 import h5py
 from collections import OrderedDict as odict
@@ -62,6 +62,52 @@ class Test_Sensitivity(unittest.TestCase):
         Dsq = self.sense.calc_P_N(Tsys, t_int, k=k, Ncoherent=1, Nincoherent=1, form='DelSq')
         nt.assert_equal(Dsq.shape, (10,))
         nt.assert_true(Dsq[1] < P_N)
+
+
+def test_noise_validation():
+    """
+    make sure that the noise.py code produces
+    correct noise 1-sigma amplitude using a
+    noise simulation.
+    """
+    # get simulated noise in Jy
+    bfile = os.path.join(DATA_PATH, 'HERA_NF_dipole_power.beamfits')
+    beam = pspecbeam.PSpecBeamUV(bfile)
+    uvfile = os.path.join(DATA_PATH, "zen.even.xx.LST.1.28828.uvOCRSA")
+    Tsys = 300.0  # Kelvin
+
+    # generate noise
+    seed = 0
+    uvd = testing.noise_sim(uvfile, Tsys, beam, seed=seed, whiten=True, inplace=False, Nextend=9)
+
+    # get redundant baseline group
+    reds, lens, angs = utils.get_reds(uvd, pick_data_ants=True, bl_len_range=(10, 20),
+                                      bl_deg_range=(0, 1))
+    bls1, bls2, blps = utils.construct_blpairs(reds[0], exclude_auto_bls=True, exclude_permutations=True)
+
+    # setup PSpecData
+    ds = pspecdata.PSpecData(dsets=[copy.deepcopy(uvd), copy.deepcopy(uvd)], wgts=[None, None], beam=beam)
+    ds.Jy_to_mK()
+
+    # get pspec
+    uvp = ds.pspec(bls1, bls2, (0, 1), [('xx', 'xx')], input_data_weight='identity', norm='I',
+                   taper='none', sampling=False, little_h=True, spw_ranges=[(0, 50)], verbose=False)
+
+    # get noise spectra from one of the blpairs
+    P_N = uvp.generate_noise_spectra(0, 'xx', Tsys, blpairs=uvp.get_blpairs()[:1], num_steps=2000).values()[0][0, 0]
+
+    # get P_std of real spectra for each baseline across time axis
+    P_stds = np.array([np.std(uvp.get_data((0, bl, 'xx')).real, axis=1) for bl in uvp.get_blpairs()])
+
+    # get average P_std_avg and its standard error
+    P_std_avg = np.mean(P_stds)
+    
+    # assert close to P_N: 2%
+    # This should be updated to be within standard error on P_std_avg
+    # when the spw_range-variable pspec amplitude bug is resolved
+    nt.assert_true(np.abs(P_std_avg - P_N) / P_N < 0.02)
+
+
 
 
 

--- a/hera_pspec/tests/test_plot.py
+++ b/hera_pspec/tests/test_plot.py
@@ -331,8 +331,8 @@ class Test_Plot(unittest.TestCase):
         f4 = plot.delay_wedge(uvp, 0, 'xx', blpairs=None, times=None, fold=False, delay=False, component='abs', 
                               rotate=False, log10=True, loglog=False, red_tol=1.0,
                               center_line=True, horizon_lines=True, title='hello', ax=None, cmap='viridis',
-                              figsize=(8, 6), deltasq=False, colorbar=True, cbax=None, vmin=6, vmax=15,
-                              edgecolor='grey', flip_xax=True, flip_yax=True, lw=2)
+                              figsize=(8, 6), deltasq=True, colorbar=True, cbax=None, vmin=6, vmax=15,
+                              edgecolor='grey', flip_xax=True, flip_yax=True, lw=2, set_bl_tick_minor=True)
         plt.close()
 
         # feed axes, red_tol
@@ -343,7 +343,7 @@ class Test_Plot(unittest.TestCase):
                         rotate=True, log10=True, loglog=False, red_tol=10.0,
                         center_line=False, horizon_lines=False, ax=ax, cmap='viridis',
                         figsize=(8, 6), deltasq=False, colorbar=True, cbax=cbax, vmin=None, vmax=None,
-                        edgecolor='none', flip_xax=False, flip_yax=False, lw=2)
+                        edgecolor='none', flip_xax=False, flip_yax=False, lw=2, set_bl_tick_major=True)
         plt.close()
 
         # test exceptions

--- a/hera_pspec/tests/test_testing.py
+++ b/hera_pspec/tests/test_testing.py
@@ -80,6 +80,11 @@ def test_noise_sim():
     testing.noise_sim(uvn2, 300.0, seed=None, whiten=True, inplace=True)
     nt.assert_equal(uvn, uvn2)
 
+    # Test with a beam!
+    beamfile = os.path.join(DATA_PATH, 'HERA_NF_dipole_power.beamfits')
+    uvn = testing.noise_sim(copy.deepcopy(uvd), 300.0, beamfile, seed=0, whiten=True, inplace=False)
+    nt.assert_equal(uvn.vis_units, 'Jy')
+
     # test Tsys scaling
     uvn3 = testing.noise_sim(uvd2, 2*300.0, seed=0, whiten=True, inplace=False)
     nt.assert_almost_equal(np.std(uvn3.data_array[:, :, :, 1].real), 2*0.20655731998619664)

--- a/hera_pspec/tests/test_testing.py
+++ b/hera_pspec/tests/test_testing.py
@@ -5,6 +5,7 @@ import os
 from pyuvdata import UVData
 import numpy as np
 from hera_cal import redcal
+import copy
 
 
 def test_build_vanilla_uvpspec():
@@ -53,4 +54,46 @@ def test_uvpspec_from_data():
     # test std
     uvp = testing.uvpspec_from_data(fname, [(37, 38), (38, 39), (52, 53), (53, 54)],
                                     data_std=fname_std, beam=beam, spw_ranges=[(20,28)])
+
+def test_noise_sim():
+    uvd = UVData()
+    uvfile = os.path.join(DATA_PATH, "zen.even.xx.LST.1.28828.uvOCRSA")
+    uvd.read_miriad(uvfile)
+    bfile = os.path.join(DATA_PATH, "HERA_NF_dipole_power.beamfits")
+    beam = pspecbeam.PSpecBeamUV(bfile)
+
+    # test noise amplitude
+    uvn = testing.noise_sim(uvd, 300.0, beam, seed=0, whiten=True, inplace=False)
+    nt.assert_equal(uvn.Ntimes, uvd.Ntimes)
+    nt.assert_equal(uvn.Nfreqs, uvd.Nfreqs)
+    nt.assert_equal(uvn.Nbls, uvd.Nbls)
+    nt.assert_equal(uvn.Npols, uvd.Npols)
+    nt.assert_almost_equal(np.std(uvn.data_array.real), 6.054660787502636)
+    nt.assert_almost_equal(np.std(uvn.data_array.imag), 6.066085566037699)
+
+    # test seed and inplace
+    np.random.seed(0)
+    uvn2 = copy.deepcopy(uvd)
+    testing.noise_sim(uvn2, 300.0, beam, seed=None, whiten=True, inplace=True)
+    nt.assert_equal(uvn, uvn2)
+
+    # test Tsys scaling
+    uvn3 = testing.noise_sim(uvd, 2*300.0, beam, seed=0, whiten=True, inplace=False)
+    nt.assert_almost_equal(np.std(uvn3.data_array.real), 2*6.054660787502636)
+    nt.assert_almost_equal(np.std(uvn3.data_array.imag), 2*6.066085566037699)
+
+    # test pyuvdata backwards compatible integration_time attr
+    uvd2 = copy.deepcopy(uvd)
+    uvd2.integration_time = uvd2.integration_time[0]
+    uvn4 = testing.noise_sim(uvfile, 2*300.0, bfile, seed=0, 
+                             whiten=True, inplace=False, run_check=False)
+    nt.assert_equal(uvn3, uvn4)
+
+    # test Nextend
+    uvn = testing.noise_sim(uvd, 300.0, beam, seed=0, whiten=True, inplace=False, Nextend=4)
+    nt.assert_equal(uvn.Ntimes, uvd.Ntimes*5)
+    nt.assert_equal(uvn.Nfreqs, uvd.Nfreqs)
+    nt.assert_equal(uvn.Nbls, uvd.Nbls)
+    nt.assert_equal(uvn.Npols, uvd.Npols)
+
 

--- a/hera_pspec/tests/test_testing.py
+++ b/hera_pspec/tests/test_testing.py
@@ -59,48 +59,34 @@ def test_noise_sim():
     uvd = UVData()
     uvfile = os.path.join(DATA_PATH, "zen.even.xx.LST.1.28828.uvOCRSA")
     uvd.read_miriad(uvfile)
-    beam = UVBeam()
-    bfile = os.path.join(DATA_PATH, "HERA_NF_dipole_power.beamfits")
-    beam.read_beamfits(bfile)
-    beam2 = UVBeam()
-    beam2.read_beamfits(os.path.join(DATA_PATH, "HERA_NF_pstokes_power.beamfits"))
-    beam += beam2
-    beam = pspecbeam.PSpecBeamUV(beam)
 
     # test noise amplitude
     uvd2 = copy.deepcopy(uvd)
     uvd2.polarization_array[0] = 1
     uvd2 += uvd
-    uvn = testing.noise_sim(uvd2, 300.0, beam, seed=0, whiten=True, inplace=False)
+    uvn = testing.noise_sim(uvd2, 300.0, seed=0, whiten=True, inplace=False)
     nt.assert_equal(uvn.Ntimes, uvd2.Ntimes)
     nt.assert_equal(uvn.Nfreqs, uvd2.Nfreqs)
     nt.assert_equal(uvn.Nbls, uvd2.Nbls)
     nt.assert_equal(uvn.Npols, uvd2.Npols)
-    nt.assert_almost_equal(np.std(uvn.data_array[:, :, :, 1].real), 6.057816667533955)
-    nt.assert_almost_equal(np.std(uvn.data_array[:, :, :, 1].imag), 6.0793964903750775)
+    nt.assert_almost_equal(np.std(uvn.data_array[:, :, :, 1].real), 0.20655731998619664)
+    nt.assert_almost_equal(np.std(uvn.data_array[:, :, :, 1].imag), 0.20728471891024444)
     nt.assert_almost_equal(np.std(uvn.data_array[:, :, :, 0].real) / np.std(uvn.data_array[:, :, :, 1].real),
                            1/np.sqrt(2), places=2)
 
     # test seed and inplace
     np.random.seed(0)
     uvn2 = copy.deepcopy(uvd2)
-    testing.noise_sim(uvn2, 300.0, beam, seed=None, whiten=True, inplace=True)
+    testing.noise_sim(uvn2, 300.0, seed=None, whiten=True, inplace=True)
     nt.assert_equal(uvn, uvn2)
 
     # test Tsys scaling
-    uvn3 = testing.noise_sim(uvd, 2*300.0, beam, seed=0, whiten=True, inplace=False)
-    nt.assert_almost_equal(np.std(uvn3.data_array.real), 2*6.054660787502636)
-    nt.assert_almost_equal(np.std(uvn3.data_array.imag), 2*6.066085566037699)
-
-    # test pyuvdata backwards compatible integration_time attr
-    uvd2 = copy.deepcopy(uvd)
-    uvd2.integration_time = uvd2.integration_time[0]
-    uvn4 = testing.noise_sim(uvfile, 2*300.0, bfile, seed=0, 
-                             whiten=True, inplace=False, run_check=False)
-    nt.assert_equal(uvn3, uvn4)
+    uvn3 = testing.noise_sim(uvd2, 2*300.0, seed=0, whiten=True, inplace=False)
+    nt.assert_almost_equal(np.std(uvn3.data_array[:, :, :, 1].real), 2*0.20655731998619664)
+    nt.assert_almost_equal(np.std(uvn3.data_array[:, :, :, 1].imag), 2*0.20728471891024444)
 
     # test Nextend
-    uvn = testing.noise_sim(uvd, 300.0, beam, seed=0, whiten=True, inplace=False, Nextend=4)
+    uvn = testing.noise_sim(uvd, 300.0, seed=0, whiten=True, inplace=False, Nextend=4)
     nt.assert_equal(uvn.Ntimes, uvd.Ntimes*5)
     nt.assert_equal(uvn.Nfreqs, uvd.Nfreqs)
     nt.assert_equal(uvn.Nbls, uvd.Nbls)

--- a/hera_pspec/uvpspec.py
+++ b/hera_pspec/uvpspec.py
@@ -1570,13 +1570,8 @@ class UVPSpec(object):
                 if form == 'Pk':
                     pn = np.ones(len(dlys), np.float) * pn
 
-                # If pseudo stokes pol (as opposed to linear or circular pol),
-                # divide by extra factor of 2
-                if isinstance(pol, (np.str, str)):
-                    pol = uvutils.polstr2num(pol)
-
-                if pol in (1, 2, 3, 4): pn /= 2.0 # pseudo stokes pol
-                if real: pn /= np.sqrt(2) # if real divide by sqrt(2)
+                if real:
+                    pn /= np.sqrt(2) # if real divide by sqrt(2)
 
                 # append to P_blp
                 P_blp.append(pn)


### PR DESCRIPTION
Adds a `noise_sim` function to simulate uncorrelated gaussian noise, and to help validate the `noise.py` and `grouping.py` code. Specifically it serves as a simple validation test of

1. our `P_N` code in `noise.py`
2. our bootstrap errorbar code (averting the correlated-blpair bias by taking auto-blpair spectra) in `grouping.py`