### PR TITLE
Remove references to deprecated `low_hi` option for get_reds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ install:
   - conda info -a
 
   # create environment and install dependencies
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy nose pip matplotlib coverage
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION 'numpy <1.15.3' scipy nose pip matplotlib coverage
   - source activate test-environment
   - conda install -c conda-forge healpy aipy
   - pip install coveralls

--- a/examples/Bootstrap_example.ipynb
+++ b/examples/Bootstrap_example.ipynb
@@ -123,7 +123,7 @@
     "# Get list of redundant baseline groups\n",
     "antpos, ants = ds.dsets[0].get_ENU_antpos(pick_data_ants=True)\n",
     "antpos = dict(zip(ants, antpos))\n",
-    "red_bls = redcal.get_pos_reds(antpos, bl_error_tol=1.0, low_hi=True)\n",
+    "red_bls = redcal.get_pos_reds(antpos, bl_error_tol=1.0)\n",
     "\n",
     "# Print members of each redundant baseline group\n",
     "for i, redgrp in enumerate(red_bls):\n",

--- a/hera_pspec/tests/test_grouping.py
+++ b/hera_pspec/tests/test_grouping.py
@@ -161,7 +161,7 @@ def test_bootstrap_resampled_error():
     uvd = UVData()
     uvd.read_miriad(visfile)
     ap, a = uvd.get_ENU_antpos(pick_data_ants=True)
-    reds = redcal.get_pos_reds(dict(zip(a, ap)), low_hi=True, bl_error_tol=1.0)[:3]
+    reds = redcal.get_pos_reds(dict(zip(a, ap)), bl_error_tol=1.0)[:3]
     uvp = testing.uvpspec_from_data(uvd, reds, spw_ranges=[(50, 100)], beam=beam, cosmo=cosmo)
 
     # Lots of this function is already tested by bootstrap_run
@@ -190,7 +190,7 @@ def test_bootstrap_run():
     uvd = UVData()
     uvd.read_miriad(visfile)
     ap, a = uvd.get_ENU_antpos(pick_data_ants=True)
-    reds = redcal.get_pos_reds(dict(zip(a, ap)), low_hi=True, bl_error_tol=1.0)[:3]
+    reds = redcal.get_pos_reds(dict(zip(a, ap)), bl_error_tol=1.0)[:3]
     uvp = testing.uvpspec_from_data(uvd, reds, spw_ranges=[(50, 100)], beam=beam, cosmo=cosmo)
     if os.path.exists("ex.h5"):
         os.remove("ex.h5")

--- a/hera_pspec/tests/test_pspecdata.py
+++ b/hera_pspec/tests/test_pspecdata.py
@@ -958,7 +958,7 @@ class Test_PSpecData(unittest.TestCase):
         # check with redundant baseline group list
         antpos, ants = uvd.get_ENU_antpos(pick_data_ants=True)
         antpos = dict(zip(ants, antpos))
-        red_bls = map(lambda blg: sorted(blg), redcal.get_pos_reds(antpos, low_hi=True))[2]
+        red_bls = map(lambda blg: sorted(blg), redcal.get_pos_reds(antpos))[2]
         bls1, bls2, blps = utils.construct_blpairs(red_bls, exclude_permutations=True)
         uvp = ds.pspec(bls1, bls2, (0, 1), ('xx','xx'), input_data_weight='identity', norm='I', taper='none',
                                 little_h=True, verbose=False)

--- a/hera_pspec/tests/test_testing.py
+++ b/hera_pspec/tests/test_testing.py
@@ -38,7 +38,7 @@ def test_uvpspec_from_data():
 
     # test multiple bl groups
     antpos, ants = uvd.get_ENU_antpos(pick_data_ants=True)
-    reds = redcal.get_pos_reds(dict(zip(ants, antpos)), low_hi=True)
+    reds = redcal.get_pos_reds(dict(zip(ants, antpos)))
     uvp = testing.uvpspec_from_data(fname, reds[:3], beam=beam, spw_ranges=[(50, 100)])
     nt.assert_equal(len(set(uvp.bl_array) - set([137138, 137151, 137152, 138139, 138152, 138153, 139153, 139154,
                                                  151152, 151167, 152153, 152167, 152168, 153154, 153168, 153169,

--- a/hera_pspec/tests/test_utils.py
+++ b/hera_pspec/tests/test_utils.py
@@ -293,7 +293,7 @@ def test_get_blvec_reds():
     uvd = UVData()
     uvd.read_miriad(fname)
     antpos, ants = uvd.get_ENU_antpos(pick_data_ants=True)
-    reds = redcal.get_pos_reds(dict(zip(ants, antpos)), low_hi=True)
+    reds = redcal.get_pos_reds(dict(zip(ants, antpos)))
     uvp = testing.uvpspec_from_data(fname, reds[:2], spw_ranges=[(10, 40)])
 
     # test execution w/ dictionary

--- a/hera_pspec/utils.py
+++ b/hera_pspec/utils.py
@@ -905,7 +905,7 @@ def get_bl_lens_angs(blvecs, bl_error_tol=1.0):
 
 
 def get_reds(uvd, bl_error_tol=1.0, pick_data_ants=False, bl_len_range=(0, 1e4),
-             bl_deg_range=(0, 180), xants=None, add_autos=False, low_hi=True):
+             bl_deg_range=(0, 180), xants=None, add_autos=False):
     """
     Given a UVData object, a Miriad filepath or antenna position dictionary,
     calculate redundant baseline groups using hera_cal.redcal and optionally 
@@ -936,10 +936,6 @@ def get_reds(uvd, bl_error_tol=1.0, pick_data_ants=False, bl_len_range=(0, 1e4),
     add_autos : bool
         If True, add into autocorrelation group to the redundant group list.
 
-    low_hi : bool
-        If True, if the first bl in a redundant blgroup has ant1 > ant2,
-        then conjugate all baselines in the group.
-
     Returns (reds, lens, angs)
     ------- 
     reds : list
@@ -967,14 +963,7 @@ def get_reds(uvd, bl_error_tol=1.0, pick_data_ants=False, bl_len_range=(0, 1e4),
         antpos_dict = uvd
 
     # get redundant baselines
-    reds = redcal.get_pos_reds(antpos_dict, bl_error_tol=bl_error_tol, low_hi=False)
-    if low_hi:
-        _reds = []
-        for r in reds:
-            if r[0][0] > r[0][1]:
-                r = [_r[::-1] for _r in r]
-            _reds.append(r)
-        reds = _reds
+    reds = redcal.get_pos_reds(antpos_dict, bl_error_tol=bl_error_tol)
 
     # get vectors, len and ang for each baseline group
     vecs = np.array([antpos_dict[r[0][0]] - antpos_dict[r[0][1]] for r in reds])

--- a/scripts/pspec_red.py
+++ b/scripts/pspec_red.py
@@ -95,7 +95,7 @@ ds = hp.PSpecData(dsets=dsets, wgts=wgts, beam=beam)
 # Set-up which baselines to cross-correlate
 antpos, ants = dsets[0].get_ENU_antpos(pick_data_ants=True)
 antpos = dict(zip(ants, antpos))
-red_bls = redcal.get_pos_reds(antpos, bl_error_tol=1.0, low_hi=True)
+red_bls = redcal.get_pos_reds(antpos, bl_error_tol=1.0)
 
 # FIXME: Use only the first redundant baseline group for now
 bls = red_bls[0]


### PR DESCRIPTION
This follows https://github.com/HERA-Team/hera_cal/pull/370 and shouldn't be merged in until that PR is done.