### PR TITLE
pspec tapering functions draw from uvtools

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@
 [![Coverage Status](https://coveralls.io/repos/github/HERA-Team/hera_pspec/badge.svg?branch=master)](https://coveralls.io/github/HERA-Team/hera_pspec?branch=master)
 [![Documentation](https://readthedocs.org/projects/hera-pspec/badge/?version=latest)](https://readthedocs.org/projects/hera-pspec/badge/?version=latest)
 
-The ``hera_pspec`` library provides all of the tools and data structures needed to perform a delay spectrum analysis on interferometric data. The input data can be in any format supported by ``pyuvdata``, and the output data are stored in HDF5 containers.
+The ``hera_pspec`` library provides all of the tools and data structures needed to perform a delay 
+spectrum analysis on interferometric data. The input data can be in any format supported by ``pyuvdata``, 
+and the output data are stored in HDF5 containers.
 
 For usage examples and documentation, see http://hera-pspec.readthedocs.io/en/latest/.
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,7 +27,7 @@ import sys
 import mock
 MOCK_MODULES = ['numpy', 'scipy', 'scipy.interpolate', 'scipy.integrate', 
                 'pyuvdata', 'h5py', 'aipy', 'omnical', 'linsolve', 'hera_qm', 
-                'uvtools', 'hera_cal', 'hera_cal.utils', 'healpy', 
+                'uvtools', 'uvtools.dspec', 'hera_cal', 'hera_cal.utils', 'healpy', 
                 'scikit-learn', 'astropy', 'astropy.cosmology', 'astropy.units', 
                 'astropy.constants', 'matplotlib', 'matplotlib.pyplot', 
                 'pylab', 'yaml', 'pyuvdata.utils', ]

--- a/hera_pspec/pspecbeam.py
+++ b/hera_pspec/pspecbeam.py
@@ -3,8 +3,9 @@ import os
 import scipy.integrate as integrate
 from scipy.interpolate import interp1d
 from pyuvdata import UVBeam, utils as uvutils
-import aipy
+import uvtools.dspec as dspec
 from collections import OrderedDict as odict
+
 
 from . import conversions as conversions, uvpspec_utils as uvputils
 
@@ -93,7 +94,7 @@ def _compute_pspec_scalar(cosmo, beam_freqs, omega_ratio, pspec_freqs,
     if taper == 'none':
         dBpp_over_BpSq = np.ones_like(integration_freqs, np.float)
     else:
-        dBpp_over_BpSq = aipy.dsp.gen_window(len(pspec_freqs), taper)**2.
+        dBpp_over_BpSq = dspec.gen_window(taper, len(pspec_freqs))**2.
         dBpp_over_BpSq = interp1d(pspec_freqs, dBpp_over_BpSq, kind='nearest', 
                                   fill_value='extrapolate')(integration_freqs)
     dBpp_over_BpSq /= (integration_freqs[-1] - integration_freqs[0])**2.

--- a/hera_pspec/pspecdata.py
+++ b/hera_pspec/pspecdata.py
@@ -1,5 +1,4 @@
 import numpy as np
-import aipy
 from pyuvdata import UVData, UVCal
 import copy, operator, itertools, sys
 from collections import OrderedDict as odict

--- a/hera_pspec/pspecdata.py
+++ b/hera_pspec/pspecdata.py
@@ -800,7 +800,7 @@ class PSpecData(object):
             if self.taper == 'none':
                 sqrtT = np.ones(self.spw_Nfreqs).reshape(1, -1)
             else:
-                sqrtT = np.sqrt(aipy.dsp.gen_window(self.spw_Nfreqs, self.taper)).reshape(1, -1)
+                sqrtT = np.sqrt(dspec.gen_window(self.taper, self.spw_Nfreqs)).reshape(1, -1)
 
             # get flag weight vector: straight multiplication of vectors
             # mimics matrix multiplication
@@ -884,7 +884,7 @@ class PSpecData(object):
         Parameters
         ----------
         taper : str
-            Type of data tapering. See aipy.dsp.gen_window for options.
+            Type of data tapering. See uvtools.dspec.gen_window for options.
         """
         self.taper = taper
 
@@ -2002,7 +2002,7 @@ class PSpecData(object):
         adjustment = self.spw_Ndlys / (self.spw_Nfreqs * mean_ratio)
 
         if self.taper != 'none':
-            tapering_fct = aipy.dsp.gen_window(self.spw_Nfreqs, self.taper)
+            tapering_fct = dspec.gen_window(self.taper, self.spw_Nfreqs)
             adjustment *= np.mean(tapering_fct**2)
 
         return adjustment
@@ -2126,7 +2126,7 @@ class PSpecData(object):
 
         taper : str, optional
             Tapering (window) function to apply to the data. Takes the same
-            arguments as aipy.dsp.gen_window(). Default: 'none'.
+            arguments as uvtools.dspec.gen_window(). Default: 'none'.
 
         sampling : boolean, optional
             Whether output pspec values are samples at various delay bins

--- a/hera_pspec/tests/test_pspecdata.py
+++ b/hera_pspec/tests/test_pspecdata.py
@@ -25,7 +25,7 @@ dfiles_std = [
 ]
 
 # List of tapering function to use in tests
-taper_selection = ['none', 'blackman',]
+taper_selection = ['none', 'bh7',]
 #taper_selection = ['blackman', 'blackman-harris', 'gaussian0.4', 'kaiser2',
 #                   'kaiser3', 'hamming', 'hanning', 'parzen']
 

--- a/hera_pspec/uvpspec.py
+++ b/hera_pspec/uvpspec.py
@@ -78,7 +78,7 @@ class UVPSpec(object):
         self._telescope_location = PSpecParam("telescope_location", description="telescope location in ECEF frame [meters]. To get it in Lat/Lon/Alt see pyuvdata.utils.LatLonAlt_from_XYZ().", expected_type=np.float64)
         self._weighting = PSpecParam("weighting", description="Form of data weighting used when forming power spectra.", expected_type=str)
         self._norm = PSpecParam("norm", description="Normalization method adopted in OQE (M matrix).", expected_type=str)
-        self._taper = PSpecParam("taper", description='Taper function applied to visibility data before FT."', expected_type=str)
+        self._taper = PSpecParam("taper", description='Taper function applied to visibility data before FT. See uvtools.dspec.gen_window for options."', expected_type=str)
         self._vis_units = PSpecParam("vis_units", description="Units of the original visibility data used to form the power spectra.", expected_type=str)
         self._norm_units = PSpecParam("norm_units", description="Power spectra normalization units, i.e. telescope units [Hz str] or cosmological [(h^-3) Mpc^3].", expected_type=str)
         self._labels = PSpecParam("labels", description="Array of dataset string labels.", expected_type=np.str)

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,6 @@ setup_args = {
         'matplotlib>=2.2'
         'pyuvdata',
         'astropy>=2.0',
-        'aipy>=3.0rc2',
         'pyyaml',
         'h5py',
         'uvtools @ git+git://github.com/HERA-Team/uvtools',


### PR DESCRIPTION
uvtools provides a much larger library of tapering functions than aipy, so our `PSpecData.taper` kwarg now draws from uvtools. One particular feature is the 7-term blackman harris window, which achieves more sidelobe suppression than the standard blackman harris window (aka 4-term blackman harris window). For users wanting to make power spectra of simulated FG + EoR datasets this may be necessary to achieve the required dynamic range. Addresses #221 