### PR TITLE
Fix backwards compatibility bugs with UVPSpec data files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,13 +40,13 @@ install:
   - conda install -c conda-forge healpy aipy
   - pip install coveralls
   - pip install h5py
+  - pip install scikit-learn
   - pip install git+https://github.com/HERA-Team/pyuvdata.git$PYUVDATA_VERSION
   - pip install git+https://github.com/HERA-Team/omnical.git
   - pip install git+https://github.com/HERA-Team/linsolve.git
   - pip install git+https://github.com/HERA-Team/hera_qm.git
   - pip install git+https://github.com/HERA-Team/uvtools.git
   - pip install git+https://github.com/HERA-Team/hera_cal.git
-  - pip install scikit-learn
   - pip install pyyaml
   - pip install multiprocess
   - python setup.py install

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ install:
   - conda info -a
 
   # create environment and install dependencies
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy=0.16.0 scipy nose pip matplotlib coverage
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy=1.16.0 scipy nose pip matplotlib coverage
   - source activate test-environment
   - conda install -c conda-forge healpy aipy scikit-learn
   - pip install coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ install:
   - conda info -a
 
   # create environment and install dependencies
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy nose pip matplotlib coverage
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy=0.16.0 scipy nose pip matplotlib coverage
   - source activate test-environment
   - conda install -c conda-forge healpy aipy scikit-learn
   - pip install coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,9 +35,9 @@ install:
   - conda info -a
 
   # create environment and install dependencies
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy=1.16.0 scipy nose pip matplotlib coverage
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy>=1.15.0 scipy nose pip matplotlib coverage
   - source activate test-environment
-  - conda install -c conda-forge healpy aipy scikit-learn
+  - conda install -c conda-forge healpy aipy
   - pip install coveralls
   - pip install h5py
   - pip install git+https://github.com/HERA-Team/pyuvdata.git$PYUVDATA_VERSION

--- a/hera_pspec/uvpspec.py
+++ b/hera_pspec/uvpspec.py
@@ -1140,6 +1140,8 @@ class UVPSpec(object):
         """
         # Make sure the group is a UVPSpec object
         assert 'pspec_type' in grp.attrs, "This object is not a UVPSpec object"
+        pstype = grp.attrs['pspec_type']
+        pstype = pstype.decode() if isinstance(pstype, bytes) else pstype
         assert grp.attrs['pspec_type'].decode() == 'UVPSpec', \
             "This object is not a UVPSpec object"
 

--- a/hera_pspec/uvpspec.py
+++ b/hera_pspec/uvpspec.py
@@ -1142,8 +1142,7 @@ class UVPSpec(object):
         assert 'pspec_type' in grp.attrs, "This object is not a UVPSpec object"
         pstype = grp.attrs['pspec_type']
         pstype = pstype.decode() if isinstance(pstype, bytes) else pstype
-        assert grp.attrs['pspec_type'].decode() == 'UVPSpec', \
-            "This object is not a UVPSpec object"
+        assert pstype == 'UVPSpec', "This object is not a UVPSpec object"
 
         # Clear all data in the current object
         self._clear()

--- a/hera_pspec/uvpspec.py
+++ b/hera_pspec/uvpspec.py
@@ -7,6 +7,7 @@ from hera_pspec.parameter import PSpecParam
 from pyuvdata import uvutils as uvutils
 import h5py
 import operator
+import warnings
 
 
 class UVPSpec(object):
@@ -128,7 +129,7 @@ class UVPSpec(object):
                        "nsample_array", "cov_array"]
         self._dicts_of_dicts = ["stats_array"]
 
-        # define which attributes are considred meta data. Large attrs should 
+        # define which attributes are considered meta data. Large attrs should 
         # be constructed as datasets
         self._meta_dsets = ["lst_1_array", "lst_2_array", "time_1_array",
                             "time_2_array", "blpair_array", "bl_vecs",
@@ -1139,7 +1140,7 @@ class UVPSpec(object):
         """
         # Make sure the group is a UVPSpec object
         assert 'pspec_type' in grp.attrs, "This object is not a UVPSpec object"
-        assert grp.attrs['pspec_type'] == 'UVPSpec', \
+        assert grp.attrs['pspec_type'].decode() == 'UVPSpec', \
             "This object is not a UVPSpec object"
 
         # Clear all data in the current object
@@ -1148,11 +1149,24 @@ class UVPSpec(object):
         # Load-in meta data
         for k in grp.attrs:
             if k in self._meta_attrs:
-                setattr(self, k, grp.attrs[k])
+                val = grp.attrs[k]
+                if isinstance(val, bytes): val = val.decode() # bytes -> str
+                setattr(self, k, val)
         for k in grp:
             if k in self._meta_dsets:
                 setattr(self, k, grp[k][:])
-
+        
+        # Backwards compatibility: pol_array exists (not polpair_array)
+        if 'pol_array' in grp.attrs:
+            warnings.warn("Stored UVPSpec contains pol_array attr, which has "
+                          "been superseded by polpair_array. Converting "
+                          "automatically.", UserWarning)
+            pol_arr = grp.attrs['pol_array']
+            
+            # Convert to polpair array
+            polpair_arr = [uvputils.polpair_tuple2int((p,p)) for p in pol_arr]
+            setattr(self, 'polpair_array', np.array(polpair_arr))
+        
         # Use _select() to pick out only the requested baselines/spws
         if just_meta:
             uvputils._select(self, spws=spws, bls=bls, lsts=lsts,

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup_args = {
     'packages':     ['hera_pspec'],
     'package_dir':  {'hera_pspec': 'hera_pspec'},
     'package_data': {'hera_pspec': data_files},
-    'install_requires': ['numpy>=1.14', 'scipy','matplotlib>=2.2'],
+    'install_requires': ['numpy>=1.15', 'scipy','matplotlib>=2.2'],
     'include_package_data': True,
     'scripts': ['scripts/pspec_run.py', 'scripts/pspec_red.py',
                 'scripts/bootstrap_run.py'],


### PR DESCRIPTION
Fix two backwards compatibility bugs related to loading old HDF5 files into `UVPSpec` objects.

The first is related to HDF5 in Py3, which returns `bytes` instead of strings. A string comparison was failing as a result. All string attributes in `UVPSpec` files are now converted from `bytes` to strings.

The second is due to the recent change from `pol_array` to `polpair_array` in the `UVPSpec` data model. The old `pol_array` attribute is now detected and automatically converted to a `polpair_array` when a file is loaded. A `UserWarning` is shown when this happens.