### PR TITLE
Allow blpair groups to be passed as list of ndarray

### DIFF
--- a/hera_pspec/grouping.py
+++ b/hera_pspec/grouping.py
@@ -186,7 +186,7 @@ def average_spectra(uvp_in, blpair_groups=None, time_avg=False,
     if blpair_groups is not None:
 
         # Enforce shape of blpair_groups
-        assert isinstance(blpair_groups[0], list), \
+        assert isinstance(blpair_groups[0], (list, np.ndarray)), \
               "blpair_groups must be fed as a list of baseline-pair lists. " \
               "See docstring."
 


### PR DESCRIPTION
The `average_spectra` method requires blpairs to be specified as a list of lists at the moment, but it would be useful to also accept a list of ndarray too. This PR allows that.