### PR TITLE
Use older version of scikit-learn for Python 2.7 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,11 @@ install:
   - conda install -c conda-forge healpy aipy
   - pip install coveralls
   - pip install h5py
-  - pip install scikit-learn
+  - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
+      pip install scikit-learn==0.20.3;
+    else
+      pip install scikit-learn;
+    fi
   - pip install git+https://github.com/HERA-Team/pyuvdata.git$PYUVDATA_VERSION
   - pip install git+https://github.com/HERA-Team/omnical.git
   - pip install git+https://github.com/HERA-Team/linsolve.git


### PR DESCRIPTION
Scikit-learn has dropped Py2.7 support; use older versions for Py2.7 tests.