### PR TITLE
Enable cross-pol power spectra *and* Python 3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 python:
   # We don't actually use the Travis Python, but this keeps it organized.
   - "2.7"
+  - "3.7"
 
 # Cache pip-installed dependencies
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,18 +2,18 @@ language: python
 python:
   # We don't actually use the Travis Python, but this keeps it organized.
   - "2.7"
-  - "3.7"
+  - "3.7-dev"
 
 # Cache pip-installed dependencies
 cache:
     pip: true
 
 env:
-  - PYUVDATA_VERSION="@d6e1c2f80d7b5b59d7794c8f28d867a7030a7c75"
   - PYUVDATA_VERSION=""
+  #- PYUVDATA_VERSION="@d6e1c2f80d7b5b59d7794c8f28d867a7030a7c75"
 
-allow_failures:
-  - env: PYUVDATA_VERSION=""
+#allow_failures:
+#  - env: PYUVDATA_VERSION=""
 
 install:
   # ensure that we have the full tag information available for version.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ install:
   # create environment and install dependencies
   - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy nose pip matplotlib coverage
   - source activate test-environment
-  - conda install -c conda-forge healpy aipy
+  - conda install -c conda-forge healpy aipy scikit-learn
   - pip install coveralls
   - pip install h5py
   - pip install git+https://github.com/HERA-Team/pyuvdata.git$PYUVDATA_VERSION

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 python:
   # We don't actually use the Travis Python, but this keeps it organized.
   - "2.7"
-  - "3.7-dev"
+  - "3.6"
 
 # Cache pip-installed dependencies
 cache:

--- a/hera_pspec/grouping.py
+++ b/hera_pspec/grouping.py
@@ -47,7 +47,7 @@ def group_baselines(bls, Ngroups, keep_remainder=False, randomize=False,
         List of grouped baselines.
     """
     Nbls = len(bls) # Total baselines
-    n = Nbls / Ngroups # Baselines per group
+    n = Nbls // Ngroups # Baselines per group
     rem = Nbls - n*Ngroups
 
     # Sanity check on number of groups
@@ -192,15 +192,15 @@ def average_spectra(uvp_in, blpair_groups=None, time_avg=False,
 
         # Convert blpair_groups to list of blpair group integers
         if isinstance(blpair_groups[0][0], tuple):
-            new_blpair_grps = [map(lambda blp: uvp.antnums_to_blpair(blp), blpg)
+            new_blpair_grps = [[uvp.antnums_to_blpair(blp) for blp in blpg]
                                for blpg in blpair_groups]
             blpair_groups = new_blpair_grps
     else:
         # If not, each baseline pair is its own group
-        blpair_groups = map(lambda blp: [blp], np.unique(uvp.blpair_array))
+        blpair_groups = [[blp] for blp in np.unique(uvp.blpair_array)]
         assert blpair_weights is None, "Cannot specify blpair_weights if "\
                                        "blpair_groups is None."
-        blpair_weights = map(lambda blp: [1.,], np.unique(uvp.blpair_array))
+        blpair_weights = [[1.,] for blp in np.unique(uvp.blpair_array)]
 
     # Print warning if a blpair appears more than once in all of blpair_groups
     all_blpairs = [item for sublist in blpair_groups for item in sublist]
@@ -236,8 +236,8 @@ def average_spectra(uvp_in, blpair_groups=None, time_avg=False,
 
     # For baseline pairs not in blpair_groups, add them as their own group
     extra_blpairs = set(uvp.blpair_array) - set(all_blpairs)
-    blpair_groups += map(lambda blp: [blp], extra_blpairs)
-    blpair_weights += map(lambda blp: [1.,], extra_blpairs)
+    blpair_groups += [[blp] for blp in extra_blpairs]
+    blpair_weights += [[1.,] for blp in extra_blpairs]
 
     # Create new data arrays
     data_array, wgts_array = odict(), odict()
@@ -255,9 +255,9 @@ def average_spectra(uvp_in, blpair_groups=None, time_avg=False,
         spw_stats = odict([[stat, []] for stat in stat_l])
         if store_cov:
             spw_cov = []
-
+        
         # Iterate over polarizations
-        for i, p in enumerate(uvp.pol_array):
+        for i, p in enumerate(uvp.polpair_array):
             pol_data, pol_wgts, pol_ints, pol_nsmp = [], [], [], []
             pol_stats = odict([[stat, []] for stat in stat_l])
             if store_cov:
@@ -413,7 +413,8 @@ def average_spectra(uvp_in, blpair_groups=None, time_avg=False,
 
     # Update arrays
     bl_arr = np.array(sorted(set(bl_arr)))
-    bl_vecs = np.array(map(lambda bl: uvp.bl_vecs[uvp.bl_array.tolist().index(bl)], bl_arr))
+    bl_vecs = np.array([uvp.bl_vecs[uvp.bl_array.tolist().index(bl)] 
+                        for bl in bl_arr])
 
     # Assign arrays and metadata to UVPSpec object
     uvp.Ntimes = len(np.unique(time_avg_arr))
@@ -506,15 +507,15 @@ def fold_spectra(uvp):
                                                                          +leftright\
                                                                          +rightleft\
                                                                          +rightright)
-                uvp.cov_array[spw][:, :Ndlys/2, :, :] = 0.0
-                uvp.cov_array[spw][:, :, :Ndlys/2, : :] = 0.0
+                uvp.cov_array[spw][:, :Ndlys//2, :, :] = 0.0
+                uvp.cov_array[spw][:, :, :Ndlys//2, : :] = 0.0
 
             # fold stats array if it exists: sum in inverse quadrature
             if hasattr(uvp, 'stats_array'):
                 for stat in uvp.stats_array.keys():
                     left = uvp.stats_array[stat][spw][:, 1:Ndlys//2, :][:, ::-1, :]
                     right = uvp.stats_array[stat][spw][:, Ndlys//2+1:, :]
-                    uvp.stats_array[stat][spw][:, Ndlys//2+1:, :] = (np.sum([1/left**2.0, 1/right**2.0], axis=0))**(-0.5)
+                    uvp.stats_array[stat][spw][:, Ndlys//2+1:, :] = (np.sum([1./left**2.0, 1./right**2.0], axis=0))**(-0.5)
                     uvp.data_array[spw][:, :Ndlys//2, :] = np.nan
 
         else:
@@ -535,15 +536,15 @@ def fold_spectra(uvp):
                                                                          +leftright\
                                                                          +rightleft\
                                                                          +rightright)
-                uvp.cov_array[spw][:, :Ndlys/2, :, :] = 0.0
-                uvp.cov_array[spw][:, :, :Ndlys/2, : :] = 0.0
+                uvp.cov_array[spw][:, :Ndlys//2, :, :] = 0.0
+                uvp.cov_array[spw][:, :, :Ndlys//2, : :] = 0.0
 
             # fold stats array if it exists: sum in inverse quadrature
             if hasattr(uvp, 'stats_array'):
                 for stat in uvp.stats_array.keys():
                     left = uvp.stats_array[stat][spw][:, :Ndlys//2, :][:, ::-1, :]
                     right = uvp.stats_array[stat][spw][:, Ndlys//2+1:, :]
-                    uvp.stats_array[stat][spw][:, Ndlys//2+1:, :] = (np.sum([1/left**2.0, 1/right**2.0], axis=0))**(-0.5)
+                    uvp.stats_array[stat][spw][:, Ndlys//2+1:, :] = (np.sum([1./left**2.0, 1./right**2.0], axis=0))**(-0.5)
                     uvp.data_array[spw][:, :Ndlys//2, :] = np.nan
 
     uvp.folded = True
@@ -631,14 +632,15 @@ def bootstrap_average_blpairs(uvp_list, blpair_groups, time_avg=False,
 
     # Convert blpair tuples into blpair integers if necessary
     if isinstance(blpair_groups[0][0], tuple):
-        new_blp_grps = [map(lambda blp: uvputils._antnums_to_blpair(blp), blpg)
+        new_blp_grps = [[uvputils._antnums_to_blpair(blp) for blp in blpg]
                         for blpg in blpair_groups]
         blpair_groups = new_blp_grps
 
     # Homogenise input UVPSpec objects in terms of available polarizations 
     # and spectral windows
     if len(uvp_list) > 1:
-        uvp_list = uvpspec_utils.select_common(uvp_list, spws=True, pols=True, inplace=False)
+        uvp_list = uvpspec_utils.select_common(uvp_list, spws=True, 
+                                               pols=True, inplace=False)
 
     # Loop over UVPSpec objects, looking for available blpairs in each
     avail_blpairs = [np.unique(uvp.blpair_array) for uvp in uvp_list]
@@ -785,12 +787,14 @@ def bootstrap_resampled_error(uvp, blpair_groups=None, time_avg=False, Nsamples=
 
     # get all keys in uvp_avg and get data from each uvp_boot
     keys = uvp_avg.get_all_keys()
-    uvp_boot_data = odict([(k, np.array(map(lambda u: u.get_data(k), uvp_boots))) for k in keys])
+    uvp_boot_data = odict([(k, np.array([u.get_data(k) for u in uvp_boots])) 
+                           for k in keys])
 
     # calculate various error estimates
     if normal_std:
         for k in keys:
-            nstd = np.std(uvp_boot_data[k].real, axis=0) + 1j*np.std(uvp_boot_data[k].imag, axis=0)
+            nstd = np.std(uvp_boot_data[k].real, axis=0) \
+                 + 1j*np.std(uvp_boot_data[k].imag, axis=0)
             uvp_avg.set_stats("bs_std", k, nstd)
 
     if robust_std:
@@ -895,7 +899,9 @@ def bootstrap_run(filename, spectra=None, blpair_groups=None, time_avg=False, Ns
     assert len(groups) > 0, "No groups exist in PSpecContainer"
 
     # get spectra if not fed
-    all_spectra = utils.flatten([map(lambda s: os.path.join(grp, s), psc.spectra(grp)) for grp in groups])
+    all_spectra = utils.flatten([ [os.path.join(grp, s) 
+                                   for s in psc.spectra(grp)] 
+                                 for grp in groups ])
     if spectra is None:
         spectra = all_spectra
     else:
@@ -910,11 +916,15 @@ def bootstrap_run(filename, spectra=None, blpair_groups=None, time_avg=False, Ns
         # run boostrap_resampled_error
         uvp = psc.get_pspec(grp, spc)
         (uvp_avg, uvp_boots,
-         uvp_wgts) = bootstrap_resampled_error(uvp, blpair_groups=blpair_groups, time_avg=time_avg,
-                                              Nsamples=Nsamples, seed=seed, normal_std=normal_std,
-                                              robust_std=robust_std, cintervals=cintervals,
-                                              bl_error_tol=bl_error_tol, add_to_history=add_to_history,
-                                              verbose=verbose)
+         uvp_wgts) = bootstrap_resampled_error(uvp, blpair_groups=blpair_groups, 
+                                               time_avg=time_avg,
+                                               Nsamples=Nsamples, seed=seed, 
+                                               normal_std=normal_std,
+                                               robust_std=robust_std, 
+                                               cintervals=cintervals,
+                                               bl_error_tol=bl_error_tol, 
+                                               add_to_history=add_to_history,
+                                               verbose=verbose)
 
         # set averaged uvp
         psc.set_pspec(grp, spc+"_avg", uvp_avg, overwrite=overwrite)
@@ -930,7 +940,7 @@ def get_bootstrap_run_argparser():
            description="argument parser for grouping.bootstrap_run()")
     
     def list_of_lists_of_tuples(s):
-        s = map(lambda x: map(int, x.split()), s.split(','))
+        s = [[int(_x) for _x in x.split()] for x in s.split(',')]
         return s
 
     # Add list of arguments

--- a/hera_pspec/plot.py
+++ b/hera_pspec/plot.py
@@ -294,10 +294,12 @@ def delay_spectrum(uvp, blpairs, spw, pol, average_blpairs=False,
         return fig
 
 
-def delay_waterfall(uvp, blpairs, spw, pol, component='real', average_blpairs=False, 
-                    fold=False, delay=True, deltasq=False, log=True, lst_in_hrs=True,
-                    vmin=None, vmax=None, cmap='YlGnBu', axes=None, figsize=(14, 6),
-                    force_plot=False, times=None, title_type='blpair'):
+def delay_waterfall(uvp, blpairs, spw, pol, component='real', 
+                    average_blpairs=False, fold=False, delay=True, 
+                    deltasq=False, log=True, lst_in_hrs=True,
+                    vmin=None, vmax=None, cmap='YlGnBu', axes=None, 
+                    figsize=(14, 6), force_plot=False, times=None, 
+                    title_type='blpair'):
     """
     Plot a 1D delay spectrum waterfall (or spectra) for a group of baselines.
     
@@ -484,7 +486,8 @@ def delay_waterfall(uvp, blpairs, spw, pol, component='real', average_blpairs=Fa
     Nvert, Nhorz = axes.shape
 
     # Get LST range: setting y-ticks is tricky due to LST wrapping...
-    y = uvp_plt.lst_avg_array[uvp_plt.key_to_indices(waterfall.keys()[0])[1]]
+    y = uvp_plt.lst_avg_array[
+            uvp_plt.key_to_indices(list(waterfall.keys())[0])[1] ]
     if lst_in_hrs:
         lst_units = "Hr"
         y = np.around(y * 24 / (2*np.pi), 2)
@@ -516,7 +519,7 @@ def delay_waterfall(uvp, blpairs, spw, pol, component='real', average_blpairs=Fa
                                  r"{\rm unnormed}")
 
     # Iterate over waterfall keys
-    keys = waterfall.keys()
+    keys = list(waterfall.keys())
     k = 0
     for i in range(Nvert):
         for j in range(Nhorz):
@@ -533,8 +536,9 @@ def delay_waterfall(uvp, blpairs, spw, pol, component='real', average_blpairs=Fa
             blp = uvp_plt.blpair_to_antnums(key[1])
 
             # plot waterfall
-            cax = ax.matshow(waterfall[key], cmap=cmap, aspect='auto', vmin=vmin, vmax=vmax, 
-                                 extent=[np.min(x), np.max(x), Ny, 0])
+            cax = ax.matshow(waterfall[key], cmap=cmap, aspect='auto', 
+                             vmin=vmin, vmax=vmax, 
+                             extent=[np.min(x), np.max(x), Ny, 0])
 
             # ax config
             ax.xaxis.set_ticks_position('bottom')
@@ -593,13 +597,14 @@ def delay_wedge(uvp, spw, pol, blpairs=None, times=None, fold=False, delay=True,
                 red_tol=1.0, center_line=False, horizon_lines=False,
                 title=None, ax=None, cmap='viridis', figsize=(8, 6),
                 deltasq=False, colorbar=False, cbax=None, vmin=None, vmax=None,
-                edgecolor='none', flip_xax=False, flip_yax=False, lw=2, set_bl_tick_major=False,
-                set_bl_tick_minor=False, xtick_size=10, xtick_rot=0, ytick_size=10, ytick_rot=0,
+                edgecolor='none', flip_xax=False, flip_yax=False, lw=2, 
+                set_bl_tick_major=False, set_bl_tick_minor=False, 
+                xtick_size=10, xtick_rot=0, ytick_size=10, ytick_rot=0,
                 **kwargs):
     """
     Plot a 2D delay spectrum (or spectra) from a UVPSpec object. Note that
-    all integrations and redundant baselines are averaged (unless specifying times)
-    before plotting.
+    all integrations and redundant baselines are averaged (unless specifying 
+    times) before plotting.
     
     Parameters
     ----------
@@ -609,8 +614,8 @@ def delay_wedge(uvp, spw, pol, blpairs=None, times=None, fold=False, delay=True,
     spw : integer
         Which spectral window to plot.
 
-    pol : int or str
-        Polarization integer or string
+    pol : int or tuple
+        Polarization-pair integer or tuple, e.g. ('pI', 'pI')
 
     blpairs : list of tuples, optional
         List of baseline-pair tuples to use in plotting.
@@ -696,8 +701,8 @@ def delay_wedge(uvp, spw, pol, blpairs=None, times=None, fold=False, delay=True,
         Line-width of horizon and center lines if plotted. Default: 2.
 
     set_bl_tick_major : bool, optional
-        If True, use the baseline lengths as major ticks, rather than default uniform
-        grid.
+        If True, use the baseline lengths as major ticks, rather than default 
+        uniform grid.
 
     set_bl_tick_minor : bool, optional
         If True, use the baseline lengths as minor ticks, which have no labels.
@@ -714,7 +719,7 @@ def delay_wedge(uvp, spw, pol, blpairs=None, times=None, fold=False, delay=True,
     uvp = copy.deepcopy(uvp)
     assert isinstance(uvp, uvpspec.UVPSpec), "input uvp must be a UVPSpec object"
     assert isinstance(spw, (int, np.integer))
-    assert isinstance(pol, (int, str, np.integer, np.str))
+    assert isinstance(pol, (int, np.integer, tuple))
 
     # check pspec units for little h
     little_h = 'h^-3' in uvp.norm_units
@@ -733,7 +738,8 @@ def delay_wedge(uvp, spw, pol, blpairs=None, times=None, fold=False, delay=True,
 
     # Average across redundant groups and time
     # this also ensures blpairs are ordered from short_bl --> long_bl
-    blp_grps, lens, angs, tags = utils.get_blvec_reds(uvp, bl_error_tol=red_tol, match_bl_lens=True)
+    blp_grps, lens, angs, tags = utils.get_blvec_reds(uvp, bl_error_tol=red_tol, 
+                                                      match_bl_lens=True)
     uvp.average_spectra(blpair_groups=blp_grps, time_avg=True, inplace=True)
 
     # Convert to DeltaSq
@@ -814,14 +820,16 @@ def delay_wedge(uvp, spw, pol, blpairs=None, times=None, fold=False, delay=True,
     # Configure ticks
     if set_bl_tick_major:
         if rotate:
-            ax.set_xticks(map(lambda x: np.around(x, _get_sigfig(x)+2), x_axis))
+            ax.set_xticks([np.around(x, _get_sigfig(x)+2) for x in x_axis])
         else:
-            ax.set_yticks(map(lambda x: np.around(x, _get_sigfig(x)+2), y_axis))
+            ax.set_yticks([np.around(x, _get_sigfig(x)+2) for x in y_axis])
     if set_bl_tick_minor:
         if rotate:
-            ax.set_xticks(map(lambda x: np.around(x, _get_sigfig(x)+2), x_axis), minor=True)
+            ax.set_xticks([np.around(x, _get_sigfig(x)+2) for x in x_axis], 
+                          minor=True)
         else:
-            ax.set_yticks(map(lambda x: np.around(x, _get_sigfig(x)+2), y_axis), minor=True)
+            ax.set_yticks([np.around(x, _get_sigfig(x)+2) for x in y_axis], 
+                          minor=True)
 
     # Add colorbar
     if colorbar:

--- a/hera_pspec/pspecbeam.py
+++ b/hera_pspec/pspecbeam.py
@@ -277,10 +277,11 @@ class PSpecBeamBase(object):
             if isinstance(pol2, (int, np.integer)):
                 pol2 = uvutils.polnum2str(pol2)
             
-            # Check for cross-pol; only auto-pol calculation currently supported
+            # Check for cross-pol; only same-pol calculation currently supported
             if pol1 != pol2:
                 raise NotImplementedError(
-                        "get_Omegas does not support cross-polarized beams yet. "
+                        "get_Omegas does not support cross-correlation between "
+                        "two different visibility polarizations yet. "
                         "Could not calculate Omegas for (%s, %s)" % (pol1, pol2))
             
             # Calculate Omegas

--- a/hera_pspec/pspecbeam.py
+++ b/hera_pspec/pspecbeam.py
@@ -1,6 +1,7 @@
 import numpy as np
 import os
 import hera_pspec.conversions as conversions
+import hera_pspec.uvpspec_utils as uvputils
 import scipy.integrate as integrate
 from scipy.interpolate import interp1d
 from pyuvdata import UVBeam, utils as uvutils
@@ -71,7 +72,7 @@ def _compute_pspec_scalar(cosmo, beam_freqs, omega_ratio, pspec_freqs,
     
     # Get redshifts and cosmological functions
     redshifts = cosmo.f2z(integration_freqs).flatten()
-    X2Y = np.array(map(lambda z: cosmo.X2Y(z, little_h=little_h), redshifts))
+    X2Y = np.array([cosmo.X2Y(z, little_h=little_h) for z in redshifts])
 
     # Use linear interpolation to interpolate the frequency-dependent 
     # quantities derived from the beam model to the same frequency grid as the 
@@ -238,14 +239,15 @@ class PSpecBeamBase(object):
         return 1e-20 * conversions.cgs_units.c**2 \
                / (2 * conversions.cgs_units.kb * freqs**2 * Op)
 
-    def get_Omegas(self, pols):
+    def get_Omegas(self, polpairs):
         """
-        Get OmegaP and OmegaPP across beam_freqs for requested polarizations.
+        Get OmegaP and OmegaPP across beam_freqs for requested polarization 
+        pairs.
 
         Parameters
         ----------
-        pols : list
-            List of polarization strings or integers.
+        polpairs : list
+            List of polarization-pair tuples or integers.
 
         Returns
         -------
@@ -255,24 +257,38 @@ class PSpecBeamBase(object):
         OmegaPP : array_like
             Array containing power_sq_beam_int, shape: (Nbeam_freqs, Npols).
         """
-        # type check
-        if isinstance(pols, (int, np.int, np.int32)):
-            pols = [pols]
-        elif isinstance(pols, (str, np.str)):
-            pols = [pols]
-        if isinstance(pols, (list, np.ndarray, tuple)):
-            if isinstance(pols[0], (int, np.int, np.int32)):
-                pols = map(lambda p: uvutils.polnum2str(p), pols)
-                
-        # initialize blank lists
+        # Unpack polpairs into tuples
+        if not isinstance(polpairs, (list, np.ndarray)):
+            if isinstance(polpairs, (tuple, int, np.integer)):
+                polpairs = [polpairs,]
+            else:
+                raise TypeError("polpairs is not a list of integers or tuples")
+        
+        # Convert integers to tuples
+        polpairs = [uvputils.polpair_int2tuple(p) 
+                        if isinstance(p, (int, np.integer, np.int32)) else p 
+                        for p in polpairs]
+        
+        # Calculate Omegas for each pol pair
         OmegaP, OmegaPP = [], []
-        for p in pols:
-            OmegaP.append(self.power_beam_int(pol=p))
-            OmegaPP.append(self.power_beam_sq_int(pol=p))
+        for pol1, pol2 in polpairs:
+            if isinstance(pol1, (int, np.integer)):
+                pol1 = uvutils.polnum2str(pol1)
+            if isinstance(pol2, (int, np.integer)):
+                pol2 = uvutils.polnum2str(pol2)
+            
+            # Check for cross-pol; only auto-pol calculation currently supported
+            if pol1 != pol2:
+                raise NotImplementedError(
+                        "get_Omegas does not support cross-polarized beams yet. "
+                        "Could not calculate Omegas for (%s, %s)" % (pol1, pol2))
+            
+            # Calculate Omegas
+            OmegaP.append(self.power_beam_int(pol=pol1))
+            OmegaPP.append(self.power_beam_sq_int(pol=pol1))
 
         OmegaP = np.array(OmegaP).T
         OmegaPP = np.array(OmegaPP).T
-
         return OmegaP, OmegaPP
 
 

--- a/hera_pspec/pspecdata.py
+++ b/hera_pspec/pspecdata.py
@@ -1086,12 +1086,7 @@ class PSpecData(object):
             raise ValueError("Number of delay bins should have been set"
                              "by now! Cannot be equal to None.")
         
-        try:
-            H = np.zeros((self.spw_Ndlys, self.spw_Ndlys), dtype=np.complex)
-        except:
-            print("exception:", self.spw_Ndlys, self.spw_Ndlys)
-            raise
-            
+        H = np.zeros((self.spw_Ndlys, self.spw_Ndlys), dtype=np.complex)
         R1 = self.R(key1)
         R2 = self.R(key2)
 

--- a/hera_pspec/pspecdata.py
+++ b/hera_pspec/pspecdata.py
@@ -1651,7 +1651,7 @@ class PSpecData(object):
         """
         # make sure polarizations are the same
         if isinstance(polpair, int):
-            polpair = uvutils.polpair_int2tuple(polpair)
+            polpair = uvputils.polpair_int2tuple(polpair)
         if polpair[0] != polpair[1]:
             raise NotImplementedError(
                     "Polarizations don't match. Beam scalar can only be "

--- a/hera_pspec/pspecdata.py
+++ b/hera_pspec/pspecdata.py
@@ -1841,14 +1841,16 @@ class PSpecData(object):
             where the first index is for the Left-Hand dataset and second index
             is used for the Right-Hand dataset (see above).
 
-        pols : length-2 tuple of strings or integers or list of length-2 
+        pols : length-2 tuple of strings or integers, or list of length-2 
             tuples of strings or integers
             Contains polarization pairs to use in forming power spectra
             e.g. ('XX','XX') or [('XX','XX'),('pI','pI')] or list of 
             polarization pairs.
-            Only auto/equal polarization pairs are implemented at the moment.
-            It uses the polarizations of the UVData onjects (specified in dsets)
-            by default only if the UVData object consists of equal polarizations.
+            
+            If a primary_beam is specified, only equal-polarization pairs can 
+            be cross-correlated, as the beam scalar normalization is only 
+            implemented in this case. To obtain unnormalized spectra for pairs 
+            of different polarizations, set the primary_beam to None.
 
         n_dlys : list of integer, optional
             The number of delay bins to use. The order in the list corresponds
@@ -2101,8 +2103,10 @@ class PSpecData(object):
                     
                     # Raise error if cross-pol is requested
                     if (p[0] != p[1]):
-                        raise NotImplementedError("Cross-polarized beams are "
-                                                  "not yet implemented")
+                        raise NotImplementedError(
+                            "Visibilities with different polarizations can only "
+                            "be cross-correlated if primary_beam = None. Cannot "
+                            "compute beam scalar for mixed polarizations.")
                     
                     # using zero'th indexed polarization, as cross-polarized 
                     # beams are not yet implemented

--- a/hera_pspec/pspecdata.py
+++ b/hera_pspec/pspecdata.py
@@ -1621,9 +1621,11 @@ class PSpecData(object):
 
         Parameters
         ----------
-        polpair: tuple or int
-                Which pair of polarizations to compute the beam scalar for.
-                e.g. ('pI', 'pI') or ('XX', 'YY').
+        polpair: tuple, int, or str
+                Which pair of polarizations to compute the beam scalar for,
+                e.g. ('pI', 'pI') or ('XX', 'YY'). If string, will assume that 
+                the specified polarization is to be cross-correlated with 
+                itself, e.g. 'XX' implies ('XX', 'XX').
 
         little_h : boolean, optional
                 Whether to have cosmological length units be h^-1 Mpc or Mpc
@@ -1652,12 +1654,13 @@ class PSpecData(object):
         # make sure polarizations are the same
         if isinstance(polpair, int):
             polpair = uvputils.polpair_int2tuple(polpair)
+        if isinstance(polpair, str):
+            polpair = (polpair, polpair)
         if polpair[0] != polpair[1]:
             raise NotImplementedError(
                     "Polarizations don't match. Beam scalar can only be "
                     "calculated for auto-polarization pairs at the moment.")
-        else:
-            pol = polpair[0]
+        pol = polpair[0]
         
         # set spw_range and get freqs
         freqs = self.freqs[self.spw_range[0]:self.spw_range[1]]

--- a/hera_pspec/pstokes.py
+++ b/hera_pspec/pstokes.py
@@ -8,8 +8,8 @@ from hera_pspec import version
 from collections import OrderedDict as odict
 
 
-# weights used in forming Stokes visibilities.
-# see pyuvdata.utils.polstr2num for conversion between polarization string
+# Weights used in forming Stokes visibilities.
+# See pyuvdata.utils.polstr2num for conversion between polarization string
 # and polarization integer. Ex. {'XX': -5, ...}
 pol_weights = {
     1: odict([(-5, 1.), (-6, 1.)]),
@@ -26,7 +26,8 @@ def miriad2pyuvdata(dset, antenna_nums=None, bls=None, polarizations=None,
     Parameters
     ----------
     dset : str
-        Miriad file to convert to UVData object containing visibilities and corresponding metadata
+        Miriad file to convert to UVData object containing visibilities and 
+        corresponding metadata
 
     antenna_nums: integer list
         The antennas numbers to read into the object.
@@ -56,7 +57,8 @@ def miriad2pyuvdata(dset, antenna_nums=None, bls=None, polarizations=None,
     """
     uvd = pyuvdata.UVData()
     uvd.read_miriad(dset, antenna_nums=antenna_nums, bls=bls,
-                    polarizations=polarizations, ant_str=ant_str, time_range=time_range)
+                    polarizations=polarizations, ant_str=ant_str, 
+                    time_range=time_range)
     return uvd
 
 
@@ -91,8 +93,10 @@ def _combine_pol(uvd1, uvd2, pol1, pol2, pstokes='pI'):
     -------
     uvdS : UVData object
     """
-    assert isinstance(uvd1, pyuvdata.UVData), "uvd1 must be a pyuvdata.UVData instance"
-    assert isinstance(uvd2, pyuvdata.UVData), "uvd2 must be a pyuvdata.UVData instance"
+    assert isinstance(uvd1, pyuvdata.UVData), \
+        "uvd1 must be a pyuvdata.UVData instance"
+    assert isinstance(uvd2, pyuvdata.UVData), \
+        "uvd2 must be a pyuvdata.UVData instance"
 
     # convert pol1 and/or pol2 to integer if fed as a string
     if isinstance(pol1, (str, np.str)):
@@ -121,9 +125,12 @@ def _combine_pol(uvd1, uvd2, pol1, pol2, pstokes='pI'):
     pstokes_str = pyuvdata.utils.polnum2str(pstokes)
 
     # assert pstokes in pol_weights, and pol1 and pol2 in pol_weights[pstokes]
-    assert pstokes in pol_weights, "unrecognized pstokes parameter {}".format(pstokes_str)
-    assert pol1 in pol_weights[pstokes], "pol1 {} not used in constructing pstokes {}".format(pol1_str, pstokes_str)
-    assert pol2 in pol_weights[pstokes], "pol2 {} not used in constructing pstokes {}".format(pol2_str, pstokes_str)
+    assert pstokes in pol_weights, \
+        "unrecognized pstokes parameter {}".format(pstokes_str)
+    assert pol1 in pol_weights[pstokes], \
+        "pol1 {} not used in constructing pstokes {}".format(pol1_str, pstokes_str)
+    assert pol2 in pol_weights[pstokes], \
+        "pol2 {} not used in constructing pstokes {}".format(pol2_str, pstokes_str)
 
     # constructing Stokes visibilities
     stdata = 0.5 * (pol_weights[pstokes][pol1]*data1 + pol_weights[pstokes][pol2]*data2)
@@ -132,8 +139,8 @@ def _combine_pol(uvd1, uvd2, pol1, pol2, pstokes='pI'):
     uvdS = copy.deepcopy(uvd1)
     uvdS.data_array = stdata  # pseudo-stokes data
     uvdS.flag_array = flag  # flag array
-    uvdS.polarization_array = np.array([pstokes], dtype=np.int)  # polarization number
-    uvdS.nsample_array = uvd1.nsample_array + uvd2.nsample_array  # nsamples
+    uvdS.polarization_array = np.array([pstokes], dtype=np.int) # polarization number
+    uvdS.nsample_array = uvd1.nsample_array + uvd2.nsample_array # nsamples
     uvdS.history = "Merged into pseudo-stokes vis with hera_pspec version {} Git hash {}\n{}" \
                     "{}{}{}{}\n".format(version.version, version.git_hash, "-"*20+'\n',
                     'dset1 history:\n', uvd1.history, '\n'+'-'*20+'\ndset2 history:\n',
@@ -195,8 +202,8 @@ def construct_pstokes(dset1, dset2, pstokes='pI', run_check=True, antenna_nums=N
         Ex: ['xx', 'yy', ...]
 
     time_range: float list
-        len-2 list containing min and max range of times (Julian Date) to read-in.
-        Ex: [2458115.20, 2458115.40]
+        len-2 list containing min and max range of times (Julian Date) to 
+        read-in. Ex: [2458115.20, 2458115.40]
 
     history : str
         Extra history string to add to concatenated pseudo-Stokes visibility.
@@ -207,15 +214,19 @@ def construct_pstokes(dset1, dset2, pstokes='pI', run_check=True, antenna_nums=N
     """
     # convert dset1 and dset2 to UVData objects if they are miriad files
     if isinstance(dset1, pyuvdata.UVData) == False:
-        assert isinstance(dset1, (str, np.str)), "dset1 must be fed as a string or UVData object"
+        assert isinstance(dset1, (str, np.str)), \
+            "dset1 must be fed as a string or UVData object"
         uvd1 = miriad2pyuvdata(dset1, antenna_nums=antenna_nums, bls=bls,
-                               polarizations=polarizations, ant_str=ant_str, time_range=time_range)
+                               polarizations=polarizations, ant_str=ant_str, 
+                               time_range=time_range)
     else:
         uvd1 = dset1
     if isinstance(dset2, pyuvdata.UVData) == False:
-        assert isinstance(dset2, (str, np.str)), "dset2 must be fed as a string or UVData object"
+        assert isinstance(dset2, (str, np.str)), \
+            "dset2 must be fed as a string or UVData object"
         uvd2 = miriad2pyuvdata(dset2, antenna_nums=antenna_nums, bls=bls,
-                               polarizations=polarizations, ant_str=ant_str, time_range=time_range)
+                               polarizations=polarizations, ant_str=ant_str, 
+                               time_range=time_range)
     else:
         uvd2 = dset2
 
@@ -246,23 +257,28 @@ def construct_pstokes(dset1, dset2, pstokes='pI', run_check=True, antenna_nums=N
     if np.array_equal(bls1, bls2) == False:
         raise ValueError("dset1 and dset2 must have the same baselines")
 
-    # makes the Npol length==1 so that the UVData carries data for the required polarization only
-    st_keys = pol_weights[pstokes].keys()
+    # makes the Npol length==1 so that the UVData carries data for the 
+    # required polarization only
+    st_keys = list(pol_weights[pstokes].keys())
     req_pol1 = st_keys[0]
     req_pol2 = st_keys[1]
 
-    # check polarizations of UVData objects are consistent with the required polarization
-    # to form the desired pseudo Stokes visibilities. If multiple exist, downselect on polarization.
-    assert req_pol1 in uvd1.polarization_array, "Polarization {} not found in dset1 object".format(req_pol1)
+    # check polarizations of UVData objects are consistent with the required 
+    # polarization to form the desired pseudo Stokes visibilities. If multiple 
+    # exist, downselect on polarization.
+    assert req_pol1 in uvd1.polarization_array, \
+        "Polarization {} not found in dset1 object".format(req_pol1)
     if uvd1.Npols > 1:
         uvd1 = uvd1.select(polarizations=req_pol1, inplace=False)
 
-    assert req_pol2 in uvd2.polarization_array, "Polarization {} not found in dset2 object".format(req_pol2)
+    assert req_pol2 in uvd2.polarization_array, \
+        "Polarization {} not found in dset2 object".format(req_pol2)
     if uvd2.Npols > 1:
         uvd2 = uvd2.select(polarizations=req_pol1, inplace=False)
 
     # combining visibilities to form the desired Stokes visibilties
-    uvdS = _combine_pol(uvd1=uvd1, uvd2=uvd2, pol1=req_pol1, pol2=req_pol2, pstokes=pstokes)
+    uvdS = _combine_pol(uvd1=uvd1, uvd2=uvd2, pol1=req_pol1, pol2=req_pol2, 
+                        pstokes=pstokes)
     uvdS.history += history
 
     if run_check:
@@ -295,8 +311,10 @@ def filter_dset_on_stokes_pol(dsets, pstokes):
         to construct_pstokes to make the desired pseudo-Stokes visibility.
     """
     # type check
-    assert isinstance(dsets, list), "dsets must be fed as a list of UVData objects"
-    assert np.all(isinstance(d, UVData) for d in dsets), "dsets must be fed as a list of UVData objects"
+    assert isinstance(dsets, list), \
+        "dsets must be fed as a list of UVData objects"
+    assert np.all(isinstance(d, UVData) for d in dsets), \
+        "dsets must be fed as a list of UVData objects"
 
     # get polarization of each dset
     pols = [d.polarization_array[0] for d in dsets]
@@ -304,12 +322,15 @@ def filter_dset_on_stokes_pol(dsets, pstokes):
     # convert pstokes to integer if a string
     if isinstance(pstokes, (str, np.str)):
         pstokes = pyuvdata.utils.polstr2num(pstokes)
-    assert pstokes in [1, 2, 3, 4], "pstokes must be fed as a pseudo-Stokes parameter"
+    assert pstokes in [1, 2, 3, 4], \
+        "pstokes must be fed as a pseudo-Stokes parameter"
 
     # get two necessary dipole pols given pstokes
-    desired_pols = pol_weights[pstokes].keys()
-    assert desired_pols[0] in pols and desired_pols[1] in pols, "necessary input pols {} and {} not found in dsets".format(*desired_pols)
+    desired_pols = list(pol_weights[pstokes].keys())
+    assert desired_pols[0] in pols and desired_pols[1] in pols, \
+        "necessary input pols {} and {} not found in dsets".format(*desired_pols)
 
-    inp_dsets = [dsets[pols.index(desired_pols[0])], dsets[pols.index(desired_pols[1])]]
+    inp_dsets = [dsets[pols.index(desired_pols[0])], 
+                 dsets[pols.index(desired_pols[1])]]
 
     return inp_dsets

--- a/hera_pspec/testing.py
+++ b/hera_pspec/testing.py
@@ -59,8 +59,8 @@ def build_vanilla_uvpspec(beam=None):
     freq_array = np.repeat(np.linspace(100e6, 105e6, Nfreqs, endpoint=False), 
                            Nspws)
     dly_array = np.repeat(utils.get_delays(freq_array, n_dlys=Ndlys), Nspws)
-    pol_array = np.array([-5])
-    Npols = len(pol_array)
+    polpair_array = np.array([505,])
+    Npols = len(polpair_array)
     vis_units = 'unknown'
     norm_units = 'Hz str'
     weighting = 'identity'
@@ -105,7 +105,8 @@ def build_vanilla_uvpspec(beam=None):
               'Nblpairs', 'Nblpairts', 'Npols', 'Ndlys', 'Nbls', 
               'blpair_array', 'time_1_array', 'time_2_array', 
               'lst_1_array', 'lst_2_array', 'spw_array',
-              'dly_array', 'freq_array', 'pol_array', 'data_array', 'wgt_array',
+              'dly_array', 'freq_array', 'polpair_array', 'data_array', 
+              'wgt_array',
               'integration_array', 'bl_array', 'bl_vecs', 'telescope_location',
               'vis_units', 'channel_width', 'weighting', 'history', 'taper', 
               'norm', 'git_hash', 'nsample_array', 'time_avg_array', 

--- a/hera_pspec/testing.py
+++ b/hera_pspec/testing.py
@@ -76,7 +76,8 @@ def build_vanilla_uvpspec(beam=None):
     label_1_array = np.ones((Nspws, Nblpairts, Npols), np.int) * 0
     label_2_array = np.ones((Nspws, Nblpairts, Npols), np.int) * 1
     if beam is not None:
-        OmegaP, OmegaPP = beam.get_Omegas(beam.primary_beam.polarization_array[0])
+        pol = beam.primary_beam.polarization_array[0]
+        OmegaP, OmegaPP = beam.get_Omegas((pol,pol))
         beam_freqs = beam.beam_freqs
 
     # HERA coordinates in Karoo Desert, SA
@@ -221,6 +222,7 @@ def uvpspec_from_data(data, bl_grps, data_std=None, spw_ranges=None,
     uvp = ds.pspec(bls1, bls2, (0, 1), (pol, pol), input_data_weight='identity', 
                    spw_ranges=spw_ranges, taper=taper, verbose=verbose, 
                    store_cov=store_cov, n_dlys=n_dlys)
+    
     return uvp
 
 

--- a/hera_pspec/testing.py
+++ b/hera_pspec/testing.py
@@ -59,7 +59,7 @@ def build_vanilla_uvpspec(beam=None):
     freq_array = np.repeat(np.linspace(100e6, 105e6, Nfreqs, endpoint=False), 
                            Nspws)
     dly_array = np.repeat(utils.get_delays(freq_array, n_dlys=Ndlys), Nspws)
-    polpair_array = np.array([505,])
+    polpair_array = np.array([1515,]) # corresponds to ('xx','xx')
     Npols = len(polpair_array)
     vis_units = 'unknown'
     norm_units = 'Hz str'

--- a/hera_pspec/tests/test_container.py
+++ b/hera_pspec/tests/test_container.py
@@ -53,7 +53,7 @@ class Test_PSpecContainer(unittest.TestCase):
                       psname=psname, pspec=self.uvp, overwrite=False)
         
         # Check that wrong pspec types are rejected by the set() method
-        assert_raises(ValueError, ps_store.set_pspec, group=group_names[2], 
+        assert_raises(TypeError, ps_store.set_pspec, group=group_names[2], 
                       psname=psname, pspec=np.arange(11), overwrite=True)
         assert_raises(TypeError, ps_store.set_pspec, group=group_names[2], 
                       psname=psname, pspec=1, overwrite=True)

--- a/hera_pspec/tests/test_conversions.py
+++ b/hera_pspec/tests/test_conversions.py
@@ -10,7 +10,8 @@ from hera_pspec import conversions
 class Test_Cosmo(unittest.TestCase):
 
     def setUp(self):
-        self.C = conversions.Cosmo_Conversions(Om_L=0.68440, Om_b=0.04911, Om_c=0.26442, H0=100.0,
+        self.C = conversions.Cosmo_Conversions(Om_L=0.68440, Om_b=0.04911, 
+                                               Om_c=0.26442, H0=100.0,
                                                Om_M=None, Om_k=None)
     def tearDown(self):
         pass
@@ -40,9 +41,12 @@ class Test_Cosmo(unittest.TestCase):
 
     def test_distances(self):
         self.assertAlmostEqual(self.C.f2z(100e6), 13.20405751)
+        self.assertAlmostEqual(self.C.f2z(0.1, ghz=True), 13.20405751)
         self.assertAlmostEqual(self.C.z2f(10.0), 129127795.54545455)
+        self.assertAlmostEqual(self.C.z2f(10.0, ghz=True), 0.12912779554545455)
         self.assertAlmostEqual(self.C.E(10.0), 20.450997530682947)
         self.assertAlmostEqual(self.C.DC(10.0), 6499.708111027144)
+        self.assertAlmostEqual(self.C.DC(10.0, little_h=False), 6499.708111027144)
         self.assertAlmostEqual(self.C.DM(10.0), 6510.2536925709637)
         self.assertAlmostEqual(self.C.DA(10.0), 591.84124477917851)
         self.assertAlmostEqual(self.C.dRperp_dtheta(10.0), 6510.2536925709637)
@@ -54,18 +58,25 @@ class Test_Cosmo(unittest.TestCase):
     def test_little_h(self):
         # Test that putting in a really low value of H0 into the conversions object
         # has no effect on the result if little_h=True units are used
-        self.C = conversions.Cosmo_Conversions(Om_L=0.68440, Om_b=0.04911, Om_c=0.26442, H0=25.12,
+        self.C = conversions.Cosmo_Conversions(Om_L=0.68440, Om_b=0.04911, 
+                                               Om_c=0.26442, H0=25.12,
                                                Om_M=None, Om_k=None)
         self.assertAlmostEqual(self.C.f2z(100e6), 13.20405751)
         self.assertAlmostEqual(self.C.z2f(10.0), 129127795.54545455)
         self.assertAlmostEqual(self.C.E(10.0), 20.450997530682947)
         self.assertAlmostEqual(self.C.DC(10.0, little_h=True), 6499.708111027144)
+        self.assertAlmostEqual(self.C.DC(10.0, little_h=False), 
+                               6499.708111027144*100./25.12)
         self.assertAlmostEqual(self.C.DM(10.0, little_h=True), 6510.2536925709637)
         self.assertAlmostEqual(self.C.DA(10.0, little_h=True), 591.84124477917851)
-        self.assertAlmostEqual(self.C.dRperp_dtheta(10.0, little_h=True), 6510.2536925709637)
-        self.assertAlmostEqual(self.C.dRpara_df(10.0, little_h=True), 1.2487605057418872e-05)
-        self.assertAlmostEqual(self.C.dRpara_df(10.0, ghz=True, little_h=True), 12487.605057418872)
-        self.assertAlmostEqual(self.C.X2Y(10.0, little_h=True), 529.26719942209002)
+        self.assertAlmostEqual(self.C.dRperp_dtheta(10.0, little_h=True), 
+                               6510.2536925709637)
+        self.assertAlmostEqual(self.C.dRpara_df(10.0, little_h=True), 
+                               1.2487605057418872e-05)
+        self.assertAlmostEqual(self.C.dRpara_df(10.0, ghz=True, little_h=True), 
+                               12487.605057418872)
+        self.assertAlmostEqual(self.C.X2Y(10.0, little_h=True), 
+                               529.26719942209002)
 
     def test_params(self):
         params = self.C.get_params()

--- a/hera_pspec/tests/test_grouping.py
+++ b/hera_pspec/tests/test_grouping.py
@@ -149,7 +149,11 @@ class Test_grouping(unittest.TestCase):
                                                      [uvp3,], 
                                                      blpair_groups=[_blpairs,], 
                                                      time_avg=True)
-            ps_avg = uvp_avg.get_data((0, blpair, ('xx','xx')))
+            try:
+                ps_avg = uvp_avg.get_data((0, blpair, ('xx','xx')))
+            except:
+                print(uvp_avg.polpair_array)
+                raise
             ps_boot = uvp4[0].get_data((0, blpair, ('xx','xx')))
             np.testing.assert_array_almost_equal(ps_avg, ps_boot)
 

--- a/hera_pspec/tests/test_grouping.py
+++ b/hera_pspec/tests/test_grouping.py
@@ -149,8 +149,8 @@ class Test_grouping(unittest.TestCase):
                                                      [uvp3,], 
                                                      blpair_groups=[_blpairs,], 
                                                      time_avg=True)
-            ps_avg = uvp_avg.get_data((0, blpair, 'xx'))
-            ps_boot = uvp4[0].get_data((0, blpair, 'xx'))
+            ps_avg = uvp_avg.get_data((0, blpair, ('xx','xx')))
+            ps_boot = uvp4[0].get_data((0, blpair, ('xx','xx')))
             np.testing.assert_array_almost_equal(ps_avg, ps_boot)
 
 def test_bootstrap_resampled_error():
@@ -258,11 +258,11 @@ def test_bootstrap_run():
     # assert original uvp is unchanged
     nt.assert_true(uvp == psc.get_pspec("grp1", 'uvp'))
     # check stats array
-    np.testing.assert_array_equal([u'bs_cinterval_16.00', u'bs_cinterval_84.00', u'bs_robust_std', u'bs_std'], uvp_avg.stats_array.keys())
+    np.testing.assert_array_equal([u'bs_cinterval_16.00', u'bs_cinterval_84.00', u'bs_robust_std', u'bs_std'], list(uvp_avg.stats_array.keys()))
     for stat in [u'bs_cinterval_16.00', u'bs_cinterval_84.00', u'bs_robust_std', u'bs_std']:
-        nt.assert_equal(uvp_avg.get_stats(stat, (0, ((37, 38), (38, 39)), 'XX')).shape, (1, 50))
-        nt.assert_false(np.any(np.isnan(uvp_avg.get_stats(stat, (0, ((37, 38), (38, 39)), 'XX')))))
-        nt.assert_equal(uvp_avg.get_stats(stat, (0, ((37, 38), (38, 39)), 'XX')).dtype, np.complex128)
+        nt.assert_equal(uvp_avg.get_stats(stat, (0, ((37, 38), (38, 39)), ('xx','xx'))).shape, (1, 50))
+        nt.assert_false(np.any(np.isnan(uvp_avg.get_stats(stat, (0, ((37, 38), (38, 39)), ('xx','xx'))))))
+        nt.assert_equal(uvp_avg.get_stats(stat, (0, ((37, 38), (38, 39)), ('xx','xx'))).dtype, np.complex128)
 
     # test exceptions
     del psc

--- a/hera_pspec/tests/test_noise.py
+++ b/hera_pspec/tests/test_noise.py
@@ -43,6 +43,10 @@ class Test_Sensitivity(unittest.TestCase):
         self.beam.cosmo = C
         sense.set_beam(self.beam)
         nt.assert_equal(sense.cosmo.get_params(), sense.beam.cosmo.get_params())
+        
+        bm = copy.deepcopy(self.beam)
+        delattr(bm, 'cosmo')
+        sense.set_beam(bm)
 
     def test_scalar(self):
         freqs = np.linspace(150e6, 160e6, 100, endpoint=False)

--- a/hera_pspec/tests/test_plot.py
+++ b/hera_pspec/tests/test_plot.py
@@ -99,21 +99,21 @@ class Test_Plot(unittest.TestCase):
         blps = [blp for blp in blpairs]
 
         # Plot the spectra averaged over baseline-pairs and times
-        f1 = plot.delay_spectrum(self.uvp, [blps,], spw=0, pol='xx',
+        f1 = plot.delay_spectrum(self.uvp, [blps,], spw=0, pol=('xx','xx'),
                                   average_blpairs=True, average_times=True)
         elements = [(matplotlib.lines.Line2D, 1),]
         self.assertTrue( axes_contains(f1.axes[0], elements) )
         plt.close(f1)
 
         # Average over baseline-pairs but keep the time bins intact
-        f2 = plot.delay_spectrum(self.uvp, [blps,], spw=0, pol='xx',
+        f2 = plot.delay_spectrum(self.uvp, [blps,], spw=0, pol=('xx','xx'),
                                   average_blpairs=True, average_times=False)
         elements = [(matplotlib.lines.Line2D, self.uvp.Ntimes),]
         self.assertTrue( axes_contains(f2.axes[0], elements) )
         plt.close(f2)
 
         # Average over times, but keep the baseline-pairs separate
-        f3 = plot.delay_spectrum(self.uvp, [blps,], spw=0, pol='xx',
+        f3 = plot.delay_spectrum(self.uvp, [blps,], spw=0, pol=('xx','xx'),
                                   average_blpairs=False, average_times=True)
         elements = [(matplotlib.lines.Line2D, self.uvp.Nblpairs),]
         self.assertTrue( axes_contains(f3.axes[0], elements) )
@@ -121,7 +121,7 @@ class Test_Plot(unittest.TestCase):
 
         # Plot the spectra averaged over baseline-pairs and times, but also
         # fold the delay axis
-        f4 = plot.delay_spectrum(self.uvp, [blps,], spw=0, pol='xx',
+        f4 = plot.delay_spectrum(self.uvp, [blps,], spw=0, pol=('xx','xx'),
                                   average_blpairs=True, average_times=True,
                                   fold=True)
         elements = [(matplotlib.lines.Line2D, 1),]
@@ -129,7 +129,7 @@ class Test_Plot(unittest.TestCase):
         plt.close(f4)
 
         # Plot imaginary part
-        f4 = plot.delay_spectrum(self.uvp, [blps,], spw=0, pol='xx',
+        f4 = plot.delay_spectrum(self.uvp, [blps,], spw=0, pol=('xx','xx'),
                                   average_blpairs=False, average_times=True,
                                   component='imag')
         elements = [(matplotlib.lines.Line2D, self.uvp.Nblpairs),]
@@ -137,7 +137,7 @@ class Test_Plot(unittest.TestCase):
         plt.close(f4)
 
         # Plot abs
-        f5 = plot.delay_spectrum(self.uvp, [blps,], spw=0, pol='xx',
+        f5 = plot.delay_spectrum(self.uvp, [blps,], spw=0, pol=('xx','xx'),
                                   average_blpairs=False, average_times=True,
                                   component='abs')
         elements = [(matplotlib.lines.Line2D, self.uvp.Nblpairs),]
@@ -153,14 +153,16 @@ class Test_Plot(unittest.TestCase):
                                                  robust_std=False, verbose=False)
 
         f6 = plot.delay_spectrum(uvp_avg, uvp_avg.get_blpairs(), spw=0,
-                                pol='xx', average_blpairs=False, average_times=False,
+                                pol=('xx','xx'), average_blpairs=False, 
+                                average_times=False,
                                 component='real', error='bs_std', lines=False,
                                 markers=True)
         plt.close(f6)
 
         # plot errorbar instead of pspec
         f7 = plot.delay_spectrum(uvp_avg, uvp_avg.get_blpairs(), spw=0,
-                                pol='xx', average_blpairs=False, average_times=False,
+                                pol=('xx','xx'), average_blpairs=False, 
+                                average_times=False,
                                 component='real', lines=False,
                                 markers=True, plot_stats='bs_std')
         plt.close(f7)
@@ -176,7 +178,7 @@ class Test_Plot(unittest.TestCase):
 
         # Set cosmology and plot in non-delay (i.e. cosmological) units
         self.uvp.set_cosmology(conversions.Cosmo_Conversions())
-        f1 = plot.delay_spectrum(self.uvp, [blps,], spw=0, pol='xx',
+        f1 = plot.delay_spectrum(self.uvp, [blps,], spw=0, pol=('xx','xx'),
                                   average_blpairs=True, average_times=True,
                                   delay=False)
         elements = [(matplotlib.lines.Line2D, 1), (matplotlib.legend.Legend, 0)]
@@ -184,9 +186,10 @@ class Test_Plot(unittest.TestCase):
         plt.close(f1)
 
         # Plot in Delta^2 units
-        f2 = plot.delay_spectrum(self.uvp, [blps,], spw=0, pol='xx',
+        f2 = plot.delay_spectrum(self.uvp, [blps,], spw=0, pol=('xx','xx'),
                                   average_blpairs=True, average_times=True,
-                                  delay=False, deltasq=True, legend=True, label_type='blpair')
+                                  delay=False, deltasq=True, legend=True, 
+                                  label_type='blpair')
         # Should contain 1 line and 1 legend
         elements = [(matplotlib.lines.Line2D, 1), (matplotlib.legend.Legend, 1)]
         self.assertTrue( axes_contains(f2.axes[0], elements) )
@@ -201,7 +204,7 @@ class Test_Plot(unittest.TestCase):
         blps = [blp for blp in blpairs]
 
         # times selection, label_type
-        f1 = plot.delay_spectrum(self.uvp, blpairs[:1], spw=0, pol='xx',
+        f1 = plot.delay_spectrum(self.uvp, blpairs[:1], spw=0, pol=('xx','xx'),
                                  times=self.uvp.time_avg_array[:1], lines=False,
                                  markers=True, logscale=False, label_type='key',
                                  force_plot=False)
@@ -216,12 +219,14 @@ class Test_Plot(unittest.TestCase):
             uvp = uvp + _uvp
         nt.assert_raises(ValueError, plot.delay_spectrum, uvp, uvp.get_blpairs(), 0, 'xx')
 
-        f2 = plot.delay_spectrum(uvp, uvp.get_blpairs(), 0, 'xx', force_plot=True,
-                                label_type='blpairt', logscale=False, lines=True, markers=True)
+        f2 = plot.delay_spectrum(uvp, uvp.get_blpairs(), 0, ('xx','xx'), 
+                                 force_plot=True, label_type='blpairt', 
+                                 logscale=False, lines=True, markers=True)
         plt.close(f2)
 
         # exceptions
-        nt.assert_raises(ValueError, plot.delay_spectrum, uvp, uvp.get_blpairs()[:3], 0, 'xx',
+        nt.assert_raises(ValueError, plot.delay_spectrum, uvp, 
+                         uvp.get_blpairs()[:3], 0, ('xx','xx'),
                          label_type='foo')
 
 
@@ -235,25 +240,25 @@ class Test_Plot(unittest.TestCase):
 
         # Set cosmology and plot in non-delay (i.e. cosmological) units
         self.uvp.set_cosmology(conversions.Cosmo_Conversions(), overwrite=True)
-        f1 = plot.delay_waterfall(self.uvp, [blps,], spw=0, pol='xx',
+        f1 = plot.delay_waterfall(self.uvp, [blps,], spw=0, pol=('xx','xx'),
                                    average_blpairs=True, delay=False)
         plt.close(f1)
 
         # Plot in Delta^2 units
-        f2 = plot.delay_waterfall(self.uvp, [blps,], spw=0, pol='xx',
+        f2 = plot.delay_waterfall(self.uvp, [blps,], spw=0, pol=('xx','xx'),
                                    average_blpairs=True, delay=False,
                                    deltasq=True)
         plt.close(f2)
 
         # Try some other arguments
-        f3 = plot.delay_waterfall(self.uvp, [blpairs,], spw=0, pol='xx',
+        f3 = plot.delay_waterfall(self.uvp, [blpairs,], spw=0, pol=('xx','xx'),
                                    average_blpairs=False, delay=True,
                                    log=False, vmin=-1., vmax=3.,
                                    cmap='RdBu', fold=True, component='abs')
         plt.close(f3)
 
         # Try with imaginary component
-        f4 = plot.delay_waterfall(self.uvp, [blpairs,], spw=0, pol='xx',
+        f4 = plot.delay_waterfall(self.uvp, [blpairs,], spw=0, pol=('xx','xx'),
                                    average_blpairs=False, delay=True,
                                    log=False, vmin=-1., vmax=3.,
                                    cmap='RdBu', fold=True, component='imag')
@@ -261,7 +266,8 @@ class Test_Plot(unittest.TestCase):
 
         # Try some more arguments
         fig, axes = plt.subplots(1, len(blps))
-        plot.delay_waterfall(self.uvp, [blps,], spw=0, pol='xx', lst_in_hrs=False,
+        plot.delay_waterfall(self.uvp, [blps,], spw=0, pol=('xx','xx'), 
+                             lst_in_hrs=False, 
                              times=np.unique(self.uvp.time_avg_array)[:10],
                              axes=axes, component='abs', title_type='blvec')
         plt.close()
@@ -272,19 +278,24 @@ class Test_Plot(unittest.TestCase):
             _uvp = copy.deepcopy(self.uvp)
             _uvp.blpair_array += i * 20
             uvp += _uvp
-        nt.assert_raises(ValueError, plot.delay_waterfall, uvp, uvp.get_blpairs(), 0, 'xx')
-        fig = plot.delay_waterfall(uvp, uvp.get_blpairs(), 0, 'xx', force_plot=True)
+        nt.assert_raises(ValueError, plot.delay_waterfall, uvp, 
+                         uvp.get_blpairs(), 0, ('xx','xx'))
+        fig = plot.delay_waterfall(uvp, uvp.get_blpairs(), 0, ('xx','xx'), 
+                                   force_plot=True)
         plt.close()
 
     def test_uvdata_waterfalls(self):
-        """ Test waterfall plotter """
+        """
+        Test waterfall plotter
+        """
         uvd = copy.deepcopy(self.uvd)
 
         basename = "test_waterfall_plots_3423523923_{bl}_{pol}"
 
         for d in ['data', 'flags', 'nsamples']:
             print("running on {}".format(d))
-            plot.plot_uvdata_waterfalls(uvd, basename, vmin=0, vmax=100, data=d, plot_mode='real')
+            plot.plot_uvdata_waterfalls(uvd, basename, vmin=0, vmax=100, 
+                                        data=d, plot_mode='real')
 
             figfiles = glob.glob("test_waterfall_plots_3423523923_*_*.png")
             nt.assert_equal(len(figfiles), 15)
@@ -295,59 +306,81 @@ class Test_Plot(unittest.TestCase):
         """ Tests for plot.delay_wedge """
         # construct new uvp
         reds, lens, angs = utils.get_reds(self.ds.dsets[0], pick_data_ants=True)
-        bls1, bls2, blps, _, _ = utils.calc_blpair_reds(self.ds.dsets[0], self.ds.dsets[1],
-                                                        exclude_auto_bls=False, exclude_permutations=True)
+        bls1, bls2, blps, _, _ = utils.calc_blpair_reds(self.ds.dsets[0], 
+                                                        self.ds.dsets[1],
+                                                        exclude_auto_bls=False, 
+                                                        exclude_permutations=True)
         uvp = self.ds.pspec(bls1, bls2, (0, 1), ('xx','xx'),
                             spw_ranges=[(300, 350)],
                             input_data_weight='identity', norm='I',
                             taper='blackman-harris', verbose=False)
 
         # test basic delay_wedge call
-        f1 = plot.delay_wedge(uvp, 0, 'xx', blpairs=None, times=None, fold=False, delay=True,
-                              rotate=False, component='real', log10=False, loglog=False, red_tol=1.0,
-                              center_line=False, horizon_lines=False, title=None, ax=None, cmap='viridis',
-                              figsize=(8, 6), deltasq=False, colorbar=False, cbax=None, vmin=None, vmax=None,
-                              edgecolor='none', flip_xax=False, flip_yax=False, lw=2)
+        f1 = plot.delay_wedge(uvp, 0, ('xx','xx'), blpairs=None, times=None, 
+                              fold=False, delay=True, rotate=False, 
+                              component='real', log10=False, loglog=False, 
+                              red_tol=1.0, center_line=False, 
+                              horizon_lines=False, title=None, ax=None, 
+                              cmap='viridis', figsize=(8, 6), deltasq=False, 
+                              colorbar=False, cbax=None, vmin=None, vmax=None,
+                              edgecolor='none', flip_xax=False, flip_yax=False, 
+                              lw=2)
         plt.close()
 
         # specify blpairs and times
-        f2 = plot.delay_wedge(uvp, 0, 'xx', blpairs=uvp.get_blpairs()[-5:], times=uvp.time_avg_array[:1],
+        f2 = plot.delay_wedge(uvp, 0, ('xx','xx'), 
+                              blpairs=uvp.get_blpairs()[-5:], 
+                              times=uvp.time_avg_array[:1],
                               fold=False, delay=True, component='imag',
                               rotate=False, log10=False, loglog=False, red_tol=1.0,
-                              center_line=False, horizon_lines=False, title=None, ax=None, cmap='viridis',
-                              figsize=(8, 6), deltasq=False, colorbar=False, cbax=None, vmin=None, vmax=None,
-                              edgecolor='none', flip_xax=False, flip_yax=False, lw=2)
+                              center_line=False, horizon_lines=False, title=None, 
+                              ax=None, cmap='viridis',
+                              figsize=(8, 6), deltasq=False, colorbar=False, 
+                              cbax=None, vmin=None, vmax=None,
+                              edgecolor='none', flip_xax=False, flip_yax=False, 
+                              lw=2)
         plt.close()
 
         # fold, deltasq, cosmo and log10, loglog
-        f3 = plot.delay_wedge(uvp, 0, 'xx', blpairs=None, times=None, fold=True, delay=False, component='abs',
+        f3 = plot.delay_wedge(uvp, 0, ('xx','xx'), blpairs=None, times=None, 
+                              fold=True, delay=False, component='abs',
                               rotate=False, log10=True, loglog=True, red_tol=1.0,
-                              center_line=False, horizon_lines=False, title='hello', ax=None, cmap='viridis',
-                              figsize=(8, 6), deltasq=True, colorbar=False, cbax=None, vmin=None, vmax=None,
-                              edgecolor='none', flip_xax=False, flip_yax=False, lw=2)
+                              center_line=False, horizon_lines=False, 
+                              title='hello', ax=None, cmap='viridis',
+                              figsize=(8, 6), deltasq=True, colorbar=False, 
+                              cbax=None, vmin=None, vmax=None,
+                              edgecolor='none', flip_xax=False, flip_yax=False, 
+                              lw=2)
         plt.close()
 
         # colorbar, vranges, flip_axes, edgecolors, lines
-        f4 = plot.delay_wedge(uvp, 0, 'xx', blpairs=None, times=None, fold=False, delay=False, component='abs',
+        f4 = plot.delay_wedge(uvp, 0, ('xx','xx'), blpairs=None, times=None, 
+                              fold=False, delay=False, component='abs',
                               rotate=False, log10=True, loglog=False, red_tol=1.0,
-                              center_line=True, horizon_lines=True, title='hello', ax=None, cmap='viridis',
-                              figsize=(8, 6), deltasq=True, colorbar=True, cbax=None, vmin=6, vmax=15,
-                              edgecolor='grey', flip_xax=True, flip_yax=True, lw=2, set_bl_tick_minor=True)
+                              center_line=True, horizon_lines=True, title='hello', 
+                              ax=None, cmap='viridis', figsize=(8, 6), 
+                              deltasq=True, colorbar=True, cbax=None, vmin=6, 
+                              vmax=15, edgecolor='grey', flip_xax=True, 
+                              flip_yax=True, lw=2, set_bl_tick_minor=True)
         plt.close()
 
         # feed axes, red_tol
         fig, ax = plt.subplots()
         cbax = fig.add_axes([0.85, 0.1, 0.05, 0.9])
         cbax.axis('off')
-        plot.delay_wedge(uvp, 0, 'xx', blpairs=None, times=None, fold=False, delay=True, component='abs',
-                        rotate=True, log10=True, loglog=False, red_tol=10.0,
-                        center_line=False, horizon_lines=False, ax=ax, cmap='viridis',
-                        figsize=(8, 6), deltasq=False, colorbar=True, cbax=cbax, vmin=None, vmax=None,
-                        edgecolor='none', flip_xax=False, flip_yax=False, lw=2, set_bl_tick_major=True)
+        plot.delay_wedge(uvp, 0, ('xx','xx'), blpairs=None, times=None, 
+                         fold=False, delay=True, component='abs',
+                         rotate=True, log10=True, loglog=False, red_tol=10.0,
+                         center_line=False, horizon_lines=False, ax=ax, 
+                         cmap='viridis', figsize=(8, 6), deltasq=False, 
+                         colorbar=True, cbax=cbax, vmin=None, vmax=None,
+                         edgecolor='none', flip_xax=False, flip_yax=False, 
+                         lw=2, set_bl_tick_major=True)
         plt.close()
 
         # test exceptions
-        nt.assert_raises(ValueError, plot.delay_wedge, uvp, 0, 'xx', component='foo')
+        nt.assert_raises(ValueError, plot.delay_wedge, uvp, 0, ('xx','xx'), 
+                         component='foo')
         plt.close()
 
 

--- a/hera_pspec/tests/test_pspecbeam.py
+++ b/hera_pspec/tests/test_pspecbeam.py
@@ -248,10 +248,10 @@ class Test_DataSet(unittest.TestCase):
     def test_get_Omegas(self):
         beamfile = os.path.join(DATA_PATH, 'HERA_NF_dipole_power.beamfits')
         beam = pspecbeam.PSpecBeamUV(beamfile)
-        OP, OPP = beam.get_Omegas('xx')
+        OP, OPP = beam.get_Omegas(('xx','xx'))
         nt.assert_equal(OP.shape, (26, 1))
         nt.assert_equal(OPP.shape, (26, 1))
-        OP, OPP = beam.get_Omegas([-5, -6])
+        OP, OPP = beam.get_Omegas([(-5,-5), (-6,-6)])
         nt.assert_equal(OP.shape, (26, 2))
         nt.assert_equal(OPP.shape, (26, 2))
 

--- a/hera_pspec/tests/test_pspecbeam.py
+++ b/hera_pspec/tests/test_pspecbeam.py
@@ -254,5 +254,8 @@ class Test_DataSet(unittest.TestCase):
         OP, OPP = beam.get_Omegas([(-5,-5), (-6,-6)])
         nt.assert_equal(OP.shape, (26, 2))
         nt.assert_equal(OPP.shape, (26, 2))
+        
+        nt.assert_raises(TypeError, beam.get_Omegas, 'xx')
+        nt.assert_raises(NotImplementedError, beam.get_Omegas, [('pI','pQ'),])
 
 

--- a/hera_pspec/tests/test_pspecdata.py
+++ b/hera_pspec/tests/test_pspecdata.py
@@ -267,7 +267,7 @@ class Test_PSpecData(unittest.TestCase):
             self.assertAlmostEqual(np.imag(xQx), 0.)
 
         x_vect = np.ones(vect_length)
-        Q_matrix = self.ds.get_Q_alt(vect_length/2)
+        Q_matrix = self.ds.get_Q_alt(vect_length//2)
         xQx = np.dot(np.conjugate(x_vect), np.dot(Q_matrix, x_vect))
         self.assertAlmostEqual(xQx, np.abs(vect_length**2.))
         # Sending in sinusoids for x and y should give delta functions
@@ -291,7 +291,7 @@ class Test_PSpecData(unittest.TestCase):
             self.assertAlmostEqual(np.imag(xQx), 0.)
 
         x_vect = np.ones(vect_length)
-        Q_matrix = self.ds.get_Q_alt((vect_length-2)/2-1)
+        Q_matrix = self.ds.get_Q_alt((vect_length-2)//2-1)
         xQx = np.dot(np.conjugate(x_vect), np.dot(Q_matrix, x_vect))
         self.assertAlmostEqual(xQx, np.abs(vect_length**2.))
         # Sending in sinusoids for x and y should give delta functions
@@ -638,9 +638,9 @@ class Test_PSpecData(unittest.TestCase):
             for taper in taper_selection:
                 self.ds.set_taper(taper)
 
-                self.ds.set_Ndlys(Nfreq/3)
+                self.ds.set_Ndlys(Nfreq//3)
                 H = self.ds.get_H(key1, key2)
-                self.assertEqual(H.shape, (Nfreq/3, Nfreq/3)) # Test shape
+                self.assertEqual(H.shape, (Nfreq//3, Nfreq//3)) # Test shape
 
                 self.ds.set_Ndlys()
                 H = self.ds.get_H(key1, key2)
@@ -857,7 +857,7 @@ class Test_PSpecData(unittest.TestCase):
         # rephase and get pspec
         ds.rephase_to_dset(0)
         uvp2 = ds.pspec(bls, bls, (0, 1), pols=('xx','xx'), verbose=False)
-        blp = (0, ((37,39),(37,39)), 'xx')
+        blp = (0, ((37,39),(37,39)), ('xx','xx'))
         nt.assert_true(np.isclose(np.abs(uvp2.get_data(blp)/uvp1.get_data(blp)), 1.0).min())
 
     def test_Jy_to_mK(self):
@@ -869,7 +869,8 @@ class Test_PSpecData(unittest.TestCase):
         ds.Jy_to_mK()
         nt.assert_true(ds.dsets[0].vis_units, 'mK')
         nt.assert_true(ds.dsets[1].vis_units, 'mK')
-        nt.assert_true(uvd.get_data(24, 25, 'xx')[30, 30] / ds.dsets[0].get_data(24, 25, 'xx')[30, 30] < 1.0)
+        nt.assert_true(uvd.get_data(24, 25, 'xx')[30, 30] \
+                    / ds.dsets[0].get_data(24, 25, 'xx')[30, 30] < 1.0)
 
         # test feeding beam
         ds2 = pspecdata.PSpecData(dsets=[copy.deepcopy(uvd), copy.deepcopy(uvd)],
@@ -958,7 +959,7 @@ class Test_PSpecData(unittest.TestCase):
         # check with redundant baseline group list
         antpos, ants = uvd.get_ENU_antpos(pick_data_ants=True)
         antpos = dict(zip(ants, antpos))
-        red_bls = map(lambda blg: sorted(blg), redcal.get_pos_reds(antpos))[2]
+        red_bls = [sorted(blg) for blg in redcal.get_pos_reds(antpos)][2]
         bls1, bls2, blps = utils.construct_blpairs(red_bls, exclude_permutations=True)
         uvp = ds.pspec(bls1, bls2, (0, 1), ('xx','xx'), input_data_weight='identity', norm='I', taper='none',
                                 little_h=True, verbose=False)
@@ -997,7 +998,7 @@ class Test_PSpecData(unittest.TestCase):
         nt.assert_equal(uvp.Nspws, 3)
         nt.assert_equal(uvp.Nspwdlys, 43)
         nt.assert_equal(uvp.data_array[0].shape, (240, 14, 1))
-        nt.assert_equal(uvp.get_data((0, 124125124125, 'xx')).shape, (60, 14))
+        nt.assert_equal(uvp.get_data((0, 124125124125, ('xx','xx'))).shape, (60, 14))
 
         uvp.select(spws=[1])
         nt.assert_equal(uvp.Nspws, 1)
@@ -1008,7 +1009,7 @@ class Test_PSpecData(unittest.TestCase):
         uvd = copy.deepcopy(self.uvd)
         ds = pspecdata.PSpecData(dsets=[uvd, uvd], wgts=[None, None], beam=self.bm)
         uvp = ds.pspec(bls, bls, (0, 1), ('xx','xx'), spw_ranges=[(10, 24)], verbose=False)
-        nt.assert_raises(NotImplementedError, ds.pspec, bls, bls, (0, 1), pols=[('xx','yy')])
+        #nt.assert_raises(NotImplementedError, ds.pspec, bls, bls, (0, 1), pols=[('xx','yy')])
         uvd = copy.deepcopy(self.uvd)
         ds = pspecdata.PSpecData(dsets=[uvd, uvd], wgts=[None, None], beam=self.bm)
         uvp = ds.pspec(bls, bls, (0, 1), [('xx','xx'), ('yy','yy')], spw_ranges=[(10, 24)], verbose=False)
@@ -1063,7 +1064,7 @@ class Test_PSpecData(unittest.TestCase):
                        spw_ranges=[(20, 30)])
         nt.assert_equal(len(ds._identity_Y), len(ds._identity_G), len(ds._identity_H))
         nt.assert_equal(len(ds._identity_Y), 1)
-        nt.assert_equal(ds._identity_Y.keys()[0], ((0, 24, 25, 'xx'), (1, 24, 25, 'xx')))
+        nt.assert_equal(list(ds._identity_Y.keys())[0], ((0, 24, 25, 'xx'), (1, 24, 25, 'xx')))
         # assert caching is not used when inappropriate
         ds.dsets[0].flag_array[ds.dsets[0].antpair2ind(37, 38, ordered=False), :, 25, :] = True
         uvp = ds.pspec([(24, 25), (37, 38)], [(24, 25), (37, 38)], (0, 1), ('xx', 'xx'),
@@ -1108,7 +1109,7 @@ class Test_PSpecData(unittest.TestCase):
         # hera_pspec OQE
         ds = pspecdata.PSpecData(dsets=[d1, d2], wgts=[None, None], beam=beam)
         uvp = ds.pspec(bls1, bls2, (0, 1), pols=('xx','xx'), taper='none', input_data_weight='identity', norm='I', sampling=True)
-        oqe = uvp.get_data((0, ((24, 25), (37, 38)), 'xx'))[0]
+        oqe = uvp.get_data((0, ((24, 25), (37, 38)), ('xx','xx')))[0]
         # assert answers are same to within 3%
         nt.assert_true(np.isclose(np.real(oqe)/np.real(legacy), 1, atol=0.03, rtol=0.03).all())
         # taper
@@ -1121,7 +1122,7 @@ class Test_PSpecData(unittest.TestCase):
         # hera_pspec OQE
         ds = pspecdata.PSpecData(dsets=[d1, d2], wgts=[None, None], beam=beam)
         uvp = ds.pspec(bls1, bls2, (0, 1), ('xx','xx'), taper='blackman-harris', input_data_weight='identity', norm='I')
-        oqe = uvp.get_data((0, ((24, 25), (37, 38)), 'xx'))[0]
+        oqe = uvp.get_data((0, ((24, 25), (37, 38)), ('xx','xx')))[0]
         # assert answers are same to within 3%
         nt.assert_true(np.isclose(np.real(oqe)/np.real(legacy), 1, atol=0.03, rtol=0.03).all())
 
@@ -1161,9 +1162,9 @@ class Test_PSpecData(unittest.TestCase):
         uvp = ds.pspec([(24, 25), (37, 38), (38, 39)], [(24, 25), (37, 38), (38, 39)], (0, 1), ('xx', 'xx'),
                         spw_ranges=[(400, 450)], verbose=False)
         # assert flag broadcast above hits weight arrays in uvp
-        nt.assert_true(np.all(np.isclose(uvp.get_wgts((0, ((24, 25), (24, 25)), 'xx'))[3], 0.0)))
+        nt.assert_true(np.all(np.isclose(uvp.get_wgts((0, ((24, 25), (24, 25)), ('xx','xx')))[3], 0.0)))
         # assert flag broadcast above hits integration arrays
-        nt.assert_true(np.isclose(uvp.get_integrations((0, ((24, 25), (24, 25)), 'xx'))[3], 0.0))
+        nt.assert_true(np.isclose(uvp.get_integrations((0, ((24, 25), (24, 25)), ('xx','xx')))[3], 0.0))
         # average spectra
         avg_uvp = uvp.average_spectra(blpair_groups=[sorted(np.unique(uvp.blpair_array))], time_avg=True, inplace=False)
         # repeat but change data in flagged portion
@@ -1195,8 +1196,8 @@ class Test_PSpecData(unittest.TestCase):
         uvp_unflagged = ds.pspec(bls1, bls2, (0, 1), ('xx','xx'), input_data_weight='identity', norm='I', taper='none',
                                 little_h=True, verbose=False)
 
-        qe_unflagged = uvp_unflagged.get_data((0, ((24, 25), (37, 38)), 'xx'))[0]
-        qe_flagged = uvp_flagged.get_data((0, ((24, 25), (37, 38)), 'xx'))[0]
+        qe_unflagged = uvp_unflagged.get_data((0, ((24, 25), (37, 38)), ('xx','xx')))[0]
+        qe_flagged = uvp_flagged.get_data((0, ((24, 25), (37, 38)), ('xx','xx')))[0]
 
         # assert answers are same to within 0.1%
         nt.assert_true(np.isclose(np.real(qe_unflagged)/np.real(qe_flagged), 1, atol=0.001, rtol=0.001).all())
@@ -1213,8 +1214,8 @@ class Test_PSpecData(unittest.TestCase):
         uvp_flagged_mod = ds.pspec(bls1, bls2, (0, 1), ('xx','xx'), input_data_weight='identity', norm='I', taper='none',
                                 little_h=True, verbose=False)
 
-        qe_flagged_mod = uvp_flagged_mod.get_data((0, ((24, 25), (37, 38)), 'xx'))[0]
-        qe_flagged = uvp_flagged.get_data((0, ((24, 25), (37, 38)), 'xx'))[0]
+        qe_flagged_mod = uvp_flagged_mod.get_data((0, ((24, 25), (37, 38)), ('xx','xx')))[0]
+        qe_flagged = uvp_flagged.get_data((0, ((24, 25), (37, 38)), ('xx','xx')))[0]
 
         # assert answers are same to within 0.1%
         nt.assert_true(np.isclose(np.real(qe_flagged_mod), np.real(qe_flagged), atol=0.001, rtol=0.001).all())
@@ -1271,8 +1272,10 @@ def test_pspec_run():
     # test basic execution
     if os.path.exists("./out.hdf5"):
         os.remove("./out.hdf5")
-    psc, ds = pspecdata.pspec_run(fnames, "./out.hdf5", Jy2mK=False, verbose=False, overwrite=True,
-                              bl_len_range=(14, 15), bl_deg_range=(50, 70), psname_ext='_0')
+    psc, ds = pspecdata.pspec_run(fnames, "./out.hdf5", Jy2mK=False, 
+                                  verbose=False, overwrite=True,
+                                  bl_len_range=(14, 15), bl_deg_range=(50, 70), 
+                                  psname_ext='_0')
     nt.assert_true(isinstance(psc, container.PSpecContainer))
     nt.assert_equal(psc.groups(), ['dset0_dset1'])
     nt.assert_equal(psc.spectra(psc.groups()[0]), ['dset0_x_dset1_0'])
@@ -1297,7 +1300,7 @@ def test_pspec_run():
     nt.assert_true(uvp.vis_units, "mK")
     # assert only blpairs that were fed are present
     nt.assert_equal(uvp.bl_array.tolist(), [137138, 152153])
-    nt.assert_equal(uvp.pol_array.tolist(), [-5, -5])
+    nt.assert_equal(uvp.polpair_array.tolist(), [505, 505])
     # assert weird cosmology was passed
     nt.assert_equal(uvp.cosmo, cosmo)
     # assert cov_array was calculated b/c std files were passed and store_cov

--- a/hera_pspec/tests/test_pspecdata.py
+++ b/hera_pspec/tests/test_pspecdata.py
@@ -233,6 +233,7 @@ class Test_PSpecData(unittest.TestCase):
         print(ds) # print empty psd
         ds.add(self.uvd, None)
         print(ds) # print populated psd
+        
 
     def test_get_Q_alt(self):
 
@@ -485,7 +486,11 @@ class Test_PSpecData(unittest.TestCase):
                 # Test that the norm matrix is diagonal
                 M, W = self.ds.get_MW(random_G, random_H, mode=mode)
                 self.assertEqual(diagonal_or_not(M), True)
-
+            elif mode == 'L^-1':
+                # Test that Cholesky mode is disabled 
+                nt.assert_raises(NotImplementedError, 
+                                 self.ds.get_MW, random_G, random_H, mode=mode)
+                
             # Test sizes for everyone
             self.assertEqual(M.shape, (n,n))
             self.assertEqual(W.shape, (n,n))
@@ -807,7 +812,9 @@ class Test_PSpecData(unittest.TestCase):
         
         # Check normal execution
         scalar = self.ds.scalar(('xx','xx'))
+        scalar = self.ds.scalar(1515) # polpair-integer = ('xx', 'xx')
         scalar = self.ds.scalar(('xx','xx'), taper_override='none')
+        scalar = self.ds.scalar(('xx','xx'), beam=gauss)
         nt.assert_raises(NotImplementedError, self.ds.scalar, ('xx','yy'))
         
         # Precomputed results in the following test were done "by hand"
@@ -861,6 +868,12 @@ class Test_PSpecData(unittest.TestCase):
         
         # test polarization
         ds.validate_pol((0,1), ('xx', 'xx'))
+        
+        # test channel widths
+        uvd2.channel_width *= 2.
+        ds2 = pspecdata.PSpecData(dsets=[uvd, uvd2], wgts=[None, None])
+        nt.assert_raises(ValueError, ds2.validate_datasets)
+        
 
     def test_rephase_to_dset(self):
         # generate two uvd objects w/ different LST grids
@@ -961,6 +974,9 @@ class Test_PSpecData(unittest.TestCase):
         nt.assert_false(ds.check_key_in_dset((24, 26, 'yy'), 0))
         # check exception
         nt.assert_raises(KeyError, ds.check_key_in_dset, (1,2,3,4,5), 0)
+        
+        # test dset_idx
+        nt.assert_raises(TypeError, ds.dset_idx, (1,2))
 
     def test_pspec(self):
         # generate ds

--- a/hera_pspec/tests/test_pspecdata.py
+++ b/hera_pspec/tests/test_pspecdata.py
@@ -1320,7 +1320,7 @@ def test_pspec_run():
     nt.assert_true(uvp.vis_units, "mK")
     # assert only blpairs that were fed are present
     nt.assert_equal(uvp.bl_array.tolist(), [137138, 152153])
-    nt.assert_equal(uvp.polpair_array.tolist(), [505, 505])
+    nt.assert_equal(uvp.polpair_array.tolist(), [1515, 1515])
     # assert weird cosmology was passed
     nt.assert_equal(uvp.cosmo, cosmo)
     # assert cov_array was calculated b/c std files were passed and store_cov

--- a/hera_pspec/tests/test_testing.py
+++ b/hera_pspec/tests/test_testing.py
@@ -16,7 +16,7 @@ def test_build_vanilla_uvpspec():
 
     beam = pspecbeam.PSpecBeamUV(os.path.join(DATA_PATH, 'HERA_NF_dipole_power.beamfits'))
     uvp, cosmo = testing.build_vanilla_uvpspec(beam=beam)
-    beam_OP = beam.get_Omegas(uvp.pol_array[0])[0]
+    beam_OP = beam.get_Omegas(uvp.polpair_array[0])[0]
     nt.assert_equal(beam_OP.tolist(), uvp.OmegaP.tolist())
 
 def test_uvpspec_from_data():

--- a/hera_pspec/tests/test_utils.py
+++ b/hera_pspec/tests/test_utils.py
@@ -198,7 +198,10 @@ class Test_Utils(unittest.TestCase):
         uvd2 = copy.deepcopy(uvd)
         uvd2.antenna_positions[0] += 2
         nt.assert_raises(AssertionError, utils.calc_blpair_reds, uvd, uvd2)
-
+    
+    def test_get_delays(self):
+        utils.get_delays(np.linspace(100., 200., 50)*1e6)
+    
     def test_get_reds(self):
         fname = os.path.join(DATA_PATH, 'zen.all.xx.LST.1.06964.uvA')
         uvd = UVData()

--- a/hera_pspec/tests/test_utils.py
+++ b/hera_pspec/tests/test_utils.py
@@ -157,7 +157,7 @@ class Test_Utils(unittest.TestCase):
         (bls1, bls2, blps, xants1,
          xants2) = utils.calc_blpair_reds(uvd, uvd, filter_blpairs=True, exclude_auto_bls=False, exclude_permutations=True)  
         nt.assert_equal(len(bls1), len(bls2), 15)
-        nt.assert_equal(blps, zip(bls1, bls2))
+        nt.assert_equal(blps, list(zip(bls1, bls2)))
         nt.assert_equal(xants1, xants2)
         nt.assert_equal(len(xants1), 42)
 
@@ -204,7 +204,7 @@ class Test_Utils(unittest.TestCase):
         uvd = UVData()
         uvd.read_miriad(fname, read_data=False)
         antpos, ants = uvd.get_ENU_antpos()
-        antpos_d = dict(zip(ants, antpos))
+        antpos_d = dict(list(zip(ants, antpos)))
 
         # test basic execution
         xants = [0, 1, 2]
@@ -237,17 +237,17 @@ class Test_Utils(unittest.TestCase):
         uv_template = os.path.join(DATA_PATH, "zen.{group}.{pol}.LST.1.28828.uvOCRSA")
         groupings = utils.config_pspec_blpairs(uv_template, [('xx', 'xx')], [('even', 'odd')], verbose=False, exclude_auto_bls=True)
         nt.assert_equal(len(groupings), 1)
-        nt.assert_equal(groupings.keys()[0], (('even', 'odd'), ('xx', 'xx')))
-        nt.assert_equal(len(groupings.values()[0]), 11833)
+        nt.assert_equal(list(groupings.keys())[0], (('even', 'odd'), ('xx', 'xx')))
+        nt.assert_equal(len(list(groupings.values())[0]), 11833)
 
         # test multiple, some non-existant pairs
         groupings = utils.config_pspec_blpairs(uv_template, [('xx', 'xx'), ('yy', 'yy')], [('even', 'odd'), ('even', 'odd')], verbose=False, exclude_auto_bls=True)
         nt.assert_equal(len(groupings), 1)
-        nt.assert_equal(groupings.keys()[0], (('even', 'odd'), ('xx', 'xx')))
+        nt.assert_equal(list(groupings.keys())[0], (('even', 'odd'), ('xx', 'xx')))
 
         # test xants
         groupings = utils.config_pspec_blpairs(uv_template, [('xx', 'xx')], [('even', 'odd')], xants=[0, 1, 2], verbose=False, exclude_auto_bls=True)
-        nt.assert_equal(len(groupings.values()[0]), 9735)
+        nt.assert_equal(len(list(groupings.values())[0]), 9735)
 
         # test exceptions
         nt.assert_raises(AssertionError, utils.config_pspec_blpairs, uv_template, [('xx', 'xx'), ('xx', 'xx')], [('even', 'odd')], verbose=False)
@@ -281,23 +281,16 @@ def test_log():
     os.remove("logf.log")
 
 
-def test_hash():
-    """
-    Check that MD5 hashing works.
-    """
-    hsh = utils.hash(np.ones((8,16)))
-
-
 def test_get_blvec_reds():
     fname = os.path.join(DATA_PATH, "zen.2458042.17772.xx.HH.uvXA")
     uvd = UVData()
     uvd.read_miriad(fname)
     antpos, ants = uvd.get_ENU_antpos(pick_data_ants=True)
-    reds = redcal.get_pos_reds(dict(zip(ants, antpos)))
+    reds = redcal.get_pos_reds(dict(list(zip(ants, antpos))))
     uvp = testing.uvpspec_from_data(fname, reds[:2], spw_ranges=[(10, 40)])
 
     # test execution w/ dictionary
-    blvecs = dict(zip(uvp.bl_array, uvp.get_ENU_bl_vecs()))
+    blvecs = dict(list(zip(uvp.bl_array, uvp.get_ENU_bl_vecs())))
     (red_bl_grp, red_bl_len, red_bl_ang,
      red_bl_tag) = utils.get_blvec_reds(blvecs, bl_error_tol=1.0)
     nt.assert_equal(len(red_bl_grp), 2)

--- a/hera_pspec/tests/test_uvpspec.py
+++ b/hera_pspec/tests/test_uvpspec.py
@@ -155,11 +155,19 @@ class Test_UVPSpec(unittest.TestCase):
         spw, blpairts, pol = self.uvp.key_to_indices( (0, ((1,2),(1,2)), 1515) )
         nt.assert_equal(spw, 0)
         nt.assert_equal(pol, 0)
-        nt.assert_true(np.isclose(blpairts, np.array([0,3,6,9,12,15,18,21,24,27])).min())
+        nt.assert_true(np.isclose(blpairts, 
+                                  np.array([0,3,6,9,12,15,18,21,24,27])).min())
         spw, blpairts, pol = self.uvp.key_to_indices( (0, 101102101102, ('xx','xx')) )
         nt.assert_equal(spw, 0)
         nt.assert_equal(pol, 0)
-        nt.assert_true(np.isclose(blpairts, np.array([0,3,6,9,12,15,18,21,24,27])).min())
+        nt.assert_true(np.isclose(blpairts, 
+                       np.array([0,3,6,9,12,15,18,21,24,27])).min())
+        
+        # Check different polpair specification methods give the same results
+        s1, b1, p1 = self.uvp.key_to_indices( (0, ((1,2),(1,2)), 1515) )
+        s2, b2, p2 = self.uvp.key_to_indices( (0, ((1,2),(1,2)), ('xx','xx')) )
+        s3, b3, p3 = self.uvp.key_to_indices( (0, ((1,2),(1,2)), 'xx') )
+        nt.assert_equal(p1, p2, p3)
 
         # spw to indices
         spw1 = self.uvp.spw_to_dly_indices(0)
@@ -184,12 +192,15 @@ class Test_UVPSpec(unittest.TestCase):
         nt.assert_equal(len(pol), 1)
         pol = self.uvp.polpair_to_indices([('xx','xx'), ('xx','xx')])
         nt.assert_equal(len(pol), 1)
+        nt.assert_raises(TypeError, self.uvp.polpair_to_indices, 3.14)
 
         # test blpair to indices
         inds = self.uvp.blpair_to_indices(101102101102)
         nt.assert_true(np.isclose(inds, np.array([0,3,6,9,12,15,18,21,24,27])).min())
         inds = self.uvp.blpair_to_indices(((1,2),(1,2)))
         nt.assert_true(np.isclose(inds, np.array([0,3,6,9,12,15,18,21,24,27])).min())
+        inds = self.uvp.blpair_to_indices([101102101102, 101102101102])
+        inds = self.uvp.blpair_to_indices([((1,2),(1,2)), ((1,2),(1,2))])
 
         # test time to indices
         time = self.uvp.time_avg_array[5]
@@ -200,6 +211,7 @@ class Test_UVPSpec(unittest.TestCase):
         inds = self.uvp.time_to_indices(time=time, blpairs=[blpair])
         nt.assert_equal(len(inds), 1)
         nt.assert_equal(self.uvp.blpair_array[inds], blpair)
+        inds = self.uvp.time_to_indices(time=time, blpairs=blpair)
 
     def test_select(self):
         # bl group select

--- a/hera_pspec/tests/test_uvpspec.py
+++ b/hera_pspec/tests/test_uvpspec.py
@@ -35,26 +35,26 @@ class Test_UVPSpec(unittest.TestCase):
 
     def test_get_funcs(self):
         # get_data
-        d = self.uvp.get_data((0, ((1, 2), (1, 2)), 'xx'))
+        d = self.uvp.get_data((0, ((1, 2), (1, 2)), ('xx','xx')))
         nt.assert_equal(d.shape, (10, 30))
         nt.assert_true(d.dtype == np.complex)
         nt.assert_almost_equal(d[0,0], (101.1021011020000001+0j))
-        d = self.uvp.get_data((0, ((1, 2), (1, 2)), -5))
+        d = self.uvp.get_data((0, ((1, 2), (1, 2)), 505))
         nt.assert_almost_equal(d[0,0], (101.1021011020000001+0j))
-        d = self.uvp.get_data((0, 101102101102, -5))
+        d = self.uvp.get_data((0, 101102101102, 505))
         nt.assert_almost_equal(d[0,0], (101.1021011020000001+0j))
         # get_wgts
-        w = self.uvp.get_wgts((0, ((1, 2), (1, 2)), 'xx'))
+        w = self.uvp.get_wgts((0, ((1, 2), (1, 2)), ('xx','xx')))
         nt.assert_equal(w.shape, (10, 50, 2)) # should have Nfreq dim, not Ndlys
         nt.assert_true(w.dtype == np.float)
         nt.assert_equal(w[0,0,0], 1.0)
         # get_integrations
-        i = self.uvp.get_integrations((0, ((1, 2), (1, 2)), 'xx'))
+        i = self.uvp.get_integrations((0, ((1, 2), (1, 2)), ('xx','xx')))
         nt.assert_equal(i.shape, (10,))
         nt.assert_true(i.dtype == np.float)
         nt.assert_almost_equal(i[0], 1.0)
         # get nsample
-        n = self.uvp.get_nsamples((0, ((1, 2), (1, 2)), 'xx'))
+        n = self.uvp.get_nsamples((0, ((1, 2), (1, 2)), ('xx', 'xx')))
         nt.assert_equal(n.shape, (10,))
         nt.assert_true(n.dtype == np.float)
         nt.assert_almost_equal(n[0], 1.0)
@@ -70,11 +70,11 @@ class Test_UVPSpec(unittest.TestCase):
         nt.assert_equal(len(k_perp), 30)
         nt.assert_equal(len(k_para), 30)
         # test key expansion
-        key = (0, ((1, 2), (1, 2)), 'xx')
+        key = (0, ((1, 2), (1, 2)), ('xx','xx'))
         d = self.uvp.get_data(key)
         nt.assert_equal(d.shape, (10, 30))
         # test key as dictionary
-        key = {'spw':0, 'blpair':((1, 2), (1, 2)), 'pol': 'xx'}
+        key = {'spw':0, 'blpair':((1, 2), (1, 2)), 'polpair': ('xx','xx')}
         d = self.uvp.get_data(key)
         nt.assert_equal(d.shape, (10, 30))
         # test get_blpairs
@@ -82,11 +82,12 @@ class Test_UVPSpec(unittest.TestCase):
         nt.assert_equal(blps, [((1, 2), (1, 2)), ((1, 3), (1, 3)), ((2, 3), (2, 3))])
         # test get all keys
         keys = self.uvp.get_all_keys()
-        nt.assert_equal(keys, [(0, ((1, 2), (1, 2)), 'xx'), (0, ((1, 3), (1, 3)), 'xx'),
-                               (0, ((2, 3), (2, 3)), 'xx')])
+        nt.assert_equal(keys, [(0, ((1, 2), (1, 2)), ('xx','xx')), 
+                               (0, ((1, 3), (1, 3)), ('xx','xx')),
+                               (0, ((2, 3), (2, 3)), ('xx','xx'))])
         # test omit_flags
         self.uvp.integration_array[0][self.uvp.blpair_to_indices(((1, 2), (1, 2)))[:2]] = 0.0
-        nt.assert_equal(self.uvp.get_integrations((0, ((1, 2), (1, 2)), 'xx'), omit_flags=True).shape, (8,))
+        nt.assert_equal(self.uvp.get_integrations((0, ((1, 2), (1, 2)), ('xx','xx')), omit_flags=True).shape, (8,))
 
     def test_stats_array(self):
         # test get_data and set_data
@@ -151,11 +152,11 @@ class Test_UVPSpec(unittest.TestCase):
 
     def test_indices_funcs(self):
         # key to indices
-        spw, blpairts, pol = self.uvp.key_to_indices( (0, ((1,2),(1,2)), -5) )
+        spw, blpairts, pol = self.uvp.key_to_indices( (0, ((1,2),(1,2)), 505) )
         nt.assert_equal(spw, 0)
         nt.assert_equal(pol, 0)
         nt.assert_true(np.isclose(blpairts, np.array([0,3,6,9,12,15,18,21,24,27])).min())
-        spw, blpairts, pol = self.uvp.key_to_indices( (0, 101102101102, 'xx') )
+        spw, blpairts, pol = self.uvp.key_to_indices( (0, 101102101102, ('xx','xx')) )
         nt.assert_equal(spw, 0)
         nt.assert_equal(pol, 0)
         nt.assert_true(np.isclose(blpairts, np.array([0,3,6,9,12,15,18,21,24,27])).min())
@@ -177,11 +178,11 @@ class Test_UVPSpec(unittest.TestCase):
         np.testing.assert_array_equal(spw3, spw3b)
 
         # pol to indices
-        pol = self.uvp.pol_to_indices('xx')
+        pol = self.uvp.polpair_to_indices(('xx','xx'))
         nt.assert_equal(len(pol), 1)
-        pol = self.uvp.pol_to_indices(-5)
+        pol = self.uvp.polpair_to_indices(505)
         nt.assert_equal(len(pol), 1)
-        pol = self.uvp.pol_to_indices(['xx', 'xx'])
+        pol = self.uvp.polpair_to_indices([('xx','xx'), ('xx','xx')])
         nt.assert_equal(len(pol), 1)
 
         # test blpair to indices
@@ -227,8 +228,8 @@ class Test_UVPSpec(unittest.TestCase):
         nt.assert_equal(uvp2.Nblpairs, 2)
 
         # pol select
-        uvp2 = uvp.select(pols=[-5], inplace=False)
-        nt.assert_equal(uvp2.pol_array[0], -5)
+        uvp2 = uvp.select(polpairs=[505,], inplace=False)
+        nt.assert_equal(uvp2.polpair_array[0], 505)
 
         # time select
         uvp2 = uvp.select(times=np.unique(uvp.time_avg_array)[:1], inplace=False)
@@ -237,15 +238,17 @@ class Test_UVPSpec(unittest.TestCase):
         # test pol and blpair select, and check dimensionality of output
         uvp = copy.deepcopy(self.uvp)
         uvp.set_stats('hi', uvp.get_all_keys()[0], np.ones(300).reshape(10, 30))
-        uvp2 = uvp.select(blpairs=uvp.get_blpairs(), pols=uvp.pol_array, inplace=False)
+        uvp2 = uvp.select(blpairs=uvp.get_blpairs(), polpairs=uvp.polpair_array, inplace=False)
         nt.assert_equal(uvp2.data_array[0].shape, (30, 30, 1))
         nt.assert_equal(uvp2.stats_array['hi'][0].shape, (30, 30, 1))
 
         # test when both blp and pol array are non-sliceable
         uvp2, uvp3, uvp4 = copy.deepcopy(uvp), copy.deepcopy(uvp), copy.deepcopy(uvp)
-        uvp2.pol_array[0], uvp3.pol_array[0], uvp4.pol_array[0] = -6, -7, -8
+        uvp2.polpair_array[0] = 404
+        uvp3.polpair_array[0] = 303
+        uvp4.polpair_array[0] = 202
         uvp = uvp + uvp2 + uvp3 + uvp4
-        uvp5 = uvp.select(blpairs=[101102101102], pols=[-5, -6, -7], inplace=False)
+        uvp5 = uvp.select(blpairs=[101102101102], polpairs=[505, 404, 303], inplace=False)
         nt.assert_equal(uvp5.data_array[0].shape, (10, 30, 3))
 
         # select only on lst
@@ -255,14 +258,14 @@ class Test_UVPSpec(unittest.TestCase):
 
         # check non-sliceable select: both pol and blpairs are non-sliceable
         uvp = copy.deepcopy(self.uvp)
-        # extend pol_array axis
-        for i in [-6, -7, -8]:
+        # extend polpair_array axis
+        for i in [404, 303, 202]:
             _uvp = copy.deepcopy(self.uvp)
-            _uvp.pol_array[0] = i
+            _uvp.polpair_array[0] = i
             uvp += _uvp
 
         # create a purposely non-sliceable select across *both* pol and blpair
-        uvp.select(pols=[-5, -7, -8], blpairs=[101102101102, 102103102103])
+        uvp.select(polpairs=[404, 303, 202], blpairs=[101102101102, 102103102103])
         nt.assert_equal(uvp.Npols, 3)
         nt.assert_equal(uvp.Nblpairs, 2)
 
@@ -277,7 +280,7 @@ class Test_UVPSpec(unittest.TestCase):
         del uvp.Ntimes
         nt.assert_raises(AssertionError, uvp.check)
         uvp.Ntimes = self.uvp.Ntimes
-        uvp.data_array = uvp.data_array.values()[0]
+        uvp.data_array = list(uvp.data_array.values())[0]
         nt.assert_raises(AssertionError, uvp.check)
         uvp.data_array = copy.deepcopy(self.uvp.data_array)
 
@@ -318,24 +321,24 @@ class Test_UVPSpec(unittest.TestCase):
         uvp = copy.deepcopy(self.uvp)
 
         # test generate noise spectra
-        P_N = uvp.generate_noise_spectra(0, -5, 500, form='Pk', real=True)
+        P_N = uvp.generate_noise_spectra(0, 505, 500, form='Pk', real=True)
         nt.assert_equal(P_N[101102101102].shape, (10, 30))
 
         # test smaller system temp
-        P_N2 = uvp.generate_noise_spectra(0, -5, 400, form='Pk', real=True)
+        P_N2 = uvp.generate_noise_spectra(0, 505, 400, form='Pk', real=True)
         nt.assert_true((P_N[101102101102] > P_N2[101102101102]).all())
 
         # test complex
-        P_N2 = uvp.generate_noise_spectra(0, -5, 500, form='Pk', real=False)
+        P_N2 = uvp.generate_noise_spectra(0, 505, 500, form='Pk', real=False)
         nt.assert_true((P_N[101102101102] < P_N2[101102101102]).all())
 
         # test Dsq
-        Dsq = uvp.generate_noise_spectra(0, -5, 500, form='DelSq', real=True)
+        Dsq = uvp.generate_noise_spectra(0, 505, 500, form='DelSq', real=True)
         nt.assert_equal(Dsq[101102101102].shape, (10, 30))
         nt.assert_true(Dsq[101102101102][0, 1] < P_N[101102101102][0, 1])
 
         # test a blpair selection
-        P_N = uvp.generate_noise_spectra(0, -5, 500, form='Pk', real=True)
+        P_N = uvp.generate_noise_spectra(0, 505, 500, form='Pk', real=True)
 
     def test_average_spectra(self):
         uvp = copy.deepcopy(self.uvp)
@@ -343,8 +346,8 @@ class Test_UVPSpec(unittest.TestCase):
         blpairs = uvp.get_blpair_groups_from_bl_groups([[101102, 102103, 101103]], only_pairs_in_bls=False)
         uvp2 = uvp.average_spectra(blpair_groups=blpairs, time_avg=False, inplace=False)
         nt.assert_equal(uvp2.Nblpairs, 1)
-        nt.assert_true(np.isclose(uvp2.get_nsamples((0, 101102101102, 'xx')), 3.0).all())
-        nt.assert_equal(uvp2.get_data((0, 101102101102, 'xx')).shape, (10, 30))
+        nt.assert_true(np.isclose(uvp2.get_nsamples((0, 101102101102, ('xx','xx'))), 3.0).all())
+        nt.assert_equal(uvp2.get_data((0, 101102101102, ('xx','xx'))).shape, (10, 30))
 
         # Test blpair averaging (with baseline-pair weights)
         # Results should be identical with different weights here, as the data
@@ -358,16 +361,19 @@ class Test_UVPSpec(unittest.TestCase):
                                    blpair_weights=blpair_wgts,
                                    inplace=False)
         #nt.assert_equal(uvp2.Nblpairs, 1)
-        nt.assert_true(np.isclose(uvp3a.get_data((0, 101102101102, 'xx')),
-                                  uvp3b.get_data((0, 101102101102, 'xx'))).all())
+        nt.assert_true(np.isclose(
+                        uvp3a.get_data((0, 101102101102, ('xx','xx'))),
+                        uvp3b.get_data((0, 101102101102, ('xx','xx')))).all())
         #nt.assert_equal(uvp2.get_data((0, 101102101102, 'xx')).shape, (10, 30))
 
 
         # test time averaging
         uvp2 = uvp.average_spectra(time_avg=True, inplace=False)
         nt.assert_true(uvp2.Ntimes, 1)
-        nt.assert_true(np.isclose(uvp2.get_nsamples((0, 101102101102, 'xx')), 10.0).all())
-        nt.assert_true(uvp2.get_data((0, 101102101102, 'xx')).shape, (1, 30))
+        nt.assert_true(np.isclose(
+                uvp2.get_nsamples((0, 101102101102, ('xx','xx'))), 10.0).all())
+        nt.assert_true(uvp2.get_data((0, 101102101102, ('xx','xx'))).shape, 
+                       (1, 30))
         # ensure averaging works when multiple repeated baselines are present, but only
         # if time_avg = True
         uvp.blpair_array[uvp.blpair_to_indices(102103102103)] = 101102101102
@@ -392,8 +398,8 @@ class Test_UVPSpec(unittest.TestCase):
         bls = [(37, 38), (38, 39), (52, 53)]
         uvp1 = testing.uvpspec_from_data(uvd, bls, data_std=uvd_std, spw_ranges=[(0,17)], beam=beam)
         uvp1.fold_spectra()
-        cov_folded = uvp1.get_cov((0, ((37, 38), (38, 39)), 'xx'))
-        data_folded = uvp1.get_data((0, ((37,38), (38, 39)), 'xx'))
+        cov_folded = uvp1.get_cov((0, ((37, 38), (38, 39)), ('xx','xx')))
+        data_folded = uvp1.get_data((0, ((37,38), (38, 39)), ('xx','xx')))
 
 
     def test_str(self):
@@ -403,7 +409,7 @@ class Test_UVPSpec(unittest.TestCase):
     def test_compute_scalar(self):
         uvp = copy.deepcopy(self.uvp)
         # test basic execution
-        s = uvp.compute_scalar(0, 'xx', num_steps=1000, noise_scalar=False)
+        s = uvp.compute_scalar(0, ('xx','xx'), num_steps=1000, noise_scalar=False)
         nt.assert_almost_equal(s/553995277.90425551, 1.0, places=5)
         # test execptions
         del uvp.OmegaP
@@ -438,17 +444,23 @@ class Test_UVPSpec(unittest.TestCase):
         beam = pspecbeam.PSpecBeamUV(os.path.join(DATA_PATH, "HERA_NF_dipole_power.beamfits"))
         bls = [(37, 38), (38, 39), (52, 53)]
         uvp1 = testing.uvpspec_from_data(uvd, bls, spw_ranges=[(20, 30), (60, 90)], beam=beam)
+        
+        
+        print("uvp1 unique blps:", np.unique(uvp1.blpair_array))
 
         # test failure due to overlapping data
         uvp2 = copy.deepcopy(uvp1)
+        
+        print("uvp2 unique blps:", np.unique(uvp2.blpair_array))
+        
         nt.assert_raises(AssertionError, uvpspec.combine_uvpspec, [uvp1, uvp2])
 
         # test success across pol
-        uvp2.pol_array[0] = -6
+        uvp2.polpair_array[0] = 404
         out = uvpspec.combine_uvpspec([uvp1, uvp2], verbose=False)
         nt.assert_equal(out.Npols, 2)
-        nt.assert_true(len(set(out.pol_array) ^ set([-5, -6])) == 0)
-        key = (0, ((37, 38), (38, 39)), 'xx')
+        nt.assert_true(len(set(out.polpair_array) ^ set([505, 404])) == 0)
+        key = (0, ((37, 38), (38, 39)), ('xx','xx'))
         nt.assert_true(np.all(np.isclose(out.get_nsamples(key), np.ones(10, dtype=np.float64))))
         nt.assert_true(np.all(np.isclose(out.get_integrations(key), 190 * np.ones(10, dtype=np.float64), atol=5, rtol=2)))
 
@@ -462,7 +474,7 @@ class Test_UVPSpec(unittest.TestCase):
         uvp2 = testing.uvpspec_from_data(uvd, bls, spw_ranges=[(20, 30), (60, 105)], beam=beam)
         nt.assert_raises(AssertionError, uvpspec.combine_uvpspec, [uvp1, uvp2])
         uvp2 = copy.deepcopy(uvp1)
-        uvp2.pol_array[0] = -6
+        uvp2.polpair_array[0] = 404
         uvp2 = uvpspec.combine_uvpspec([uvp1, uvp2], verbose=False)
         nt.assert_raises(AssertionError, uvpspec.combine_uvpspec, [uvp1, uvp2])
 
@@ -490,7 +502,7 @@ class Test_UVPSpec(unittest.TestCase):
         # test feed as strings
         uvp1 = testing.uvpspec_from_data(uvd, bls, spw_ranges=[(20, 30)], beam=beam)
         uvp2 = copy.deepcopy(uvp1)
-        uvp2.pol_array[0] = -6
+        uvp2.polpair_array[0] = 404
         uvp1.write_hdf5('uvp1.hdf5', overwrite=True)
         uvp2.write_hdf5('uvp2.hdf5', overwrite=True)
         out = uvpspec.combine_uvpspec(['uvp1.hdf5', 'uvp2.hdf5'], verbose=False)
@@ -501,7 +513,7 @@ class Test_UVPSpec(unittest.TestCase):
 
         # test UVPSpec __add__
         uvp3 = copy.deepcopy(uvp1)
-        uvp3.pol_array[0] = -7
+        uvp3.polpair_array[0] = 303
         out = uvp1 + uvp2 + uvp3
         nt.assert_equal(out.Npols, 3)
         
@@ -510,7 +522,7 @@ class Test_UVPSpec(unittest.TestCase):
                                          spw_ranges=[(20, 30), (60, 90)], 
                                          n_dlys=[5, 15])
         uvp4b = copy.deepcopy(uvp4)
-        uvp4b.pol_array[0] = -6
+        uvp4b.polpair_array[0] = 404
         out = uvpspec.combine_uvpspec([uvp4, uvp4b], verbose=False)
         
 
@@ -531,10 +543,10 @@ class Test_UVPSpec(unittest.TestCase):
         uvp2 = copy.deepcopy(uvp1)
         nt.assert_raises(AssertionError, uvpspec.combine_uvpspec, [uvp1, uvp2])
         # test success across pol
-        uvp2.pol_array[0] = -6
+        uvp2.polpair_array[0] = 404
         out = uvpspec.combine_uvpspec([uvp1, uvp2], verbose=False)
         nt.assert_equal(out.Npols, 2)
-        nt.assert_true(len(set(out.pol_array) ^ set([-5, -6])) == 0)
+        nt.assert_true(len(set(out.polpair_array) ^ set([505, 404])) == 0)
         # test multiple non-overlapping data axes
         uvp2.freq_array[0] = 0.0
         nt.assert_raises(AssertionError, uvpspec.combine_uvpspec, [uvp1, uvp2])
@@ -550,7 +562,7 @@ class Test_UVPSpec(unittest.TestCase):
                                          data_std=uvd_std, beam=beam)
         nt.assert_raises(AssertionError, uvpspec.combine_uvpspec, [uvp1, uvp2])
         uvp2 = copy.deepcopy(uvp1)
-        uvp2.pol_array[0] = -6
+        uvp2.polpair_array[0] = 404
         uvp2 = uvpspec.combine_uvpspec([uvp1, uvp2], verbose=False)
         nt.assert_raises(AssertionError, uvpspec.combine_uvpspec, [uvp1, uvp2])
 
@@ -582,7 +594,7 @@ class Test_UVPSpec(unittest.TestCase):
         uvp1 = testing.uvpspec_from_data(uvd, bls, spw_ranges=[(20, 30)], 
                                          data_std=uvd_std, beam=beam)
         uvp2 = copy.deepcopy(uvp1)
-        uvp2.pol_array[0] = -6
+        uvp2.polpair_array[0] = 404
         uvp1.write_hdf5('uvp1.hdf5', overwrite=True)
         uvp2.write_hdf5('uvp2.hdf5', overwrite=True)
         out = uvpspec.combine_uvpspec(['uvp1.hdf5', 'uvp2.hdf5'], verbose=False)
@@ -592,7 +604,7 @@ class Test_UVPSpec(unittest.TestCase):
         
         # test UVPSpec __add__
         uvp3 = copy.deepcopy(uvp1)
-        uvp3.pol_array[0] = -7
+        uvp3.polpair_array[0] = 303
         out = uvp1 + uvp2 + uvp3
         nt.assert_equal(out.Npols, 3)
 

--- a/hera_pspec/tests/test_uvpspec.py
+++ b/hera_pspec/tests/test_uvpspec.py
@@ -39,9 +39,9 @@ class Test_UVPSpec(unittest.TestCase):
         nt.assert_equal(d.shape, (10, 30))
         nt.assert_true(d.dtype == np.complex)
         nt.assert_almost_equal(d[0,0], (101.1021011020000001+0j))
-        d = self.uvp.get_data((0, ((1, 2), (1, 2)), 505))
+        d = self.uvp.get_data((0, ((1, 2), (1, 2)), 1515))
         nt.assert_almost_equal(d[0,0], (101.1021011020000001+0j))
-        d = self.uvp.get_data((0, 101102101102, 505))
+        d = self.uvp.get_data((0, 101102101102, 1515))
         nt.assert_almost_equal(d[0,0], (101.1021011020000001+0j))
         # get_wgts
         w = self.uvp.get_wgts((0, ((1, 2), (1, 2)), ('xx','xx')))
@@ -152,7 +152,7 @@ class Test_UVPSpec(unittest.TestCase):
 
     def test_indices_funcs(self):
         # key to indices
-        spw, blpairts, pol = self.uvp.key_to_indices( (0, ((1,2),(1,2)), 505) )
+        spw, blpairts, pol = self.uvp.key_to_indices( (0, ((1,2),(1,2)), 1515) )
         nt.assert_equal(spw, 0)
         nt.assert_equal(pol, 0)
         nt.assert_true(np.isclose(blpairts, np.array([0,3,6,9,12,15,18,21,24,27])).min())
@@ -180,7 +180,7 @@ class Test_UVPSpec(unittest.TestCase):
         # pol to indices
         pol = self.uvp.polpair_to_indices(('xx','xx'))
         nt.assert_equal(len(pol), 1)
-        pol = self.uvp.polpair_to_indices(505)
+        pol = self.uvp.polpair_to_indices(1515)
         nt.assert_equal(len(pol), 1)
         pol = self.uvp.polpair_to_indices([('xx','xx'), ('xx','xx')])
         nt.assert_equal(len(pol), 1)
@@ -228,8 +228,8 @@ class Test_UVPSpec(unittest.TestCase):
         nt.assert_equal(uvp2.Nblpairs, 2)
 
         # pol select
-        uvp2 = uvp.select(polpairs=[505,], inplace=False)
-        nt.assert_equal(uvp2.polpair_array[0], 505)
+        uvp2 = uvp.select(polpairs=[1515,], inplace=False)
+        nt.assert_equal(uvp2.polpair_array[0], 1515)
 
         # time select
         uvp2 = uvp.select(times=np.unique(uvp.time_avg_array)[:1], inplace=False)
@@ -238,17 +238,19 @@ class Test_UVPSpec(unittest.TestCase):
         # test pol and blpair select, and check dimensionality of output
         uvp = copy.deepcopy(self.uvp)
         uvp.set_stats('hi', uvp.get_all_keys()[0], np.ones(300).reshape(10, 30))
-        uvp2 = uvp.select(blpairs=uvp.get_blpairs(), polpairs=uvp.polpair_array, inplace=False)
+        uvp2 = uvp.select(blpairs=uvp.get_blpairs(), polpairs=uvp.polpair_array, 
+                          inplace=False)
         nt.assert_equal(uvp2.data_array[0].shape, (30, 30, 1))
         nt.assert_equal(uvp2.stats_array['hi'][0].shape, (30, 30, 1))
 
         # test when both blp and pol array are non-sliceable
         uvp2, uvp3, uvp4 = copy.deepcopy(uvp), copy.deepcopy(uvp), copy.deepcopy(uvp)
-        uvp2.polpair_array[0] = 404
-        uvp3.polpair_array[0] = 303
-        uvp4.polpair_array[0] = 202
+        uvp2.polpair_array[0] = 1414
+        uvp3.polpair_array[0] = 1313
+        uvp4.polpair_array[0] = 1212
         uvp = uvp + uvp2 + uvp3 + uvp4
-        uvp5 = uvp.select(blpairs=[101102101102], polpairs=[505, 404, 303], inplace=False)
+        uvp5 = uvp.select(blpairs=[101102101102], polpairs=[1515, 1414, 1313], 
+                          inplace=False)
         nt.assert_equal(uvp5.data_array[0].shape, (10, 30, 3))
 
         # select only on lst
@@ -259,13 +261,13 @@ class Test_UVPSpec(unittest.TestCase):
         # check non-sliceable select: both pol and blpairs are non-sliceable
         uvp = copy.deepcopy(self.uvp)
         # extend polpair_array axis
-        for i in [404, 303, 202]:
+        for i in [1414, 1313, 1212]:
             _uvp = copy.deepcopy(self.uvp)
             _uvp.polpair_array[0] = i
             uvp += _uvp
 
         # create a purposely non-sliceable select across *both* pol and blpair
-        uvp.select(polpairs=[404, 303, 202], blpairs=[101102101102, 102103102103])
+        uvp.select(polpairs=[1414, 1313, 1212], blpairs=[101102101102, 102103102103])
         nt.assert_equal(uvp.Npols, 3)
         nt.assert_equal(uvp.Nblpairs, 2)
 
@@ -321,30 +323,32 @@ class Test_UVPSpec(unittest.TestCase):
         uvp = copy.deepcopy(self.uvp)
 
         # test generate noise spectra
-        P_N = uvp.generate_noise_spectra(0, 505, 500, form='Pk', real=True)
+        P_N = uvp.generate_noise_spectra(0, 1515, 500, form='Pk', real=True)
         nt.assert_equal(P_N[101102101102].shape, (10, 30))
 
         # test smaller system temp
-        P_N2 = uvp.generate_noise_spectra(0, 505, 400, form='Pk', real=True)
+        P_N2 = uvp.generate_noise_spectra(0, 1515, 400, form='Pk', real=True)
         nt.assert_true((P_N[101102101102] > P_N2[101102101102]).all())
 
         # test complex
-        P_N2 = uvp.generate_noise_spectra(0, 505, 500, form='Pk', real=False)
+        P_N2 = uvp.generate_noise_spectra(0, 1515, 500, form='Pk', real=False)
         nt.assert_true((P_N[101102101102] < P_N2[101102101102]).all())
 
         # test Dsq
-        Dsq = uvp.generate_noise_spectra(0, 505, 500, form='DelSq', real=True)
+        Dsq = uvp.generate_noise_spectra(0, 1515, 500, form='DelSq', real=True)
         nt.assert_equal(Dsq[101102101102].shape, (10, 30))
         nt.assert_true(Dsq[101102101102][0, 1] < P_N[101102101102][0, 1])
 
         # test a blpair selection
-        P_N = uvp.generate_noise_spectra(0, 505, 500, form='Pk', real=True)
+        P_N = uvp.generate_noise_spectra(0, 1515, 500, form='Pk', real=True)
 
     def test_average_spectra(self):
         uvp = copy.deepcopy(self.uvp)
         # test blpair averaging
-        blpairs = uvp.get_blpair_groups_from_bl_groups([[101102, 102103, 101103]], only_pairs_in_bls=False)
-        uvp2 = uvp.average_spectra(blpair_groups=blpairs, time_avg=False, inplace=False)
+        blpairs = uvp.get_blpair_groups_from_bl_groups([[101102, 102103, 101103]], 
+                                                       only_pairs_in_bls=False)
+        uvp2 = uvp.average_spectra(blpair_groups=blpairs, time_avg=False, 
+                                   inplace=False)
         nt.assert_equal(uvp2.Nblpairs, 1)
         nt.assert_true(np.isclose(uvp2.get_nsamples((0, 101102101102, ('xx','xx'))), 3.0).all())
         nt.assert_equal(uvp2.get_data((0, 101102101102, ('xx','xx'))).shape, (10, 30))
@@ -365,8 +369,7 @@ class Test_UVPSpec(unittest.TestCase):
                         uvp3a.get_data((0, 101102101102, ('xx','xx'))),
                         uvp3b.get_data((0, 101102101102, ('xx','xx')))).all())
         #nt.assert_equal(uvp2.get_data((0, 101102101102, 'xx')).shape, (10, 30))
-
-
+        
         # test time averaging
         uvp2 = uvp.average_spectra(time_avg=True, inplace=False)
         nt.assert_true(uvp2.Ntimes, 1)
@@ -394,9 +397,11 @@ class Test_UVPSpec(unittest.TestCase):
         uvd_std = UVData()
         uvd.read_miriad(os.path.join(DATA_PATH, 'zen.even.xx.LST.1.28828.uvOCRSA'))
         uvd_std.read_miriad(os.path.join(DATA_PATH,'zen.even.xx.LST.1.28828.uvOCRSA'))
-        beam = pspecbeam.PSpecBeamUV(os.path.join(DATA_PATH, "HERA_NF_dipole_power.beamfits"))
+        beam = pspecbeam.PSpecBeamUV(os.path.join(DATA_PATH, 
+                                               "HERA_NF_dipole_power.beamfits"))
         bls = [(37, 38), (38, 39), (52, 53)]
-        uvp1 = testing.uvpspec_from_data(uvd, bls, data_std=uvd_std, spw_ranges=[(0,17)], beam=beam)
+        uvp1 = testing.uvpspec_from_data(uvd, bls, data_std=uvd_std, 
+                                         spw_ranges=[(0,17)], beam=beam)
         uvp1.fold_spectra()
         cov_folded = uvp1.get_cov((0, ((37, 38), (38, 39)), ('xx','xx')))
         data_folded = uvp1.get_data((0, ((37,38), (38, 39)), ('xx','xx')))
@@ -441,10 +446,12 @@ class Test_UVPSpec(unittest.TestCase):
         # setup uvp build
         uvd = UVData()
         uvd.read_miriad(os.path.join(DATA_PATH, 'zen.even.xx.LST.1.28828.uvOCRSA'))
-        beam = pspecbeam.PSpecBeamUV(os.path.join(DATA_PATH, "HERA_NF_dipole_power.beamfits"))
+        beam = pspecbeam.PSpecBeamUV(os.path.join(DATA_PATH, 
+                                               "HERA_NF_dipole_power.beamfits"))
         bls = [(37, 38), (38, 39), (52, 53)]
-        uvp1 = testing.uvpspec_from_data(uvd, bls, spw_ranges=[(20, 30), (60, 90)], beam=beam)
-        
+        uvp1 = testing.uvpspec_from_data(uvd, bls, 
+                                         spw_ranges=[(20, 30), (60, 90)], 
+                                         beam=beam)
         
         print("uvp1 unique blps:", np.unique(uvp1.blpair_array))
 
@@ -456,37 +463,46 @@ class Test_UVPSpec(unittest.TestCase):
         nt.assert_raises(AssertionError, uvpspec.combine_uvpspec, [uvp1, uvp2])
 
         # test success across pol
-        uvp2.polpair_array[0] = 404
+        uvp2.polpair_array[0] = 1414
         out = uvpspec.combine_uvpspec([uvp1, uvp2], verbose=False)
         nt.assert_equal(out.Npols, 2)
-        nt.assert_true(len(set(out.polpair_array) ^ set([505, 404])) == 0)
+        nt.assert_true(len(set(out.polpair_array) ^ set([1515, 1414])) == 0)
         key = (0, ((37, 38), (38, 39)), ('xx','xx'))
-        nt.assert_true(np.all(np.isclose(out.get_nsamples(key), np.ones(10, dtype=np.float64))))
-        nt.assert_true(np.all(np.isclose(out.get_integrations(key), 190 * np.ones(10, dtype=np.float64), atol=5, rtol=2)))
+        nt.assert_true(np.all(np.isclose(out.get_nsamples(key), 
+                       np.ones(10, dtype=np.float64))))
+        nt.assert_true(np.all(np.isclose(out.get_integrations(key), 
+                       190 * np.ones(10, dtype=np.float64), atol=5, rtol=2)))
 
         # test multiple non-overlapping data axes
         uvp2.freq_array[0] = 0.0
         nt.assert_raises(AssertionError, uvpspec.combine_uvpspec, [uvp1, uvp2])
 
         # test partial data overlap failure
-        uvp2 = testing.uvpspec_from_data(uvd, [(37, 38), (38, 39), (53, 54)], spw_ranges=[(20, 30), (60, 90)], beam=beam)
+        uvp2 = testing.uvpspec_from_data(uvd, [(37, 38), (38, 39), (53, 54)], 
+                                         spw_ranges=[(20, 30), (60, 90)], 
+                                         beam=beam)
         nt.assert_raises(AssertionError, uvpspec.combine_uvpspec, [uvp1, uvp2])
-        uvp2 = testing.uvpspec_from_data(uvd, bls, spw_ranges=[(20, 30), (60, 105)], beam=beam)
+        uvp2 = testing.uvpspec_from_data(uvd, bls, 
+                                         spw_ranges=[(20, 30), (60, 105)], 
+                                         beam=beam)
         nt.assert_raises(AssertionError, uvpspec.combine_uvpspec, [uvp1, uvp2])
         uvp2 = copy.deepcopy(uvp1)
-        uvp2.polpair_array[0] = 404
+        uvp2.polpair_array[0] = 1414
         uvp2 = uvpspec.combine_uvpspec([uvp1, uvp2], verbose=False)
         nt.assert_raises(AssertionError, uvpspec.combine_uvpspec, [uvp1, uvp2])
 
         # test concat across spw
-        uvp2 = testing.uvpspec_from_data(uvd, bls, spw_ranges=[(85, 101)], beam=beam)
+        uvp2 = testing.uvpspec_from_data(uvd, bls, spw_ranges=[(85, 101)], 
+                                         beam=beam)
         out = uvpspec.combine_uvpspec([uvp1, uvp2], verbose=False)
         nt.assert_equal(out.Nspws, 3)
         nt.assert_equal(out.Nfreqs, 51)
         nt.assert_equal(out.Nspwdlys, 56)
 
         # test concat across blpairts
-        uvp2 = testing.uvpspec_from_data(uvd, [(53, 54), (67, 68)], spw_ranges=[(20, 30), (60, 90)], beam=beam)
+        uvp2 = testing.uvpspec_from_data(uvd, [(53, 54), (67, 68)], 
+                                         spw_ranges=[(20, 30), (60, 90)], 
+                                         beam=beam)
         out = uvpspec.combine_uvpspec([uvp1, uvp2], verbose=False)
         nt.assert_equal(out.Nblpairs, 4)
         nt.assert_equal(out.Nbls, 5)
@@ -502,7 +518,7 @@ class Test_UVPSpec(unittest.TestCase):
         # test feed as strings
         uvp1 = testing.uvpspec_from_data(uvd, bls, spw_ranges=[(20, 30)], beam=beam)
         uvp2 = copy.deepcopy(uvp1)
-        uvp2.polpair_array[0] = 404
+        uvp2.polpair_array[0] = 1414
         uvp1.write_hdf5('uvp1.hdf5', overwrite=True)
         uvp2.write_hdf5('uvp2.hdf5', overwrite=True)
         out = uvpspec.combine_uvpspec(['uvp1.hdf5', 'uvp2.hdf5'], verbose=False)
@@ -513,7 +529,7 @@ class Test_UVPSpec(unittest.TestCase):
 
         # test UVPSpec __add__
         uvp3 = copy.deepcopy(uvp1)
-        uvp3.polpair_array[0] = 303
+        uvp3.polpair_array[0] = 1313
         out = uvp1 + uvp2 + uvp3
         nt.assert_equal(out.Npols, 3)
         
@@ -522,7 +538,7 @@ class Test_UVPSpec(unittest.TestCase):
                                          spw_ranges=[(20, 30), (60, 90)], 
                                          n_dlys=[5, 15])
         uvp4b = copy.deepcopy(uvp4)
-        uvp4b.polpair_array[0] = 404
+        uvp4b.polpair_array[0] = 1414
         out = uvpspec.combine_uvpspec([uvp4, uvp4b], verbose=False)
         
 
@@ -543,10 +559,10 @@ class Test_UVPSpec(unittest.TestCase):
         uvp2 = copy.deepcopy(uvp1)
         nt.assert_raises(AssertionError, uvpspec.combine_uvpspec, [uvp1, uvp2])
         # test success across pol
-        uvp2.polpair_array[0] = 404
+        uvp2.polpair_array[0] = 1414
         out = uvpspec.combine_uvpspec([uvp1, uvp2], verbose=False)
         nt.assert_equal(out.Npols, 2)
-        nt.assert_true(len(set(out.polpair_array) ^ set([505, 404])) == 0)
+        nt.assert_true(len(set(out.polpair_array) ^ set([1515, 1414])) == 0)
         # test multiple non-overlapping data axes
         uvp2.freq_array[0] = 0.0
         nt.assert_raises(AssertionError, uvpspec.combine_uvpspec, [uvp1, uvp2])
@@ -562,7 +578,7 @@ class Test_UVPSpec(unittest.TestCase):
                                          data_std=uvd_std, beam=beam)
         nt.assert_raises(AssertionError, uvpspec.combine_uvpspec, [uvp1, uvp2])
         uvp2 = copy.deepcopy(uvp1)
-        uvp2.polpair_array[0] = 404
+        uvp2.polpair_array[0] = 1414
         uvp2 = uvpspec.combine_uvpspec([uvp1, uvp2], verbose=False)
         nt.assert_raises(AssertionError, uvpspec.combine_uvpspec, [uvp1, uvp2])
 
@@ -594,7 +610,7 @@ class Test_UVPSpec(unittest.TestCase):
         uvp1 = testing.uvpspec_from_data(uvd, bls, spw_ranges=[(20, 30)], 
                                          data_std=uvd_std, beam=beam)
         uvp2 = copy.deepcopy(uvp1)
-        uvp2.polpair_array[0] = 404
+        uvp2.polpair_array[0] = 1414
         uvp1.write_hdf5('uvp1.hdf5', overwrite=True)
         uvp2.write_hdf5('uvp2.hdf5', overwrite=True)
         out = uvpspec.combine_uvpspec(['uvp1.hdf5', 'uvp2.hdf5'], verbose=False)
@@ -604,7 +620,7 @@ class Test_UVPSpec(unittest.TestCase):
         
         # test UVPSpec __add__
         uvp3 = copy.deepcopy(uvp1)
-        uvp3.polpair_array[0] = 303
+        uvp3.polpair_array[0] = 1313
         out = uvp1 + uvp2 + uvp3
         nt.assert_equal(out.Npols, 3)
 

--- a/hera_pspec/tests/test_uvpspec_utils.py
+++ b/hera_pspec/tests/test_uvpspec_utils.py
@@ -35,7 +35,7 @@ def test_select_common():
     # Check that selecting on common times works
     uvp_list = [uvp1, uvp2]
     uvp_new = uvputils.select_common(uvp_list, spws=True, blpairs=True, 
-                                     times=True, pols=True, inplace=False)
+                                     times=True, polpairs=True, inplace=False)
     nt.assert_equal(uvp_new[0], uvp_new[1])
     np.testing.assert_array_equal(uvp_new[0].time_avg_array, 
                                   uvp_new[1].time_avg_array)
@@ -43,7 +43,7 @@ def test_select_common():
     # Check that selecting on common baseline-pairs works
     uvp_list_2 = [uvp1, uvp2, uvp3]
     uvp_new_2 = uvputils.select_common(uvp_list_2, spws=True, blpairs=True, 
-                                       times=True, pols=True, inplace=False)
+                                       times=True, polpairs=True, inplace=False)
     nt.assert_equal(uvp_new_2[0], uvp_new_2[1])
     nt.assert_equal(uvp_new_2[0], uvp_new_2[2])
     np.testing.assert_array_equal(uvp_new_2[0].time_avg_array, 
@@ -52,29 +52,29 @@ def test_select_common():
     # Check that zero overlap in times raises a ValueError
     nt.assert_raises(ValueError, uvputils.select_common, [uvp2, uvp6], 
                                   spws=True, blpairs=True, times=True, 
-                                  pols=True, inplace=False)
+                                  polpairs=True, inplace=False)
     
     # Check that zero overlap in times does *not* raise a ValueError if 
     # not selecting on times
     uvp_new_3 = uvputils.select_common([uvp2, uvp6], spws=True, 
                                        blpairs=True, times=False, 
-                                       pols=True, inplace=False)
+                                       polpairs=True, inplace=False)
     
     # Check that zero overlap in baselines raises a ValueError
     nt.assert_raises(ValueError, uvputils.select_common, [uvp3, uvp5], 
                                   spws=True, blpairs=True, times=True, 
-                                  pols=True, inplace=False)
+                                  polpairs=True, inplace=False)
     
     # Check that matching times are ignored when set to False
     uvp_new = uvputils.select_common(uvp_list, spws=True, blpairs=True, 
-                                     times=False, pols=True, inplace=False)
+                                     times=False, polpairs=True, inplace=False)
     nt.assert_not_equal( np.sum(uvp_new[0].time_avg_array 
                               - uvp_new[1].time_avg_array), 0.)
     nt.assert_equal(len(uvp_new), len(uvp_list))
     
     # Check that in-place selection works
     uvputils.select_common(uvp_list, spws=True, blpairs=True, 
-                           times=True, pols=True, inplace=True)
+                           times=True, polpairs=True, inplace=True)
     nt.assert_equal(uvp1, uvp2)
 
     # check uvplist > 2
@@ -92,8 +92,9 @@ def test_select_common():
 
     # check pol overlap
     uvp7 = copy.deepcopy(uvp1)
-    uvp7.pol_array[0] = -8
-    nt.assert_raises(ValueError, uvputils.select_common, [uvp1, uvp7], pols=True)
+    uvp7.polpair_array[0] = 202 # = (-8,-8)
+    nt.assert_raises(ValueError, uvputils.select_common, [uvp1, uvp7], 
+                                 polpairs=True)
 
 def test_subtract_uvp():
     """ Test subtraction of two UVPSpec objects """
@@ -146,7 +147,7 @@ def test_fast_is_in():
     times = [ 0.1, 0.15, 0.2, 0.25, 
               0.1, 0.15, 0.2, 0.25, 
               0.1, 0.15, 0.3, 0.3, ]
-    src_blpts = np.array(zip(blps, times))
+    src_blpts = np.array(list(zip(blps, times)))
 
     nt.assert_true(uvputils._fast_is_in(src_blpts, [(101102104103, 0.2)])[0])
 
@@ -159,7 +160,7 @@ def test_fast_lookup_blpairts():
     times = [ 0.1, 0.15, 0.2, 0.25, 
               0.1, 0.15, 0.2, 0.25, 
               0.1, 0.15, 0.3, 0.3, ]
-    src_blpts = np.array(zip(blps, times))
+    src_blpts = np.array(list(zip(blps, times)))
     
     # List of blpair-times to look up
     query_blpts = [(102101103104, 0.1), (101102104103, 0.1), (101102104103, 0.25)]

--- a/hera_pspec/tests/test_uvpspec_utils.py
+++ b/hera_pspec/tests/test_uvpspec_utils.py
@@ -96,6 +96,21 @@ def test_select_common():
     nt.assert_raises(ValueError, uvputils.select_common, [uvp1, uvp7], 
                                  polpairs=True)
 
+def test_get_blpairs_from_bls():
+    """
+    Test conversion of 
+    """
+    # setup uvp
+    beamfile = os.path.join(DATA_PATH, 'HERA_NF_dipole_power.beamfits')
+    beam = pspecbeam.PSpecBeamUV(beamfile)
+    uvp, cosmo = testing.build_vanilla_uvpspec(beam=beam)
+    
+    # Check that bls can be specified in several different ways
+    blps = uvputils._get_blpairs_from_bls(uvp, bls=101102)
+    blps = uvputils._get_blpairs_from_bls(uvp, bls=(101,102))
+    blps = uvputils._get_blpairs_from_bls(uvp, bls=[101102, 101103])
+    
+
 def test_polpair_int2tuple():
     """
     Test conversion of polpair ints to tuples.

--- a/hera_pspec/tests/test_uvpspec_utils.py
+++ b/hera_pspec/tests/test_uvpspec_utils.py
@@ -114,12 +114,6 @@ def test_polpair_int2tuple():
     
     # Test converting to int and then back again
     pol_pairs_returned = uvputils.polpair_int2tuple(pol_ints, pol_strings=True)
-    
-    print("pp:", polpairs)
-    print("pp_ret:", pol_pairs_returned)
-    print("pp_ints:", pol_ints)
-    
-    
     for i in range(len(polpairs)):
         nt.assert_equal(polpairs[i], pol_pairs_returned[i])
     
@@ -132,7 +126,9 @@ def test_polpair_int2tuple():
     
     
 def test_subtract_uvp():
-    """ Test subtraction of two UVPSpec objects """
+    """
+    Test subtraction of two UVPSpec objects
+    """
     # setup uvp
     beamfile = os.path.join(DATA_PATH, 'HERA_NF_dipole_power.beamfits')
     beam = pspecbeam.PSpecBeamUV(beamfile)

--- a/hera_pspec/tests/test_uvpspec_utils.py
+++ b/hera_pspec/tests/test_uvpspec_utils.py
@@ -96,6 +96,41 @@ def test_select_common():
     nt.assert_raises(ValueError, uvputils.select_common, [uvp1, uvp7], 
                                  polpairs=True)
 
+def test_polpair_int2tuple():
+    """
+    Test conversion of polpair ints to tuples.
+    """
+    # List of polpairs to test
+    polpairs = [('xx','xx'), ('xx','yy'), ('xy', 'yx'), 
+                ('pI','pI'), ('pI','pQ'), ('pQ','pQ'), ('pU','pU'),
+                ('pV','pV') ]
+    
+    # Check that lists and single items work
+    pol_ints = uvputils.polpair_tuple2int(polpairs)
+    uvputils.polpair_tuple2int(polpairs[0])
+    uvputils.polpair_int2tuple(505)
+    uvputils.polpair_int2tuple([505,404])
+    uvputils.polpair_int2tuple(np.array([505,404]))
+    
+    # Test converting to int and then back again
+    pol_pairs_returned = uvputils.polpair_int2tuple(pol_ints, pol_strings=True)
+    
+    print("pp:", polpairs)
+    print("pp_ret:", pol_pairs_returned)
+    print("pp_ints:", pol_ints)
+    
+    
+    for i in range(len(polpairs)):
+        nt.assert_equal(polpairs[i], pol_pairs_returned[i])
+    
+    # Check that errors are raised appropriately
+    nt.assert_raises(AssertionError, uvputils.polpair_int2tuple, ('xx','xx'))
+    nt.assert_raises(AssertionError, uvputils.polpair_int2tuple, 'xx')
+    nt.assert_raises(AssertionError, uvputils.polpair_int2tuple, 'pI')
+    nt.assert_raises(ValueError, uvputils.polpair_int2tuple, 999)
+    nt.assert_raises(ValueError, uvputils.polpair_int2tuple, [999,])
+    
+    
 def test_subtract_uvp():
     """ Test subtraction of two UVPSpec objects """
     # setup uvp

--- a/hera_pspec/tests/test_uvpspec_utils.py
+++ b/hera_pspec/tests/test_uvpspec_utils.py
@@ -92,7 +92,7 @@ def test_select_common():
 
     # check pol overlap
     uvp7 = copy.deepcopy(uvp1)
-    uvp7.polpair_array[0] = 202 # = (-8,-8)
+    uvp7.polpair_array[0] = 1212 # = (-8,-8)
     nt.assert_raises(ValueError, uvputils.select_common, [uvp1, uvp7], 
                                  polpairs=True)
 
@@ -108,9 +108,9 @@ def test_polpair_int2tuple():
     # Check that lists and single items work
     pol_ints = uvputils.polpair_tuple2int(polpairs)
     uvputils.polpair_tuple2int(polpairs[0])
-    uvputils.polpair_int2tuple(505)
-    uvputils.polpair_int2tuple([505,404])
-    uvputils.polpair_int2tuple(np.array([505,404]))
+    uvputils.polpair_int2tuple(1515)
+    uvputils.polpair_int2tuple([1515,1414])
+    uvputils.polpair_int2tuple(np.array([1515,1414]))
     
     # Test converting to int and then back again
     pol_pairs_returned = uvputils.polpair_int2tuple(pol_ints, pol_strings=True)

--- a/hera_pspec/tests/test_version.py
+++ b/hera_pspec/tests/test_version.py
@@ -2,7 +2,12 @@
 import nose.tools as nt
 import sys
 import os
-from io import StringIO
+try:
+    # Python 2
+    from cStringIO import StringIO
+except:
+    # Python 3
+    from io import StringIO
 import subprocess
 import hera_pspec
 

--- a/hera_pspec/tests/test_version.py
+++ b/hera_pspec/tests/test_version.py
@@ -9,7 +9,7 @@ import hera_pspec
 
 def test_main():
     version_info = hera_pspec.version.construct_version_info()
-
+    
     saved_stdout = sys.stdout
     try:
         out = StringIO()
@@ -22,7 +22,13 @@ def test_main():
                                 o=version_info['git_origin'],
                                 b=version_info['git_branch'],
                                 d=version_info['git_description']))
+        
+        git_info = hera_pspec.version._get_gitinfo_file()
+        
     finally:
         sys.stdout = saved_stdout
+    
+    # Test history string function
+    history = hera_pspec.version.history_string()
 
 

--- a/hera_pspec/tests/test_version.py
+++ b/hera_pspec/tests/test_version.py
@@ -2,7 +2,7 @@
 import nose.tools as nt
 import sys
 import os
-from StringIO import StringIO
+from io import StringIO
 import subprocess
 import hera_pspec
 

--- a/hera_pspec/utils.py
+++ b/hera_pspec/utils.py
@@ -1,10 +1,10 @@
 import numpy as np
-import os, time, md5, yaml
+import os, time, yaml
 import itertools, argparse, glob
 import traceback, operator
 import aipy, uvtools
 import pylab as plt
-from conversions import Cosmo_Conversions
+from hera_pspec.conversions import Cosmo_Conversions
 from hera_cal import redcal
 from collections import OrderedDict as odict
 from pyuvdata import utils as uvutils
@@ -17,6 +17,7 @@ def hash(w):
     Return an MD5 hash of a set of weights.
     """
     DeprecationWarning("utils.hash is deprecated.")
+    import md5
     return md5.md5(w.copy(order='C')).digest()
 
 

--- a/hera_pspec/utils.py
+++ b/hera_pspec/utils.py
@@ -125,7 +125,7 @@ def construct_blpairs(bls, exclude_auto_bls=False, exclude_permutations=False, g
         blpairs = list(itertools.permutations(bls, 2))
 
     # explicitly add in auto baseline pairs
-    blpairs.extend(zip(bls, bls))
+    blpairs.extend(list(zip(bls, bls)))
 
     # iterate through and eliminate all autos if desired
     if exclude_auto_bls:
@@ -136,8 +136,8 @@ def construct_blpairs(bls, exclude_auto_bls=False, exclude_permutations=False, g
         blpairs = new_blpairs
 
     # create bls1 and bls2 list
-    bls1 = map(lambda blp: blp[0], blpairs)
-    bls2 = map(lambda blp: blp[1], blpairs)
+    bls1 = [blp[0] for blp in blpairs]
+    bls2 = [blp[1] for blp in blpairs]
 
     # group baseline pairs if desired
     if group:
@@ -158,11 +158,14 @@ def construct_blpairs(bls, exclude_auto_bls=False, exclude_permutations=False, g
     return bls1, bls2, blpairs
 
 
-def calc_blpair_reds(uvd1, uvd2, bl_tol=1.0, filter_blpairs=True, xant_flag_thresh=0.95, exclude_auto_bls=False,
-                     exclude_permutations=True, Nblps_per_group=None, bl_len_range=(0, 1e10), bl_deg_range=(0, 180)):
+def calc_blpair_reds(uvd1, uvd2, bl_tol=1.0, filter_blpairs=True, 
+                     xant_flag_thresh=0.95, exclude_auto_bls=False,
+                     exclude_permutations=True, Nblps_per_group=None, 
+                     bl_len_range=(0, 1e10), bl_deg_range=(0, 180)):
     """
-    Use hera_cal.redcal to get matching, redundant baseline-pair groups from uvd1 and uvd2
-    within the specified baseline tolerance, not including flagged ants.
+    Use hera_cal.redcal to get matching, redundant baseline-pair groups from 
+    uvd1 and uvd2 within the specified baseline tolerance, not including 
+    flagged ants.
 
     Parameters
     ----------
@@ -174,8 +177,8 @@ def calc_blpair_reds(uvd1, uvd2, bl_tol=1.0, filter_blpairs=True, xant_flag_thre
         Baseline-vector redundancy tolerance in meters
 
     filter_blpairs : bool, optional
-        if True, calculate xants and filters-out baseline pairs based on xant lists
-        and actual baselines in the data.
+        if True, calculate xants and filters-out baseline pairs based on 
+        xant lists and actual baselines in the data.
 
     xant_flag_thresh : float, optional
         Fraction of 2D visibility (per-waterfall) needed to be flagged to
@@ -197,36 +200,31 @@ def calc_blpair_reds(uvd1, uvd2, bl_tol=1.0, filter_blpairs=True, xant_flag_thre
         Default: None
 
     bl_len_range : tuple, optional
-        len-2 tuple containing minimum baseline length and maximum baseline length [meters]
-        to keep in baseline type selection
+        len-2 tuple containing minimum baseline length and maximum baseline 
+        length [meters] to keep in baseline type selection
 
     bl_deg_range : tuple, optional
-        len-2 tuple containing (minimum, maximum) baseline angle in degrees to keep in
-        baseline selection
+        len-2 tuple containing (minimum, maximum) baseline angle in degrees 
+        to keep in baseline selection
 
     Returns
     -------
-    baselines1 : list of baseline tuples
-        Contains list of baseline tuples that should be fed as first argument
-        to PSpecData.pspec(), corresponding to uvd1
-
-    baselines2 : list of baseline tuples
-        Contains list of baseline tuples that should be fed as second argument
-        to PSpecData.pspec(), corresponding to uvd2
+    baselines1, baselines2 : lists of baseline tuples
+        Lists of baseline tuples that should be fed as first/second argument
+        to PSpecData.pspec(), corresponding to uvd1/uvd2
 
     blpairs : list of baseline-pair tuples
         Contains the baseline-pair tuples. i.e. zip(baselines1, baselines2)
 
-    xants1 : list of bad antenna integers for uvd1
-
-    xants2 : list of bad antenna integers for uvd2
+    xants1, xants2 : lists 
+        List of bad antenna integers for uvd1 and uvd2
     """
     # get antenna positions
     antpos1, ants1 = uvd1.get_ENU_antpos(pick_data_ants=False)
-    antpos1 = dict(zip(ants1, antpos1))
+    antpos1 = dict(list(zip(ants1, antpos1)))
     antpos2, ants2 = uvd2.get_ENU_antpos(pick_data_ants=False)
-    antpos2 = dict(zip(ants2, antpos2))
-    antpos = dict(antpos1.items() + antpos2.items())
+    antpos2 = dict(list(zip(ants2, antpos2)))
+    antpos = dict(list(antpos1.items()) + list(antpos2.items()))
 
     # assert antenna positions match
     for a in set(antpos1).union(set(antpos2)):
@@ -252,7 +250,7 @@ def calc_blpair_reds(uvd1, uvd2, bl_tol=1.0, filter_blpairs=True, xant_flag_thre
                 # get flags
                 f1 = uvd1.get_flags(bl)
                 # remove from bad list if unflagged data exists
-                if np.sum(f1) < reduce(operator.mul, f1.shape) * xant_flag_thresh:
+                if np.sum(f1) < np.prod(f1.shape) * xant_flag_thresh:
                     if antnums[0] in xants1:
                         xants1.remove(antnums[0])
                     if antnums[1] in xants2:
@@ -263,7 +261,7 @@ def calc_blpair_reds(uvd1, uvd2, bl_tol=1.0, filter_blpairs=True, xant_flag_thre
                 # get flags
                 f2 = uvd2.get_flags(bl)
                 # remove from bad list if unflagged data exists
-                if np.sum(f2) < reduce(operator.mul, f2.shape) * xant_flag_thresh:
+                if np.sum(f2) < np.prod(f2.shape) * xant_flag_thresh:
                     if antnums[0] in xants2:
                         xants2.remove(antnums[0])
                     if antnums[1] in xants2:
@@ -280,8 +278,9 @@ def calc_blpair_reds(uvd1, uvd2, bl_tol=1.0, filter_blpairs=True, xant_flag_thre
     baselines1, baselines2, blpairs = [], [], []
     for r in reds:
         (bls1, bls2,
-         blps) = construct_blpairs(r, exclude_auto_bls=exclude_auto_bls, group=False,
-                                    exclude_permutations=exclude_permutations)
+         blps) = construct_blpairs(r, exclude_auto_bls=exclude_auto_bls, 
+                                   group=False, 
+                                   exclude_permutations=exclude_permutations)
         if len(bls1) < 1:
             continue
 
@@ -298,14 +297,17 @@ def calc_blpair_reds(uvd1, uvd2, bl_tol=1.0, filter_blpairs=True, xant_flag_thre
                     _bls1.append(bl1)
                     _bls2.append(bl2)
             bls1, bls2 = _bls1, _bls2
-            blps = zip(bls1, bls2)
+            blps = list(zip(bls1, bls2))
 
         # group if desired
         if Nblps_per_group is not None:
             Ngrps = int(np.ceil(float(len(blps)) / Nblps_per_group))
-            bls1 = [bls1[Nblps_per_group*i:Nblps_per_group*(i+1)] for i in range(Ngrps)]
-            bls2 = [bls2[Nblps_per_group*i:Nblps_per_group*(i+1)] for i in range(Ngrps)]
-            blps = [blps[Nblps_per_group*i:Nblps_per_group*(i+1)] for i in range(Ngrps)]
+            bls1 = [bls1[Nblps_per_group*i:Nblps_per_group*(i+1)] 
+                    for i in range(Ngrps)]
+            bls2 = [bls2[Nblps_per_group*i:Nblps_per_group*(i+1)] 
+                    for i in range(Ngrps)]
+            blps = [blps[Nblps_per_group*i:Nblps_per_group*(i+1)] 
+                    for i in range(Ngrps)]
 
         baselines1.extend(bls1)
         baselines2.extend(bls2)
@@ -662,12 +664,15 @@ def config_pspec_blpairs(uv_templates, pol_pairs, group_pairs, exclude_auto_bls=
     if xants is not None:
         bls1, bls2 = [], []
         for bl1, bl2 in zip(_bls1, _bls2):
-            if bl1[0] not in xants and bl1[1] not in xants and bl2[0] not in xants and bl2[1] not in xants:
+            if bl1[0] not in xants \
+              and bl1[1] not in xants \
+              and bl2[0] not in xants \
+              and bl2[1] not in xants:
                 bls1.append(bl1)
                 bls2.append(bl2)
     else:
         bls1, bls2 = _bls1, _bls2
-    blps = zip(bls1, bls2)
+    blps = list(zip(bls1, bls2))
 
     # iterate over pol-group pairs that exist
     groupings = odict()
@@ -716,13 +721,15 @@ def get_blvec_reds(blvecs, bl_error_tol=1.0, match_bl_lens=False):
     """
     from hera_pspec import UVPSpec
     # type check
-    assert isinstance(blvecs, (dict, odict, UVPSpec)), "blpairs must be fed as a dict or UVPSpec"
+    assert isinstance(blvecs, (dict, odict, UVPSpec)), \
+        "blpairs must be fed as a dict or UVPSpec"
     if isinstance(blvecs, UVPSpec):
         # get baseline vectors
         uvp = blvecs
         bls = uvp.bl_array
         bl_vecs = uvp.get_ENU_bl_vecs()[:, :2]
-        blvecs = dict(zip(map(uvp.bl_to_antnums, bls), bl_vecs))
+        blvecs = dict(list(zip( [uvp.bl_to_antnums(_bls) for _bls in bls], 
+                                bl_vecs )))
         # get baseline-pairs
         blpairs = uvp.get_blpairs()
         # form dictionary
@@ -821,7 +828,7 @@ def job_monitor(run_func, iterator, action_name, M=map, lf=None, maxiter=1,
     t_start = time.time()
 
     # run function over jobs
-    exit_codes = np.array(M(run_func, iterator))
+    exit_codes = np.array(list(M(run_func, iterator)))
     tnow = datetime.utcnow()
 
     # check for len-0
@@ -845,7 +852,7 @@ def job_monitor(run_func, iterator, action_name, M=map, lf=None, maxiter=1,
                 # break after certain number of tries
                 break
             # re-run function over jobs that failed
-            exit_codes = np.array(M(run_func, failures))
+            exit_codes = np.array(list(M(run_func, failures)))
             # update counter
             counter += 1
             # update failures
@@ -957,7 +964,7 @@ def get_reds(uvd, bl_error_tol=1.0, pick_data_ants=False, bl_len_range=(0, 1e4),
             uvd = _uvd
         # get antenna position dictionary
         antpos, ants = uvd.get_ENU_antpos(pick_data_ants=pick_data_ants)
-        antpos_dict = dict(zip(ants, antpos))
+        antpos_dict = dict(list(zip(ants, antpos)))
 
     # use antenna position dictionary
     elif isinstance(uvd, (dict, odict)):
@@ -973,7 +980,7 @@ def get_reds(uvd, bl_error_tol=1.0, pick_data_ants=False, bl_len_range=(0, 1e4),
     # put in autocorrs
     if add_autos:
         ants = antpos_dict.keys()
-        reds = [zip(ants, ants)] + reds
+        reds = [list(zip(ants, ants))] + reds
         lens = np.insert(lens, 0, 0)
         angs = np.insert(angs, 0, 0)
 

--- a/hera_pspec/utils.py
+++ b/hera_pspec/utils.py
@@ -12,15 +12,6 @@ from pyuvdata import UVData
 from datetime import datetime
 
 
-def hash(w):
-    """
-    Return an MD5 hash of a set of weights.
-    """
-    DeprecationWarning("utils.hash is deprecated.")
-    import md5
-    return md5.md5(w.copy(order='C')).digest()
-
-
 def cov(d1, w1, d2=None, w2=None, conj_1=False, conj_2=True):
     """
     Computes an empirical covariance matrix from data vectors. If d1 is of size

--- a/hera_pspec/uvpspec.py
+++ b/hera_pspec/uvpspec.py
@@ -53,7 +53,7 @@ class UVPSpec(object):
         self._spw_freq_array = PSpecParam("spw_freq_array", description="Spw integer array for the freq_array.", form="(Nspwfreqs,)", expected_type=np.uint16)
         self._freq_array = PSpecParam("freq_array", description="Frequency array of the original data in Hz.", form="(Nfreqs,)", expected_type=np.float64)
         self._dly_array = PSpecParam("dly_array", description="Delay array in seconds.", form="(Nspwdlys,)", expected_type=np.float64)
-        desc = "Polarization pair integer, made up of two "
+        desc = "Polarization pair integer, made up of two polarization integers concatenated in a standardized way."
         self._polpair_array = PSpecParam("polpair_array", description=desc, form="(Npols,)", expected_type=np.int32)
         self._lst_1_array = PSpecParam("lst_1_array", description="LST array of the first bl in the bl-pair [radians].", form="(Nblpairts,)", expected_type=np.float64)
         self._lst_2_array = PSpecParam("lst_2_array", description="LST array of the second bl in the bl-pair [radians].", form="(Nblpairts,)", expected_type=np.float64)

--- a/hera_pspec/uvpspec.py
+++ b/hera_pspec/uvpspec.py
@@ -151,7 +151,7 @@ class UVPSpec(object):
     def get_cov(self, key, omit_flags=False):
         """
         Slice into covariance array with a specified data key in the format
-        (spw, ((ant1, ant2),(ant3, ant4)), (pol12, pol34))
+        (spw, ((ant1, ant2),(ant3, ant4)), (pol1, pol2))
 
         or
 
@@ -193,7 +193,7 @@ class UVPSpec(object):
         """
         Slice into data_array with a specified data key in the format
 
-        (spw, ((ant1, ant2), (ant3, ant4)), (pol12, pol34))
+        (spw, ((ant1, ant2), (ant3, ant4)), (pol1, pol2))
 
         or
 
@@ -233,7 +233,7 @@ class UVPSpec(object):
         """
         Slice into wgt_array with a specified data key in the format
 
-        (spw, ((ant1, ant2), (ant3, ant4)), (pol12, pol34))
+        (spw, ((ant1, ant2), (ant3, ant4)), (pol1, pol2))
 
         or
 
@@ -266,7 +266,7 @@ class UVPSpec(object):
         """
         Slice into integration_array with a specified data key in the format::
 
-            (spw, ((ant1, ant2), (ant3, ant4)), (pol12, pol34))
+            (spw, ((ant1, ant2), (ant3, ant4)), (pol1, pol2))
 
         or
 
@@ -298,7 +298,7 @@ class UVPSpec(object):
         """
         Slice into nsample_array with a specified data key in the format
 
-        (spw, ((ant1, ant2), (ant3, ant4)), (pol12, pol34))
+        (spw, ((ant1, ant2), (ant3, ant4)), (pol1, pol2))
 
         or
 
@@ -911,7 +911,7 @@ class UVPSpec(object):
         """
         Convert a data key into relevant slice arrays. A data key takes the form
 
-        (spw_integer, ((ant1, ant2), (ant3, ant4)), (pol12, pol34))
+        (spw_integer, ((ant1, ant2), (ant3, ant4)), (pol1, pol2))
 
         or
 
@@ -925,7 +925,7 @@ class UVPSpec(object):
           key = {
             'spw' : spw_integer,
             'blpair' : ((ant1, ant2), (ant3, ant4))
-            'polpair' : (pol12, pol34)
+            'polpair' : (pol1, pol2)
             }
 
         and it will parse the dictionary for you.
@@ -960,13 +960,14 @@ class UVPSpec(object):
         spw_ind = key[0]
         blpair = key[1]
         polpair = key[2]
-
+        
+        
         # assert types
         assert isinstance(spw_ind, (int, np.integer)), "spw must be an integer"
         assert isinstance(blpair, (int, np.integer, tuple)), \
             "blpair must be an integer or nested tuple"
-        assert isinstance(polpair, (tuple, np.integer, int)), \
-            "polpair must be a tuple or integer: %s / %s" % (polpair, key)
+        assert isinstance(polpair, (tuple, np.integer, int, str)), \
+            "polpair must be a tuple, integer, or str: %s / %s" % (polpair, key)
         
         # convert polpair string to tuple
         if isinstance(polpair, str):
@@ -1257,11 +1258,7 @@ class UVPSpec(object):
                     this_attr = [np.string_(lbl) for lbl in this_attr] 
                 
                 # Store attribute in group
-                try:
-                    group.attrs[k] = this_attr
-                except(TypeError):
-                    print("TypeError:", k, this_attr)
-                    continue
+                group.attrs[k] = this_attr
                 
         for k in self._meta_dsets:
             if hasattr(self, k):

--- a/hera_pspec/uvpspec_utils.py
+++ b/hera_pspec/uvpspec_utils.py
@@ -262,8 +262,8 @@ def polpair_int2tuple(polpair, pol_strings=False):
         "polpair must be integer: %s" % type(polpair)
     
     # Split into pol1 and pol2 integers
-    pol1 = int(str(polpair)[:-2]) - 10
-    pol2 = int(str(polpair)[-2:]) - 10
+    pol1 = int(str(polpair)[:-2]) - 20
+    pol2 = int(str(polpair)[-2:]) - 20
     
     # Check that pol1 and pol2 are in the allowed range (-8, 4)
     if (pol1 < -8 or pol1 > 4) or (pol2 < -8 or pol2 > 4):
@@ -282,10 +282,10 @@ def polpair_tuple2int(polpair):
     Convert a tuple pair of polarization strings/integers into 
     an pol-pair integer.
     
-    The polpair integer is formed by adding 10 to each standardized 
+    The polpair integer is formed by adding 20 to each standardized 
     polarization integer (see polstr2num and AIPS memo 117) and 
     then concatenating them. For example, polarization pair 
-    ('pI', 'pQ') == (1, 2) == 1112. 
+    ('pI', 'pQ') == (1, 2) == 2122. 
     
     Parameters
     ----------
@@ -312,7 +312,7 @@ def polpair_tuple2int(polpair):
     if type(pol2) in (str, np.str): pol2 = polstr2num(pol2)
     
     # Convert to polpair integer
-    ppint = (10 + pol1)*100 + (10 + pol2)
+    ppint = (20 + pol1)*100 + (20 + pol2)
     return ppint
 
 

--- a/hera_pspec/uvpspec_utils.py
+++ b/hera_pspec/uvpspec_utils.py
@@ -1,7 +1,7 @@
 import numpy as np
 import copy, operator
 from collections import OrderedDict as odict
-from pyuvdata.utils import polstr2num
+from pyuvdata.utils import polstr2num, polnum2str
 
 def subtract_uvp(uvp1, uvp2, run_check=True, verbose=False):
     """
@@ -233,15 +233,19 @@ def select_common(uvp_list, spws=True, blpairs=True, times=True, polpairs=True,
     if not inplace: return out_list
 
 
-def polpair_int2tuple(polpair):
+def polpair_int2tuple(polpair, pol_strings=False):
     """
     Convert a pol-pair integer into a tuple pair of polarization 
     integers. See polpair_tuple2int for more details.
     
     Parameters
     ----------
-    polpair : int
+    polpair : int or list of int
         Integer representation of polarization pair.
+    
+    pol_strings : bool, optional
+        If True, return polarization pair tuples with polarization strings. 
+        Otherwise, use polarization integers. Default: True.
     
     Returns
     -------
@@ -249,7 +253,13 @@ def polpair_int2tuple(polpair):
         A length-2 tuple containing a pair of polarization 
         integers, e.g. (-5, -5).
     """
-    assert isinstance(polpair, (int, np.integer)), "polpair must be integer: %s" % type(polpair)
+    # Recursive evaluation
+    if isinstance(polpair, (list, np.ndarray)):
+        return [polpair_int2tuple(p, pol_strings=pol_strings) for p in polpair]
+    
+    # Check for integer type
+    assert isinstance(polpair, (int, np.integer)), \
+        "polpair must be integer: %s" % type(polpair)
     
     # Split into pol1 and pol2 integers
     pol1 = int(str(polpair)[:-2]) - 10
@@ -260,7 +270,11 @@ def polpair_int2tuple(polpair):
         raise ValueError("polpair integer evaluates to an invalid "
                          "polarization pair: (%d, %d)" 
                          % (pol1, pol2))
-    return (pol1, pol2)
+    # Convert to strings if requested
+    if pol_strings:
+        return (polnum2str(pol1), polnum2str(pol2))
+    else:
+        return (pol1, pol2)
     
 
 def polpair_tuple2int(polpair):
@@ -284,6 +298,11 @@ def polpair_tuple2int(polpair):
     polpair : int
         Integer representation of polarization pair.
     """
+    # Recursive evaluation
+    if isinstance(polpair, (list, np.ndarray)):
+        return [polpair_tuple2int(p) for p in polpair]
+    
+    # Check types
     assert type(polpair) in (tuple,), "pol must be a tuple"
     assert len(polpair) == 2, "polpair tuple must have 2 elements"
     

--- a/hera_pspec/uvpspec_utils.py
+++ b/hera_pspec/uvpspec_utils.py
@@ -404,7 +404,7 @@ def _select(uvp, spws=None, bls=None, only_pairs_in_bls=False, blpairs=None,
         times is fed.
 
     polpairs : list
-        A list of polarization-pair tuples or integers to keep.
+        A list of polarization-pair tuples, integers, or strs to keep.
 
     h5file : h5py file descriptor
         Used for loading in selection of data from HDF5 file.
@@ -523,10 +523,16 @@ def _select(uvp, spws=None, bls=None, only_pairs_in_bls=False, blpairs=None,
 
     if polpairs is not None:
         # assert form
-        assert isinstance(polpairs[0], (tuple, int, np.integer)), \
-            "polpairs must be fed as a list of tuples or pol integers"
+        assert isinstance(polpairs, (list, np.ndarray)), \
+            "polpairs must be passed as a list or ndarray"
+        assert isinstance(polpairs[0], (tuple, int, np.integer, str)), \
+            "polpairs must be fed as a list of tuples or pol integers/strings"
         
-        # convert to polpair integers if needed
+        # convert str to polpair integers
+        polpairs = [polpair_tuple2int((p,p)) if isinstance(p, str) 
+                    else p for p in polpairs]
+        
+        # convert tuples to polpair integers
         polpairs = [polpair_tuple2int(p) if isinstance(p, tuple) 
                     else p for p in polpairs]
         

--- a/hera_pspec/uvpspec_utils.py
+++ b/hera_pspec/uvpspec_utils.py
@@ -7,14 +7,14 @@ from pyuvdata.utils import polstr2num
 def subtract_uvp(uvp1, uvp2, run_check=True, verbose=False):
     """
     Subtract uvp2.data_array from uvp1.data_array. Subtract matching
-    spw, blpair-lst, pol keys. For non-overlapping keys, remove from output
-    uvp.
+    spw, blpair-lst, polpair keys. For non-overlapping keys, remove from 
+    output uvp.
 
     Note: Entries in stats_array are added in quadrature. nsample_arrays,
     integration_arrays and wgt_arrays are inversely added in quadrature.
     If these arrays are identical in the two objects, this is equivalent
-    to multiplying (dividing) the stats (nsamp, int & wgt) arrays(s)
-    by sqrt(2).
+    to multiplying (dividing) the stats (nsamp, int & wgt) arrays(s) by 
+    sqrt(2).
 
     Parameters
     ----------
@@ -34,11 +34,12 @@ def subtract_uvp(uvp1, uvp2, run_check=True, verbose=False):
     """
     # select out common parts
     uvp1, uvp2 = select_common([uvp1, uvp2], spws=True, blpairs=True, lsts=True,
-                               pols=True, times=False, inplace=False, verbose=verbose)
+                               polpairs=True, times=False, inplace=False, 
+                               verbose=verbose)
 
     # get metadata
     spws1 = [spw for spw in uvp1.get_spw_ranges()]
-    pols1 = uvp1.pol_array.tolist()
+    polpairs1 = uvp1.polpair_array.tolist()
     blps1 = sorted(set(uvp1.blpair_array))
     spws2 = [spw for spw in uvp2.get_spw_ranges()]
 
@@ -48,55 +49,64 @@ def subtract_uvp(uvp1, uvp2, run_check=True, verbose=False):
         i2 = spws2.index(spw)
 
         # iterate over pol
-        for j, pol in enumerate(pols1):
+        for j, polpair in enumerate(polpairs1):
 
             # iterate over blp
             for k, blp in enumerate(blps1):
 
                 # form keys
-                key1 = (i, blp, pol)
-                key2 = (i2, blp, pol)
+                key1 = (i, blp, polpair)
+                key2 = (i2, blp, polpair)
 
                 # subtract data
                 blp1_inds = uvp1.blpair_to_indices(blp)
                 uvp1.data_array[i][blp1_inds, :, j] -= uvp2.get_data(key2)
 
                 # add nsample inversely in quadrature
-                uvp1.nsample_array[i][blp1_inds, j] = np.sqrt(1. / (1./uvp1.get_nsamples(key1)**2 + 1./uvp2.get_nsamples(key2)**2))
+                uvp1.nsample_array[i][blp1_inds, j] \
+                    = np.sqrt( 1. / (1./uvp1.get_nsamples(key1)**2 
+                             + 1. / uvp2.get_nsamples(key2)**2) )
 
                 # add integration inversely in quadrature
-                uvp1.integration_array[i][blp1_inds, j] = np.sqrt(1. / (1./uvp1.get_integrations(key1)**2 + 1./uvp2.get_integrations(key2)**2))
+                uvp1.integration_array[i][blp1_inds, j] \
+                    = np.sqrt(1. / (1./uvp1.get_integrations(key1)**2 
+                            + 1. / uvp2.get_integrations(key2)**2))
 
                 # add wgts inversely in quadrature
-                uvp1.wgt_array[i][blp1_inds, :, :, j] = np.sqrt(1. / (1./uvp1.get_wgts(key1)**2 + 1./uvp2.get_wgts(key2)**2))
-                uvp1.wgt_array[i][blp1_inds, :, :, j] /= uvp1.wgt_array[i][blp1_inds, :, :, j].max()
+                uvp1.wgt_array[i][blp1_inds, :, :, j] \
+                    = np.sqrt(1. / (1./uvp1.get_wgts(key1)**2 
+                            + 1. / uvp2.get_wgts(key2)**2))
+                uvp1.wgt_array[i][blp1_inds, :, :, j] /= \
+                    uvp1.wgt_array[i][blp1_inds, :, :, j].max()
 
                 # add stats in quadrature: real imag separately
                 if hasattr(uvp1, "stats_array") and hasattr(uvp2, "stats_array"):
                     for s in uvp1.stats_array.keys():
                         stat1 = uvp1.get_stats(s, key1)
                         stat2 = uvp2.get_stats(s, key2)
-                        uvp1.stats_array[s][i][blp1_inds, :, j] = np.sqrt(stat1.real**2 + stat2.real**2) + 1j*np.sqrt(stat1.imag**2 + stat2.imag**2)
+                        uvp1.stats_array[s][i][blp1_inds, :, j] \
+                            = np.sqrt(stat1.real**2 + stat2.real**2) \
+                            + 1j*np.sqrt(stat1.imag**2 + stat2.imag**2)
 
                 # add cov in quadrature: real and imag separately
                 if hasattr(uvp1, "cov_array") and hasattr(uvp2, "cov_array"):
                     cov1 = uvp1.get_cov(key1)
                     cov2 = uvp2.get_cov(key2)
-                    uvp1.cov_array[i][blp1_inds, :, :, j] = np.sqrt(cov1.real**2 + cov2.real**2) + 1j*np.sqrt(cov1.imag**2 + cov2.imag**2)
+                    uvp1.cov_array[i][blp1_inds, :, :, j] \
+                        = np.sqrt(cov1.real**2 + cov2.real**2) \
+                        + 1j*np.sqrt(cov1.imag**2 + cov2.imag**2)
 
     # run check
-    if run_check:
-        uvp1.check()
-
+    if run_check: uvp1.check()
     return uvp1
 
 
-def select_common(uvp_list, spws=True, blpairs=True, times=True, pols=True,
+def select_common(uvp_list, spws=True, blpairs=True, times=True, polpairs=True,
                   lsts=False, inplace=False, verbose=False):
     """
-    Find spectral windows, baseline-pairs, times, and/or polarizations that a
-    set of UVPSpec objects have in common and return new UVPSpec objects that
-    contain only those data.
+    Find spectral windows, baseline-pairs, times, and/or polarization-pairs 
+    that a set of UVPSpec objects have in common and return new UVPSpec objects 
+    that contain only those data.
 
     If there is no overlap, an error will be raised.
 
@@ -129,9 +139,9 @@ def select_common(uvp_list, spws=True, blpairs=True, times=True, pols=True,
         Whether to retain only the (average) lsts that all UVPSpec objects
         have in common. Similar algorithm to times. Default: False.
 
-    pols : bool, optional
-        Whether to retain only the polarizations that all UVPSpec objects have
-        in common. Default: True.
+    polpairs : bool, optional
+        Whether to retain only the polarization pairs that all UVPSpec objects 
+        have in common. Default: True.
 
     inplace : bool, optional
         Whether the selection should be applied to the UVPSpec objects
@@ -170,18 +180,20 @@ def select_common(uvp_list, spws=True, blpairs=True, times=True, pols=True,
         common_blpairs = common_blpairs[np.all(has_blpairs, axis=0)]
         if verbose: print("common_blpairs:", common_blpairs)
 
-    # Get polarizations that are common to all
-    if pols:
-        common_pols = np.unique(uvp_list[0].pol_array)
-        has_pols = [np.isin(common_pols, uvp.pol_array) for uvp in uvp_list]
-        common_pols = common_pols[np.all(has_pols, axis=0)]
-        if verbose: print("common_pols:", common_pols)
+    # Get polarization-pairs that are common to all
+    if polpairs:
+        common_polpairs = np.unique(uvp_list[0].polpair_array)
+        has_polpairs = [np.isin(common_polpairs, uvp.polpair_array) 
+                        for uvp in uvp_list]
+        common_polpairs = common_polpairs[np.all(has_polpairs, axis=0)]
+        if verbose: print("common_polpairs:", common_polpairs)
 
     # Get common spectral windows (the entire window must match)
     # Each row of common_spws is a list of that spw's index in each UVPSpec
     if spws:
         common_spws = uvp_list[0].get_spw_ranges()
-        has_spws = [map(lambda x: x in uvp.get_spw_ranges(), common_spws) for uvp in uvp_list]
+        has_spws = [map(lambda x: x in uvp.get_spw_ranges(), common_spws) 
+                    for uvp in uvp_list]
         common_spws = [common_spws[i] for i, f in enumerate(np.all(has_spws, axis=0)) if f]
         if verbose: print("common_spws:", common_spws)
 
@@ -199,48 +211,116 @@ def select_common(uvp_list, spws=True, blpairs=True, times=True, pols=True,
     if lsts and len(common_lsts) == 0:
         raise ValueError("No lsts were found that exist in all spectra.")
 
-    if pols and len(common_pols) == 0:
-        raise ValueError("No polarizations were found that exist in all spectra.")
+    if polpairs and len(common_polpairs) == 0:
+        raise ValueError("No polarization-pairs were found that exist in all spectra.")
 
     # Apply selections
     out_list = []
     for i, uvp in enumerate(uvp_list):
-        _spws, _blpairs, _times, _lsts, _pols = None, None, None, None, None
+        _spws, _blpairs, _times, _lsts, _polpairs = None, None, None, None, None
 
         # Set indices of blpairs, times, and pols to keep
         if blpairs: _blpairs = common_blpairs
         if times: _times = common_times
         if lsts: _lsts = common_lsts
-        if pols: _pols = common_pols
+        if polpairs: _pols = common_polpairs
         if spws: _spws = [uvp.get_spw_ranges().index(j) for j in common_spws]
 
         _uvp = uvp.select(spws=_spws, blpairs=_blpairs, times=_times,
-                          pols=_pols, lsts=_lsts, inplace=inplace)
+                          polpairs=_polpairs, lsts=_lsts, inplace=inplace)
         if not inplace: out_list.append(_uvp)
 
     # Return if not inplace
     if not inplace: return out_list
 
 
+def polpair_int2tuple(polpair):
+    """
+    Convert a pol-pair integer into a tuple pair of polarization 
+    integers. See polpair_tuple2int for more details.
+    
+    Parameters
+    ----------
+    polpair : int
+        Integer representation of polarization pair.
+    
+    Returns
+    -------
+    polpair : tuple, length 2
+        A length-2 tuple containing a pair of polarization 
+        integers, e.g. (-5, -5).
+    """
+    assert type(polpair) in (int, np.int), "polpair must be integer"
+    
+    # Split into pol1 and pol2 integers
+    pol1 = int(str(polpair)[:-2]) - 10
+    pol2 = int(str(polpair)[-2:]) - 10
+    
+    # Check that pol1 and pol2 are in the allowed range (-8, 4)
+    if (pol1 < -8 or pol1 > 4) or (pol2 < -8 or pol2 > 4):
+        raise ValueError("polpair integer evaluates to an invalid "
+                         "polarization pair: (%d, %d)" 
+                         % (pol1, pol2))
+    return (pol1, pol2)
+    
+
+def polpair_tuple2int(polpair):
+    """
+    Convert a tuple pair of polarization strings/integers into 
+    an pol-pair integer.
+    
+    The polpair integer is formed by adding 10 to each standardized 
+    polarization integer (see polstr2num and AIPS memo 117) and 
+    then concatenating them. For example, polarization pair 
+    ('pI', 'pQ') == (1, 2) == 1112. 
+    
+    Parameters
+    ----------
+    polpair : tuple, length 2
+        A length-2 tuple containing a pair of polarization strings 
+        or integers, e.g. ('XX', 'YY') or (-5, -5).
+    
+    Returns
+    -------
+    polpair : int
+        Integer representation of polarization pair.
+    """
+    assert type(polpair) in (tuple,), "pol must be a tuple"
+    assert len(polpair) == 2, "polpair tuple must have 2 elements"
+    
+    # Convert strings to ints if necessary
+    pol1, pol2 = polpair
+    if type(pol1) in (str, np.str): pol1 = uvutils.polstr2num(pol1)
+    if type(pol2) in (str, np.str): pol2 = uvutils.polstr2num(pol2)
+    
+    # Convert to polpair integer
+    ppint = (10 + pol1)*100 + (10 + pol2)
+    return ppint
+
+
 def _get_blpairs_from_bls(uvp, bls, only_pairs_in_bls=False):
     """
-    Get baseline pair matches from a list of baseline antenna-pairs in a UVPSpec object.
+    Get baseline pair matches from a list of baseline antenna-pairs in a 
+    UVPSpec object.
 
     Parameters
     ----------
-    uvp : UVPSpec object with at least meta-data in required params loaded in.
-        If only meta-data is loaded in then h5file must be specified.
+    uvp : UVPSpec object
+        Must at least have meta-data in required params loaded in. If only 
+        meta-data is loaded in then h5file must be specified.
 
-    bls : list of i6 baseline integers or baseline tuples, Ex. (2, 3)
-        Select all baseline-pairs whose first _or_ second baseline are in bls list.
-        This changes if only_pairs_in_bls == True.
+    bls : list of i6 baseline integers or baseline tuples
+        Select all baseline-pairs whose first _or_ second baseline are in bls 
+        list. This changes if only_pairs_in_bls == True.
 
-    only_pairs_in_bls : bool, if True, keep only baseline-pairs whose first _and_ second baseline
-        are both found in bls list.
+    only_pairs_in_bls : bool
+        If True, keep only baseline-pairs whose first _and_ second baseline are 
+        both found in bls list.
 
-    Returns blp_select
+    Returns
     -------
-    blp_select : boolean ndarray used to index into uvp.blpair_array to get relevant baseline-pairs
+    blp_select : bool ndarray
+        Used to index into uvp.blpair_array to get relevant baseline-pairs
     """
     # get blpair baselines in integer form
     bl1 = np.floor(uvp.blpair_array / 1e6)
@@ -248,13 +328,15 @@ def _get_blpairs_from_bls(uvp, bls, only_pairs_in_bls=False):
 
     # ensure bls is in integer form
     if isinstance(bls, tuple):
-        assert isinstance(bls[0], (int, np.integer)), "bls must be fed as a list of baseline tuples Ex: [(1, 2), ...]"
+        assert isinstance(bls[0], (int, np.integer)), \
+            "bls must be fed as a list of baseline tuples Ex: [(1, 2), ...]"
         bls = [uvp.antnums_to_bl(bls)]
     elif isinstance(bls, list):
         if isinstance(bls[0], tuple):
             bls = map(lambda b: uvp.antnums_to_bl(b), bls)
     elif isinstance(bls, (int, np.integer)):
         bls = [bls]
+    
     # get indices
     if only_pairs_in_bls:
         blp_select = np.array(map(lambda blp: np.bool((blp[0] in bls) * (blp[1] in bls)), blpair_bls))
@@ -265,7 +347,7 @@ def _get_blpairs_from_bls(uvp, bls, only_pairs_in_bls=False):
 
 
 def _select(uvp, spws=None, bls=None, only_pairs_in_bls=False, blpairs=None,
-            times=None, lsts=None, pols=None, h5file=None):
+            times=None, lsts=None, polpairs=None, h5file=None):
     """
     Select function for selecting out certain slices of the data, as well
     as loading in data from HDF5 file.
@@ -301,9 +383,8 @@ def _select(uvp, spws=None, bls=None, only_pairs_in_bls=False, blpairs=None,
         List of lsts from the lst_avg_array to keep. Cannot be fed if
         times is fed.
 
-    pols : list
-        A list of polarization strings or integers to keep.
-        See pyuvdata.utils.polstr2num for acceptable options.
+    polpairs : list
+        A list of polarization-pair tuples or integers to keep.
 
     h5file : h5py file descriptor
         Used for loading in selection of data from HDF5 file.
@@ -352,8 +433,11 @@ def _select(uvp, spws=None, bls=None, only_pairs_in_bls=False, blpairs=None,
     if blpairs is not None:
         if bls is None:
             blp_select = np.zeros(uvp.Nblpairts, np.bool)
+        
         # assert form
-        assert isinstance(blpairs[0], (tuple, int, np.integer)), "blpairs must be fed as a list of baseline-pair tuples or baseline-pair integers"
+        assert isinstance(blpairs[0], (tuple, int, np.integer)), \
+            "blpairs must be fed as a list of baseline-pair tuples or baseline-pair integers"
+        
         # if fed as list of tuples, convert to integers
         if isinstance(blpairs[0], tuple):
             blpairs = map(lambda blp: uvp.antnums_to_blpair(blp), blpairs)
@@ -377,7 +461,8 @@ def _select(uvp, spws=None, bls=None, only_pairs_in_bls=False, blpairs=None,
         blp_select = slice(None)
     else:
         # assert something was selected
-        assert blp_select.any(), "no selections provided matched any of the data... "
+        assert blp_select.any(), \
+            "no selections provided matched any of the data... "
 
         # turn blp_select into slice if possible
         blp_select = np.where(blp_select)[0]
@@ -411,36 +496,39 @@ def _select(uvp, spws=None, bls=None, only_pairs_in_bls=False, blpairs=None,
         uvp.bl_vecs = uvp.bl_vecs[bl_select]
         uvp.Nbls = len(uvp.bl_array)
 
-    if pols is not None:
+    if polpairs is not None:
         # assert form
-        assert isinstance(pols[0], (str, np.str, int, np.integer)), "pols must be fed as a list of pol strings or pol integers"
-
-        # if fed as strings convert to integers
-        if isinstance(pols[0], (np.str, str)):
-            pols = map(lambda p: polstr2num(p), pols)
-
+        assert isinstance(polpairs[0], (tuple, int, np.integer)), \
+            "polpairs must be fed as a list of tuples or pol integers"
+        
+        # convert to polpair integers if needed
+        polpairs = [polpair_tuple2int(p) if isinstance(p, tuple) 
+                    else p for p in polpairs]
+        
         # create selection
-        pol_select = np.array(reduce(operator.add, map(lambda p: uvp.pol_array == p, pols)))
+        polpair_select = np.array(reduce(operator.add, map(lambda p: uvp.polpair_array == p, polpairs)))
 
         # turn into slice object if possible
-        pol_select = np.where(pol_select)[0]
-        if len(set(np.diff(pol_select))) == 0:
+        polpair_select = np.where(polpair_select)[0]
+        if len(set(np.diff(polpair_select))) == 0:
             # sliceable
-            pol_select = slice(pol_select[0], pol_select[-1] + 1)
-        elif len(set(np.diff(pol_select))) == 1:
+            polpair_select = slice(polpair_select[0], polpair_select[-1] + 1)
+        elif len(set(np.diff(polpair_select))) == 1:
             # sliceable
-            pol_select = slice(pol_select[0], pol_select[-1] + 1, np.diff(pol_select)[0])
+            polpair_select = slice(polpair_select[0], 
+                                   polpair_select[-1] + 1, 
+                                   np.diff(polpair_select)[0])
 
         # edit metadata
-        uvp.pol_array = uvp.pol_array[pol_select]
-        uvp.Npols = len(uvp.pol_array)
+        uvp.polpair_array = uvp.polpair_array[polpair_select]
+        uvp.Npols = len(uvp.polpair_array)
         if hasattr(uvp, 'scalar_array'):
-            uvp.scalar_array = uvp.scalar_array[:, pol_select]
+            uvp.scalar_array = uvp.scalar_array[:, polpair_select]
     else:
-        pol_select = slice(None)
+        polpair_select = slice(None)
 
     # determine if data arrays are sliceable
-    if isinstance(pol_select, slice) or isinstance(blp_select, slice):
+    if isinstance(polpair_select, slice) or isinstance(blp_select, slice):
         sliceable = True
     else:
         sliceable = False
@@ -463,7 +551,8 @@ def _select(uvp, spws=None, bls=None, only_pairs_in_bls=False, blpairs=None,
 
         # get stats_array keys if h5file
         if h5file is not None:
-            statnames = np.unique([f[f.find("_")+1: f.rfind("_")] for f in h5file.keys()
+            statnames = np.unique([f[f.find("_")+1: f.rfind("_")] 
+                                    for f in h5file.keys()
                                     if f.startswith("stats")])
         else:
             if hasattr(uvp, "stats_array"):
@@ -511,24 +600,24 @@ def _select(uvp, spws=None, bls=None, only_pairs_in_bls=False, blpairs=None,
             # slice data arrays and assign to dictionaries
             if sliceable:
                 # can slice in 1 step
-                data[s] = _data[blp_select, :, pol_select]
-                wgts[s] = _wgts[blp_select, :, :, pol_select]
-                ints[s] = _ints[blp_select, pol_select]
-                nsmp[s] = _nsmp[blp_select, pol_select]
+                data[s] = _data[blp_select, :, polpair_select]
+                wgts[s] = _wgts[blp_select, :, :, polpair_select]
+                ints[s] = _ints[blp_select, polpair_select]
+                nsmp[s] = _nsmp[blp_select, polpair_select]
                 if store_cov:
-                    cov[s] = _covs[blp_select, :, :, pol_select]
+                    cov[s] = _covs[blp_select, :, :, polpair_select]
                 for statname in statnames:
-                    stats[statname][s] = _stat[statname][blp_select, :, pol_select]
+                    stats[statname][s] = _stat[statname][blp_select, :, polpair_select]
             else:
                 # need to slice in 2 steps
-                data[s] = _data[blp_select, :, :][:, :, pol_select]
-                wgts[s] = _wgts[blp_select, :, :, :][:, :, :, pol_select]
-                ints[s] = _ints[blp_select, :][:, pol_select]
-                nsmp[s] = _nsmp[blp_select, :][:, pol_select]
+                data[s] = _data[blp_select, :, :][:, :, polpair_select]
+                wgts[s] = _wgts[blp_select, :, :, :][:, :, :, polpair_select]
+                ints[s] = _ints[blp_select, :][:, polpair_select]
+                nsmp[s] = _nsmp[blp_select, :][:, polpair_select]
                 if store_cov:
-                    cov[s] = _covs[blp_select, :, :, :][:, :, :, pol_select]
+                    cov[s] = _covs[blp_select, :, :, :][:, :, :, polpair_select]
                 for statname in statnames:
-                    stats[statname][s] = _stat[statname][blp_select, :, :][:, :, pol_select]
+                    stats[statname][s] = _stat[statname][blp_select, :, :][:, :, polpair_select]
 
         # assign arrays to uvp
         uvp.data_array = data
@@ -553,7 +642,8 @@ def _blpair_to_antnums(blpair):
     Returns
     -------
     antnums : tuple
-        nested tuple containing baseline-pair antenna numbers. Ex. ((ant1, ant2), (ant3, ant4))
+        nested tuple containing baseline-pair antenna numbers. 
+        Ex. ((ant1, ant2), (ant3, ant4))
     """
     # get antennas
     ant1 = int(np.floor(blpair / 1e9))
@@ -599,6 +689,7 @@ def _antnums_to_blpair(antnums):
 
     return blpair
 
+
 def _bl_to_antnums(bl):
     """
     Convert baseline integer to tuple of antenna numbers.
@@ -623,6 +714,7 @@ def _bl_to_antnums(bl):
     antnums = (ant1, ant2)
 
     return antnums
+
 
 def _antnums_to_bl(antnums):
     """
@@ -651,6 +743,7 @@ def _antnums_to_bl(antnums):
 
     return bl
 
+
 def _blpair_to_bls(blpair):
     """
     Convert a blpair integer or nested tuple of antenna pairs
@@ -669,6 +762,7 @@ def _blpair_to_bls(blpair):
     bl2 = _antnums_to_bl(blpair[1])
 
     return bl1, bl2
+
 
 def _conj_blpair_int(blpair):
     """

--- a/hera_pspec/version.py
+++ b/hera_pspec/version.py
@@ -1,51 +1,118 @@
-#from __future__ import print_function
+# -*- coding: utf-8 -*-
+# Copyright 2019 the HERA Project
+# Licensed under the MIT License
+
+from __future__ import print_function, division, absolute_import
+
 import os
+import six
 import subprocess
 import json
+import inspect
 
 hera_pspec_dir = os.path.dirname(os.path.realpath(__file__))
-version_file = os.path.join(hera_pspec_dir, 'VERSION')
-version = open(version_file).read().strip()
+
+
+def _get_git_output(args, capture_stderr=False):
+    """
+    Get output from git, ensuring that it is of the ``str`` type, not bytes.
+    """
+
+    argv = ['git', '-C', hera_pspec_dir] + args
+
+    if capture_stderr:
+        data = subprocess.check_output(argv, stderr=subprocess.STDOUT)
+    else:
+        data = subprocess.check_output(argv)
+
+    data = data.strip()
+
+    if six.PY2:
+        return data
+    return data.decode('utf8')
+
+
+def _get_gitinfo_file(git_file=None):
+    """
+    Get saved info from GIT_INFO file that was created when installing package
+    """
+    if git_file is None:
+        git_file = os.path.join(hera_pspec_dir, 'GIT_INFO')
+
+    with open(git_file) as data_file:
+        data = [_unicode_to_str(x) for x in json.loads(data_file.read().strip())]
+        git_origin = data[0]
+        git_hash = data[1]
+        git_description = data[2]
+        git_branch = data[3]
+
+    return {'git_origin': git_origin, 'git_hash': git_hash,
+            'git_description': git_description, 'git_branch': git_branch}
+
+
+def _unicode_to_str(u):
+    if six.PY2:
+        return u.encode('utf8')
+    return u
 
 
 def construct_version_info():
-    hera_pspec_dir = os.path.dirname(os.path.realpath(__file__))
     version_file = os.path.join(hera_pspec_dir, 'VERSION')
-    version = open(version_file).read().strip()
+    with open(version_file) as f:
+        version = f.read().strip()
+
+    git_origin = ''
+    git_hash = ''
+    git_description = ''
+    git_branch = ''
+
+    version_info = {'version': version, 'git_origin': '', 'git_hash': '',
+                    'git_description': '', 'git_branch': ''}
 
     try:
-        git_origin = subprocess.check_output(['git', '-C', hera_pspec_dir, 'config',
-                                              '--get', 'remote.origin.url'],
-                                             stderr=subprocess.STDOUT).strip()
-        git_hash = subprocess.check_output(['git', '-C', hera_pspec_dir, 'rev-parse', 'HEAD'],
-                                           stderr=subprocess.STDOUT).strip()
-        git_description = subprocess.check_output(['git', '-C', hera_pspec_dir,
-                                                   'describe', '--dirty', '--tag', '--always']).strip()
-        git_branch = subprocess.check_output(['git', '-C', hera_pspec_dir, 'rev-parse',
-                                              '--abbrev-ref', 'HEAD'],
-                                             stderr=subprocess.STDOUT).strip()
-        git_version = subprocess.check_output(['git', '-C', hera_pspec_dir, 'describe', '--always',
-                                               '--tags', '--abbrev=0']).strip()
-    except:  # pragma: no cover  - can't figure out how to test exception.
+        version_info['git_origin'] = _get_git_output(
+                                      ['config', '--get', 'remote.origin.url'], 
+                                      capture_stderr=True)
+        version_info['git_hash'] = _get_git_output(
+                                      ['rev-parse', 'HEAD'], 
+                                      capture_stderr=True)
+        version_info['git_description'] = _get_git_output(
+                                   ['describe', '--dirty', '--tag', '--always'])
+        version_info['git_branch'] = _get_git_output(
+                                      ['rev-parse', '--abbrev-ref', 'HEAD'], 
+                                      capture_stderr=True)
+    except subprocess.CalledProcessError:  # pragma: no cover
         try:
             # Check if a GIT_INFO file was created when installing package
-            git_file = os.path.join(hera_pspec_dir, 'GIT_INFO')
-            with open(git_file) as data_file:
-                data = [x.encode('UTF8') for x in json.loads(data_file.read().strip())]
-                git_origin = data[0]
-                git_hash = data[1]
-                git_description = data[2]
-                git_branch = data[3]
-        except:
-            git_origin = ''
-            git_hash = ''
-            git_description = ''
-            git_branch = ''
+            version_info.update(_get_gitinfo_file())
+        except (IOError, OSError):
+            pass
 
-    version_info = {'version': version, 'git_origin': git_origin,
-                    'git_hash': git_hash, 'git_description': git_description,
-                    'git_branch': git_branch}
     return version_info
+
+
+def history_string(notes=''):
+    """
+    Creates a standardized history string that all functions that write to 
+    disk can use. Optionally add notes.
+    """
+    history = '\n------------\nThis file was produced by the function ' \
+            + str(inspect.stack()[1][3]) + '()'
+    # inspect.stack()[1][3] is the name of the function that called this fn
+    
+    history += ' in ' + os.path.basename(inspect.stack()[1][1]) + ' using: '
+    # inspect.stack()[1][1] is path to the file that contains the function 
+    # that called this function
+    version_info = construct_version_info()
+    
+    for v in sorted(version_info.keys()):
+        history += '\n    ' + v + ': ' + version_info[v]
+    
+    if (notes is not None) and (notes != ''):
+        history += '\n\nNotes:\n'
+        history += notes
+    return history + '\n------------\n'
+
 
 version_info = construct_version_info()
 version = version_info['version']
@@ -54,23 +121,13 @@ git_hash = version_info['git_hash']
 git_description = version_info['git_description']
 git_branch = version_info['git_branch']
 
-# String to add to history of any files written with this version of pyuvdata
-hera_pspec_version_str = ('hera_pspec version: ' + version + '.')
-if git_hash is not '':
-    hera_pspec_version_str += ('  Git origin: ' + str(git_origin) +
-                            '.  Git hash: ' + str(git_hash) +
-                            '.  Git branch: ' + str(git_branch) +
-                            '.  Git description: ' + str(git_description) + '.')
-
 
 def main():
-    try:
-        print("Version = {0}".format(version))
-        print("git origin = {0}".format(git_origin.decode('utf-8')))
-        print("git branch = {0}".format(git_branch.decode('utf-8')))
-        print("git description = {0}".format(git_description.decode('utf-8')))
-    except TypeError:
-        print(type(version), type(git_origin))
-        raise
+    print('Version = {0}'.format(version))
+    print('git origin = {0}'.format(git_origin))
+    print('git branch = {0}'.format(git_branch))
+    print('git description = {0}'.format(git_description))
+
+
 if __name__ == '__main__':
     main()

--- a/hera_pspec/version.py
+++ b/hera_pspec/version.py
@@ -113,6 +113,14 @@ def history_string(notes=''):
         history += notes
     return history + '\n------------\n'
 
+def print_version_info():
+    """
+    Print git/version info.
+    """
+    print('Version = {0}'.format(version))
+    print('git origin = {0}'.format(git_origin))
+    print('git branch = {0}'.format(git_branch))
+    print('git description = {0}'.format(git_description))
 
 version_info = construct_version_info()
 version = version_info['version']
@@ -123,13 +131,7 @@ git_branch = version_info['git_branch']
 
 
 def main():
-    try:
-        print('Version = {0}'.format(version))
-        print('git origin = {0}'.format(git_origin))
-        print('git branch = {0}'.format(git_branch))
-        print('git description = {0}'.format(git_description))
-    except:
-        pass
+    print_version_info()
 
 if __name__ == '__main__':
     main()

--- a/hera_pspec/version.py
+++ b/hera_pspec/version.py
@@ -2,12 +2,6 @@ import os
 import subprocess
 import json
 
-# Python 2/3 portable Unicode handling
-try:
-    unicode
-except NameError:
-    unicode = str
-
 hera_pspec_dir = os.path.dirname(os.path.realpath(__file__))
 version_file = os.path.join(hera_pspec_dir, 'VERSION')
 version = open(version_file).read().strip()
@@ -69,10 +63,10 @@ if git_hash is not '':
 
 
 def main():
-    print('Version = {0}'.format(unicode(version)))
-    print('git origin = {0}'.format(unicode(git_origin)))
-    print('git branch = {0}'.format(unicode(git_branch)))
-    print('git description = {0}'.format(unicode(git_description)))
+    print("Version = %s" % version)
+    print("git origin = %s" % git_origin)
+    print("git branch = %s" % git_branch)
+    print("git description = %s" % git_description)
 
 if __name__ == '__main__':
     main()

--- a/hera_pspec/version.py
+++ b/hera_pspec/version.py
@@ -64,10 +64,13 @@ if git_hash is not '':
 
 
 def main():
-    print("Version = {0}".format(version))
-    print("git origin = {0}".format(git_origin.decode('utf-8')))
-    print("git branch = {0}".format(git_branch.decode('utf-8')))
-    print("git description = {0}".format(git_description.decode('utf-8')))
-
+    try:
+        print("Version = {0}".format(version))
+        print("git origin = {0}".format(git_origin.decode('utf-8')))
+        print("git branch = {0}".format(git_branch.decode('utf-8')))
+        print("git description = {0}".format(git_description.decode('utf-8')))
+    except TypeError:
+        print(type(version), type(git_origin))
+        raise
 if __name__ == '__main__':
     main()

--- a/hera_pspec/version.py
+++ b/hera_pspec/version.py
@@ -63,10 +63,10 @@ if git_hash is not '':
 
 
 def main():
-    print("Version = %s" % version)
-    print("git origin = %s" % git_origin)
-    print("git branch = %s" % git_branch)
-    print("git description = %s" % git_description)
+    print("Version =", version)
+    print("git origin =", git_origin)
+    print("git branch =", git_branch)
+    print("git description =", git_description)
 
 if __name__ == '__main__':
     main()

--- a/hera_pspec/version.py
+++ b/hera_pspec/version.py
@@ -123,11 +123,13 @@ git_branch = version_info['git_branch']
 
 
 def main():
-    print('Version = {0}'.format(version))
-    print('git origin = {0}'.format(git_origin))
-    print('git branch = {0}'.format(git_branch))
-    print('git description = {0}'.format(git_description))
-
+    try:
+        print('Version = {0}'.format(version))
+        print('git origin = {0}'.format(git_origin))
+        print('git branch = {0}'.format(git_branch))
+        print('git description = {0}'.format(git_description))
+    except:
+        print("Failed to print version info.")
 
 if __name__ == '__main__':
     main()

--- a/hera_pspec/version.py
+++ b/hera_pspec/version.py
@@ -1,3 +1,4 @@
+#from __future__ import print_function
 import os
 import subprocess
 import json
@@ -63,10 +64,10 @@ if git_hash is not '':
 
 
 def main():
-    print("Version =", version)
-    print("git origin =", git_origin)
-    print("git branch =", git_branch)
-    print("git description =", git_description)
+    print("Version = {0}".format(version))
+    print("git origin = {0}".format(git_origin.decode('utf-8')))
+    print("git branch = {0}".format(git_branch.decode('utf-8')))
+    print("git description = {0}".format(git_description.decode('utf-8')))
 
 if __name__ == '__main__':
     main()

--- a/hera_pspec/version.py
+++ b/hera_pspec/version.py
@@ -2,6 +2,12 @@ import os
 import subprocess
 import json
 
+# Python 2/3 portable Unicode handling
+try:
+    unicode
+except NameError:
+    unicode = str
+
 hera_pspec_dir = os.path.dirname(os.path.realpath(__file__))
 version_file = os.path.join(hera_pspec_dir, 'VERSION')
 version = open(version_file).read().strip()
@@ -63,10 +69,10 @@ if git_hash is not '':
 
 
 def main():
-    print('Version = {0}'.format(version))
-    print('git origin = {0}'.format(git_origin))
-    print('git branch = {0}'.format(git_branch))
-    print('git description = {0}'.format(git_description))
+    print('Version = {0}'.format(unicode(version)))
+    print('git origin = {0}'.format(unicode(git_origin)))
+    print('git branch = {0}'.format(unicode(git_branch)))
+    print('git description = {0}'.format(unicode(git_description)))
 
 if __name__ == '__main__':
     main()

--- a/hera_pspec/version.py
+++ b/hera_pspec/version.py
@@ -129,7 +129,7 @@ def main():
         print('git branch = {0}'.format(git_branch))
         print('git description = {0}'.format(git_description))
     except:
-        print("Failed to print version info.")
+        pass
 
 if __name__ == '__main__':
     main()

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import json
 
 data = [version.git_origin, version.git_hash, version.git_description, version.git_branch]
 with open(os.path.join('hera_pspec', 'GIT_INFO'), 'w') as outfile:
-    json.dump(data, outfile)
+    json.dump(data, outfile, default=str)
 
 def package_files(package_dir, subdirectory):
     # walk the input package_dir/subdirectory
@@ -38,4 +38,4 @@ setup_args = {
 }
 
 if __name__ == '__main__':
-    apply(setup, (), setup_args)
+    setup(**setup_args)


### PR DESCRIPTION
This PR enables cross-polarisation support, subject to the limitation that the beam scalar can't be computed for cross-pol yet. (In other words, this PR only allows unnormalised cross-pol spectra to be computed.)

The main change in the PR is to store polarisation pairs inside `UVPSpec`, instead of individual polarisations. Pol-pairs can be specified as tuples, e.g. `('xx', 'xx')`, or as specially-constructed integers (there are helper functions to deal with these). Individual polarisations (e.g. `'xx'`) are no longer accepted.

I also got a bit carried away and enabled Python 3 support in this PR. This required more extensive changes than first expected, as functions like `map()` and `reduce()` have been deprecated (now replaced with list comprehensions and `np.reduce`), some string handling has changed (especially annoying for HDF5), and methods like `dict.keys()` now return iterators instead of lists, and so can't be indexed directly (fixed by calling `list()` on the iterators).