### PR TITLE
Partial load from container.get_pspec

### DIFF
--- a/hera_pspec/__init__.py
+++ b/hera_pspec/__init__.py
@@ -1,13 +1,13 @@
 """
 __init__.py file for hera_pspec
 """
-from hera_pspec import version, conversions, grouping, pspecbeam, plot, pstokes, testing
-from hera_pspec import uvpspec_utils as uvputils
+from . import version, conversions, grouping, pspecbeam, plot, pstokes, testing
+from . import uvpspec_utils as uvputils
 
-from hera_pspec.uvpspec import UVPSpec
-from hera_pspec.pspecdata import PSpecData
-from hera_pspec.container import PSpecContainer
-from hera_pspec.parameter import PSpecParam
-from hera_pspec.pspecbeam import PSpecBeamUV, PSpecBeamGauss, PSpecBeamFromArray
+from .uvpspec import UVPSpec
+from .pspecdata import PSpecData
+from .container import PSpecContainer
+from .parameter import PSpecParam
+from .pspecbeam import PSpecBeamUV, PSpecBeamGauss, PSpecBeamFromArray
 
 __version__ = version.version

--- a/hera_pspec/grouping.py
+++ b/hera_pspec/grouping.py
@@ -1,13 +1,12 @@
 import numpy as np
 from collections import OrderedDict as odict
-from hera_pspec import uvpspec_utils as uvputils
-from hera_pspec import utils, version
 import random
 import copy
 import argparse
 from astropy import stats as astats
 import os
 
+from . import utils, version, uvpspec_utils as uvputils
 
 def group_baselines(bls, Ngroups, keep_remainder=False, randomize=False,
                     seed=None):

--- a/hera_pspec/noise.py
+++ b/hera_pspec/noise.py
@@ -1,9 +1,10 @@
 import numpy as np
 import os
-from hera_pspec import conversions, pspecbeam
 import copy
 import ast
 from collections import OrderedDict as odict
+
+from . import conversions, pspecbeam
 
 
 def calc_P_N(scalar, Tsys, t_int, Ncoherent=1, Nincoherent=None, form='Pk', k=None, component='real'):

--- a/hera_pspec/plot.py
+++ b/hera_pspec/plot.py
@@ -1,14 +1,13 @@
 import numpy as np
 import pyuvdata
-from hera_pspec import conversions, uvpspec, utils
-import matplotlib
-import matplotlib.pyplot as plt
 import copy
 from collections import OrderedDict as odict
 import astropy.units as u
 import astropy.constants as c
 from pyuvdata import UVData
 import uvtools
+
+from . import conversions, uvpspec, utils
 
 
 def delay_spectrum(uvp, blpairs, spw, pol, average_blpairs=False, 
@@ -107,6 +106,9 @@ def delay_spectrum(uvp, blpairs, spw, pol, average_blpairs=False,
     fig : matplotlib.pyplot.Figure
         Matplotlib Figure instance.
     """
+    import matplotlib
+    import matplotlib.pyplot as plt
+
     # Create new Axes if none specified
     new_plot = False
     if ax is None:
@@ -373,6 +375,9 @@ def delay_waterfall(uvp, blpairs, spw, pol, component='real',
     fig : matplotlib.pyplot.Figure
         Matplotlib Figure instance if input ax is None.
     """
+    import matplotlib
+    import matplotlib.pyplot as plt
+
     # assert component
     assert component in ['real', 'abs', 'imag'], "Can't parse specified component {}".format(component)
 
@@ -715,6 +720,9 @@ def delay_wedge(uvp, spw, pol, blpairs=None, times=None, fold=False, delay=True,
     fig : matplotlib.pyplot.Figure
         Matplotlib Figure instance if ax is None.
     """
+    import matplotlib
+    import matplotlib.pyplot as plt
+
     # type checking
     uvp = copy.deepcopy(uvp)
     assert isinstance(uvp, uvpspec.UVPSpec), "input uvp must be a UVPSpec object"
@@ -964,6 +972,9 @@ def plot_uvdata_waterfalls(uvd, basename, data='data', plot_mode='log',
         Keyword arguments passed to uvtools.plot.waterfall, which passes them 
         on to matplotlib.imshow.
     """
+    import matplotlib
+    import matplotlib.pyplot as plt
+
     assert isinstance(uvd, UVData), "'uvd' must be a UVData object."
     assert data in ['data', 'flags', 'nsamples'], \
             "'%s' not a valid data array; use 'data', 'flags', or 'nsamples'" \

--- a/hera_pspec/pspecbeam.py
+++ b/hera_pspec/pspecbeam.py
@@ -1,12 +1,12 @@
 import numpy as np
 import os
-import hera_pspec.conversions as conversions
-import hera_pspec.uvpspec_utils as uvputils
 import scipy.integrate as integrate
 from scipy.interpolate import interp1d
 from pyuvdata import UVBeam, utils as uvutils
 import aipy
 from collections import OrderedDict as odict
+
+from . import conversions as conversions, uvpspec_utils as uvputils
 
 
 def _compute_pspec_scalar(cosmo, beam_freqs, omega_ratio, pspec_freqs, 

--- a/hera_pspec/pspecdata.py
+++ b/hera_pspec/pspecdata.py
@@ -4,8 +4,6 @@ from pyuvdata import UVData, UVCal
 import copy, operator, itertools, sys
 from collections import OrderedDict as odict
 import hera_cal as hc
-from hera_pspec import uvpspec, utils, version, pspecbeam, container
-from hera_pspec import uvpspec_utils as uvputils
 from pyuvdata import utils as uvutils
 import datetime
 import time
@@ -15,6 +13,9 @@ import glob
 import warnings
 import json
 import uvtools.dspec as dspec
+
+from . import uvpspec, utils, version, pspecbeam, container, uvpspec_utils as uvputils
+
 
 class PSpecData(object):
 

--- a/hera_pspec/pstokes.py
+++ b/hera_pspec/pstokes.py
@@ -4,9 +4,9 @@ Module to construct pseudo-Stokes (I,Q,U,V) visibilities from miriad files or UV
 import numpy as np, os
 import pyuvdata
 import copy
-from hera_pspec import version
 from collections import OrderedDict as odict
 
+from . import version
 
 # Weights used in forming Stokes visibilities.
 # See pyuvdata.utils.polstr2num for conversion between polarization string

--- a/hera_pspec/testing.py
+++ b/hera_pspec/testing.py
@@ -2,11 +2,11 @@
 import numpy as np
 import copy, operator, itertools
 from collections import OrderedDict as odict
-from hera_pspec import uvpspec, pspecdata, conversions, pspecbeam, utils
 from pyuvdata import UVData
 from hera_cal.utils import JD2LST
 from scipy import stats
-import hera_pspec.uvpspec_utils as uvputils
+
+from . import uvpspec, pspecdata, conversions, pspecbeam, utils, uvpspec_utils as uvputils
 
 
 def build_vanilla_uvpspec(beam=None):

--- a/hera_pspec/tests/test_container.py
+++ b/hera_pspec/tests/test_container.py
@@ -118,6 +118,14 @@ class Test_PSpecContainer(unittest.TestCase):
                 ps = ps_store.get_pspec(g, psname=psname)
                 assert(isinstance(ps, UVPSpec))
         
+        # check partial IO in get_pspec
+        ps = ps_store.get_pspec(group_names[0], pspec_names[0], just_meta=True)
+        assert not hasattr(ps, 'data_array')
+        assert hasattr(ps, 'time_avg_array')
+        ps = ps_store.get_pspec(group_names[0], pspec_names[0], blpairs=[((1, 2), (1, 2))])
+        assert hasattr(ps, 'data_array')
+        assert np.all(np.isclose(ps.blpair_array, 101102101102))
+
         # Check that invalid list arguments raise errors in set_pspec()
         assert_raises(ValueError, ps_store.set_pspec, group=group_names[:2], 
                       psname=pspec_names[0], pspec=self.uvp, overwrite=True)

--- a/hera_pspec/utils.py
+++ b/hera_pspec/utils.py
@@ -3,12 +3,14 @@ import os, time, yaml
 import itertools, argparse, glob
 import traceback, operator
 import aipy, uvtools
-from hera_pspec.conversions import Cosmo_Conversions
 from hera_cal import redcal
 from collections import OrderedDict as odict
 from pyuvdata import utils as uvutils
 from pyuvdata import UVData
 from datetime import datetime
+
+from .conversions import Cosmo_Conversions
+
 
 def cov(d1, w1, d2=None, w2=None, conj_1=False, conj_2=True):
     """

--- a/hera_pspec/uvpspec.py
+++ b/hera_pspec/uvpspec.py
@@ -1,15 +1,14 @@
 import numpy as np
 from collections import OrderedDict as odict
 import os, copy, shutil, operator, ast, fnmatch
-from hera_pspec import conversions, noise, version, pspecbeam, grouping, utils
-from hera_pspec import uvpspec_utils as uvputils
-from hera_pspec.parameter import PSpecParam
 from pyuvdata import uvutils as uvutils
 import h5py
 import operator
 import warnings
 import json
 
+from . import conversions, noise, version, pspecbeam, grouping, utils, uvpspec_utils as uvputils
+from .parameter import PSpecParam
 
 class UVPSpec(object):
     """

--- a/hera_pspec/uvpspec_utils.py
+++ b/hera_pspec/uvpspec_utils.py
@@ -1,9 +1,10 @@
 import numpy as np
 import copy, operator
-from . import utils
 from collections import OrderedDict as odict
 from pyuvdata.utils import polstr2num, polnum2str
 import json
+
+from . import utils
 
 def subtract_uvp(uvp1, uvp2, run_check=True, verbose=False):
     """


### PR DESCRIPTION
Enables partial UVPSpec loading from within a `PSpecContainer.get_pspec` method. Also makes all module imports relative imports (thought this was already done?)