### PR TITLE
Fix problems with spw select and polstr

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ cache:
     pip: true
 
 env:
-  - PYUVDATA_VERSION="@fae18f1a97e6c521b822b2ffc3c1afef4e2ac3b3"
+  - PYUVDATA_VERSION="@d6e1c2f80d7b5b59d7794c8f28d867a7030a7c75"
   - PYUVDATA_VERSION=""
 
 allow_failures:

--- a/hera_pspec/tests/test_utils.py
+++ b/hera_pspec/tests/test_utils.py
@@ -184,7 +184,7 @@ class Test_Utils(unittest.TestCase):
                                    Nblps_per_group=2)  
         nt.assert_equal(len(blps), 10)
         nt.assert_true(isinstance(blps[0], list))
-        nt.assert_equal(blps[0], [((37, 24), (38, 25)), ((37, 24), (37, 24))])
+        nt.assert_equal(blps[0], [((24, 37), (25, 38)), ((24, 37), (24, 37))])
 
         # test baseline select on uvd
         uvd2 = copy.deepcopy(uvd)

--- a/hera_pspec/tests/test_utils.py
+++ b/hera_pspec/tests/test_utils.py
@@ -184,7 +184,7 @@ class Test_Utils(unittest.TestCase):
                                    Nblps_per_group=2)  
         nt.assert_equal(len(blps), 10)
         nt.assert_true(isinstance(blps[0], list))
-        nt.assert_equal(blps[0], [((24, 37), (25, 38)), ((24, 37), (24, 37))])
+        nt.assert_equal(blps[0], [((37, 24), (38, 25)), ((37, 24), (37, 24))])
 
         # test baseline select on uvd
         uvd2 = copy.deepcopy(uvd)

--- a/hera_pspec/uvpspec_utils.py
+++ b/hera_pspec/uvpspec_utils.py
@@ -1,6 +1,7 @@
 import numpy as np
 import copy, operator
 from collections import OrderedDict as odict
+from pyuvdata.utils import polstr2num
 
 
 def subtract_uvp(uvp1, uvp2, run_check=True, verbose=False):
@@ -409,7 +410,7 @@ def _select(uvp, spws=None, bls=None, only_pairs_in_bls=False, blpairs=None,
 
         # if fed as strings convert to integers
         if isinstance(pols[0], (np.str, str)):
-            pols = map(lambda p: uvutils.polstr2num(p), pols)
+            pols = map(lambda p: polstr2num(p), pols)
 
         # create selection
         pol_select = np.array(reduce(operator.add, map(lambda p: uvp.pol_array == p, pols)))

--- a/hera_pspec/uvpspec_utils.py
+++ b/hera_pspec/uvpspec_utils.py
@@ -308,13 +308,19 @@ def _select(uvp, spws=None, bls=None, only_pairs_in_bls=False, blpairs=None,
     h5file : h5py file descriptor
         Used for loading in selection of data from HDF5 file.
     """
+    spw_mapping = None
     if spws is not None:
-        # make selections
+        # Get info for each spw that will be retained
         spw_freq_select = uvp.spw_to_freq_indices(spws)
         spw_dly_select = uvp.spw_to_dly_indices(spws)
         spw_select = uvp.spw_indices(spws)
         uvp.spw_freq_array = uvp.spw_freq_array[spw_freq_select]
         uvp.spw_dly_array = uvp.spw_dly_array[spw_dly_select]
+        
+        # Ordered list of old spw indices for the new spws
+        spw_mapping = uvp.spw_array[spw_select]
+        
+        # Update spw-related arrays (NB data arrays haven't been reordered yet!)
         uvp.spw_array = uvp.spw_array[spw_select]
         uvp.freq_array = uvp.freq_array[spw_freq_select]
         uvp.dly_array = uvp.dly_array[spw_dly_select]
@@ -324,7 +330,8 @@ def _select(uvp, spws=None, bls=None, only_pairs_in_bls=False, blpairs=None,
         uvp.Nspwfreqs = len(uvp.spw_freq_array)
         if hasattr(uvp, 'scalar_array'):
             uvp.scalar_array = uvp.scalar_array[spw_select, :]
-        # down-convert spw indices such that spw_array == np.arange(Nspws)
+        
+        # Down-convert spw indices such that spw_array == np.arange(Nspws)
         for i in range(uvp.Nspws):
             if i in uvp.spw_array:
                 continue
@@ -465,40 +472,41 @@ def _select(uvp, spws=None, bls=None, only_pairs_in_bls=False, blpairs=None,
                 statnames = []
 
         # iterate over spws
-        for s in uvp.spw_array:
+        if spw_mapping is None: spw_mapping = uvp.spw_array
+        for s, s_old in zip(uvp.spw_array, spw_mapping):
             # if h5file is passed, default to loading in data
             if h5file is not None:
                 # assign data arrays
-                _data = h5file['data_spw{}'.format(s)]
-                _wgts = h5file['wgt_spw{}'.format(s)]
-                _ints = h5file['integration_spw{}'.format(s)]
-                _nsmp = h5file['nsample_spw{}'.format(s)]
+                _data = h5file['data_spw{}'.format(s_old)]
+                _wgts = h5file['wgt_spw{}'.format(s_old)]
+                _ints = h5file['integration_spw{}'.format(s_old)]
+                _nsmp = h5file['nsample_spw{}'.format(s_old)]
                 # assign cov array
                 if store_cov:
-                    _covs = h5file['cov_spw{}'.format(s)]
+                    _covs = h5file['cov_spw{}'.format(s_old)]
                 # assign stats array
                 _stat = odict()
                 for statname in statnames:
                     if statname not in stats:
                         stats[statname] = odict()
-                    _stat[statname] = h5file["stats_{}_{}".format(statname, s)]
+                    _stat[statname] = h5file["stats_{}_{}".format(statname, s_old)]
 
             # if no h5file, we are performing a select, so use uvp's arrays
             else:
                 # assign data arrays
-                _data = uvp.data_array[s]
-                _wgts = uvp.wgt_array[s]
-                _ints = uvp.integration_array[s]
-                _nsmp = uvp.nsample_array[s]
+                _data = uvp.data_array[s_old]
+                _wgts = uvp.wgt_array[s_old]
+                _ints = uvp.integration_array[s_old]
+                _nsmp = uvp.nsample_array[s_old]
                 # assign cov
                 if store_cov:
-                    _covs = uvp.cov_array[s]
+                    _covs = uvp.cov_array[s_old]
                 # assign stats array
                 _stat = odict()
                 for statname in statnames:
                     if statname not in stats:
                         stats[statname] = odict()
-                    _stat[statname] = uvp.stats_array[statname][s]
+                    _stat[statname] = uvp.stats_array[statname][s_old]
 
             # slice data arrays and assign to dictionaries
             if sliceable:


### PR DESCRIPTION
(1) Fixes a problem with `UVPSpec.select()` assigning data arrays from the wrong spectral windows when `spws` is not `None`.
(2) Fixes issue with polstr conversion in `select()`.
(3) Fixes unit test failure caused by change in ordering of bl tuple elements.