### PR TITLE
Uvp combine history

### DIFF
--- a/hera_pspec/container.py
+++ b/hera_pspec/container.py
@@ -494,7 +494,7 @@ class PSpecContainer(object):
 
 
 def combine_psc_spectra(psc, groups=None, dset_split_str='_x_', ext_split_str='_',
-                        verbose=True, overwrite=False):
+                        merge_history=True, verbose=True, overwrite=False):
     """
     Iterate through a PSpecContainer and, within each specified group, combine 
     UVPSpec (i.e. spectra) of similar name but varying psname extension.
@@ -528,6 +528,9 @@ def combine_psc_spectra(psc, groups=None, dset_split_str='_x_', ext_split_str='_
 
     ext_split_str : str
         The pattern used to split the dset name from its extension in the psname.
+
+    merge_history : bool
+        If True merge UVPSpec histories. Else use zeroth object's history.
 
     verbose : bool
         If True, report feedback to stdout.
@@ -581,7 +584,7 @@ def combine_psc_spectra(psc, groups=None, dset_split_str='_x_', ext_split_str='_
             try:
                 # merge
                 uvps = [psc.get_pspec(grp, uvp) for uvp in to_merge]
-                merged_uvp = uvpspec.combine_uvpspec(uvps, verbose=verbose)
+                merged_uvp = uvpspec.combine_uvpspec(uvps, merge_history=merge_history, verbose=verbose)
                 # write to file
                 psc.set_pspec(grp, spc, merged_uvp, overwrite=True)
                 # if successful merge, remove uvps

--- a/hera_pspec/pspecdata.py
+++ b/hera_pspec/pspecdata.py
@@ -2900,7 +2900,7 @@ def pspec_run(dsets, filename, dsets_std=None, cals=None, cal_flag=True,
               trim_dset_lsts=False, broadcast_dset_flags=True,
               time_thresh=0.2, Jy2mK=False, overwrite=True,
               file_type='miriad', verbose=True, store_cov=False,
-              history='', r_params=None):
+              history='', r_params=None, tsleep=0.1, maxiter=1):
     """
     Create a PSpecData object, run OQE delay spectrum estimation and write
     results to a PSpecContainer object.
@@ -3067,6 +3067,13 @@ def pspec_run(dsets, filename, dsets_std=None, cals=None, cal_flag=True,
     history : str
         String to add to history of each UVPSpec object.
 
+    tsleep : float, optional
+        Time to wait in seconds after each attempt at opening the container file.
+
+    maxiter : int, optional
+        Maximum number of attempts to open container file (useful for concurrent 
+        access when file may be locked temporarily by other processes).
+
     r_params: dict, optional
         Dictionary with parameters for weighting matrix. Required fields and
         formats depend on the mode of `data_weighting`. Default: None.
@@ -3087,10 +3094,6 @@ def pspec_run(dsets, filename, dsets_std=None, cals=None, cal_flag=True,
 
     Returns
     -------
-    psc : PSpecContainer object
-        A container for the output UVPSpec objects, which themselves contain
-        the power spectra and their metadata.
-
     ds : PSpecData object
         The PSpecData object used for OQE of power spectrum, with cached
         weighting matrices.
@@ -3307,7 +3310,7 @@ def pspec_run(dsets, filename, dsets_std=None, cals=None, cal_flag=True,
 
     # Open PSpecContainer to store all output in
     if verbose: print("Opening {} in transactional mode".format(filename))
-    psc = container.PSpecContainer(filename, mode='rw', keep_open=False, tsleep=1, maxiter=20)
+    psc = container.PSpecContainer(filename, mode='rw', keep_open=False, tsleep=tsleep, maxiter=maxiter)
 
     # assign group name
     if groupname is None:

--- a/hera_pspec/testing.py
+++ b/hera_pspec/testing.py
@@ -131,7 +131,7 @@ def build_vanilla_uvpspec(beam=None):
 
 def uvpspec_from_data(data, bl_grps, data_std=None, spw_ranges=None,
                       beam=None, taper='none', cosmo=None, n_dlys=None,
-                      r_params = None, verbose=False):
+                      r_params=None, verbose=False):
     """
     Build an example UVPSpec object from a visibility file and PSpecData.
 
@@ -234,7 +234,7 @@ def uvpspec_from_data(data, bl_grps, data_std=None, spw_ranges=None,
     # run pspec
     uvp = ds.pspec(bls1, bls2, (0, 1), (pol, pol), input_data_weight='identity',
                    spw_ranges=spw_ranges, taper=taper, verbose=verbose,
-                   store_cov=store_cov, n_dlys=n_dlys, r_params = r_params)
+                   store_cov=store_cov, n_dlys=n_dlys, r_params=r_params)
 
     return uvp
 

--- a/hera_pspec/tests/test_uvpspec.py
+++ b/hera_pspec/tests/test_uvpspec.py
@@ -12,6 +12,7 @@ from collections import OrderedDict as odict
 from pyuvdata import UVData
 import json
 
+
 class Test_UVPSpec(unittest.TestCase):
 
     def setUp(self):
@@ -503,33 +504,12 @@ class Test_UVPSpec(unittest.TestCase):
         beam = pspecbeam.PSpecBeamUV(os.path.join(DATA_PATH,
                                                "HERA_NF_dipole_power.beamfits"))
         bls = [(37, 38), (38, 39), (52, 53)]
-
-        rp = {'filter_centers':[0.],
-              'filter_widths':[250e-9],
-              'filter_factors':[1e-9]}
-
-        r_params = {}
-
-        for bl in bls:
-            key1 =  bl + ('xx',)
-            r_params[key1] = rp
-
-        #create an r_params copy with inconsistent weighting to test
-        #error case
-        r_params_inconsistent = copy.deepcopy(r_params)
-        r_params[key1]['filter_widths'] = [100e-9]
-
-        uvp1 = testing.uvpspec_from_data(uvd, bls,
-                                         spw_ranges=[(20, 30), (60, 90)],
-                                         beam=beam, r_params = r_params)
-
-        print("uvp1 unique blps:", np.unique(uvp1.blpair_array))
+        uvp1 = testing.uvpspec_from_data(uvd, bls, 
+                                         spw_ranges=[(20, 30), (60, 90)], 
+                                         beam=beam)
 
         # test failure due to overlapping data
         uvp2 = copy.deepcopy(uvp1)
-
-        print("uvp2 unique blps:", np.unique(uvp2.blpair_array))
-
         nt.assert_raises(AssertionError, uvpspec.combine_uvpspec, [uvp1, uvp2])
 
         # test success across pol
@@ -538,22 +518,10 @@ class Test_UVPSpec(unittest.TestCase):
         nt.assert_equal(out.Npols, 2)
         nt.assert_true(len(set(out.polpair_array) ^ set([1515, 1414])) == 0)
         key = (0, ((37, 38), (38, 39)), ('xx','xx'))
-        nt.assert_true(np.all(np.isclose(out.get_nsamples(key),
+        nt.assert_true(np.all(np.isclose(out.get_nsamples(key), 
                        np.ones(10, dtype=np.float64))))
-        nt.assert_true(np.all(np.isclose(out.get_integrations(key),
+        nt.assert_true(np.all(np.isclose(out.get_integrations(key), 
                        190 * np.ones(10, dtype=np.float64), atol=5, rtol=2)))
-        #test errors when combining with pspecs without r_params
-        uvp3 = copy.deepcopy(uvp2)
-        uvp3.r_params = ''
-        nt.assert_raises(ValueError, uvpspec.combine_uvpspec, [uvp1, uvp3])
-        #combining multiple uvp objects without r_params should run fine
-        uvp4 = copy.deepcopy(uvp1)
-        uvp4.r_params = ''
-        uvpspec.combine_uvpspec([uvp3, uvp4])
-        #now test error case with inconsistent weightings.
-        uvp5 = copy.deepcopy(uvp2)
-        uvp5.r_params = uvputils.compress_r_params(r_params_inconsistent)
-        nt.assert_raises(ValueError, uvpspec.combine_uvpspec, [uvp1, uvp5])
 
         # test multiple non-overlapping data axes
         uvp2.freq_array[0] = 0.0
@@ -575,7 +543,7 @@ class Test_UVPSpec(unittest.TestCase):
 
         # test concat across spw
         uvp2 = testing.uvpspec_from_data(uvd, bls, spw_ranges=[(85, 101)],
-                                         beam=beam, r_params = r_params)
+                                         beam=beam)
         out = uvpspec.combine_uvpspec([uvp1, uvp2], verbose=False)
         nt.assert_equal(out.Nspws, 3)
         nt.assert_equal(out.Nfreqs, 51)
@@ -584,7 +552,7 @@ class Test_UVPSpec(unittest.TestCase):
         # test concat across blpairts
         uvp2 = testing.uvpspec_from_data(uvd, [(53, 54), (67, 68)],
                                          spw_ranges=[(20, 30), (60, 90)],
-                                         beam=beam, r_params = r_params)
+                                         beam=beam)
         out = uvpspec.combine_uvpspec([uvp1, uvp2], verbose=False)
         nt.assert_equal(out.Nblpairs, 4)
         nt.assert_equal(out.Nbls, 5)
@@ -623,6 +591,68 @@ class Test_UVPSpec(unittest.TestCase):
         uvp4b.polpair_array[0] = 1414
         out = uvpspec.combine_uvpspec([uvp4, uvp4b], verbose=False)
 
+        # test history adding
+        uvp_a = copy.deepcopy(uvp1)
+        uvp_b = copy.deepcopy(uvp1)
+        uvp_b.polpair_array[0] = 1414
+        uvp_a.history = 'batwing'
+        uvp_b.history = 'foobar'
+
+        # w/ merge
+        out = uvpspec.combine_uvpspec([uvp_a, uvp_b], merge_history=True, verbose=False)
+        assert 'batwing' in out.history and 'foobar' in out.history
+        # w/o merge
+        out = uvpspec.combine_uvpspec([uvp_a, uvp_b], merge_history=False, verbose=False)
+        assert 'batwing' in out.history and not 'foobar' in out.history
+
+    def test_combine_uvpspec_r_params(self):
+        # setup uvp build
+        uvd = UVData()
+        uvd.read_miriad(os.path.join(DATA_PATH, 'zen.even.xx.LST.1.28828.uvOCRSA'))
+        beam = pspecbeam.PSpecBeamUV(os.path.join(DATA_PATH,
+                                               "HERA_NF_dipole_power.beamfits"))
+        bls = [(37, 38), (38, 39), (52, 53)]
+
+        rp = {'filter_centers':[0.],
+              'filter_widths':[250e-9],
+              'filter_factors':[1e-9]}
+
+        r_params = {}
+
+        for bl in bls:
+            key1 =  bl + ('xx',)
+            r_params[key1] = rp
+
+        # create an r_params copy with inconsistent weighting to test
+        # error case
+        r_params_inconsistent = copy.deepcopy(r_params)
+        r_params[key1]['filter_widths'] = [100e-9]
+
+        uvp1 = testing.uvpspec_from_data(uvd, bls,
+                                         spw_ranges=[(20, 30), (60, 90)],
+                                         beam=beam, r_params=r_params)
+
+        # test failure due to overlapping data
+        uvp2 = copy.deepcopy(uvp1)
+        nt.assert_raises(AssertionError, uvpspec.combine_uvpspec, [uvp1, uvp2])
+
+        # test success across pol
+        uvp2.polpair_array[0] = 1414
+
+        # test errors when combining with pspecs without r_params
+        uvp3 = copy.deepcopy(uvp2)
+        uvp3.r_params = ''
+        nt.assert_raises(ValueError, uvpspec.combine_uvpspec, [uvp1, uvp3])
+
+        # combining multiple uvp objects without r_params should run fine
+        uvp4 = copy.deepcopy(uvp1)
+        uvp4.r_params = ''
+        uvpspec.combine_uvpspec([uvp3, uvp4])
+
+        # now test error case with inconsistent weightings.
+        uvp5 = copy.deepcopy(uvp2)
+        uvp5.r_params = uvputils.compress_r_params(r_params_inconsistent)
+        nt.assert_raises(ValueError, uvpspec.combine_uvpspec, [uvp1, uvp5])
 
     def test_combine_uvpspec_std(self):
         # setup uvp build

--- a/hera_pspec/uvpspec.py
+++ b/hera_pspec/uvpspec.py
@@ -1940,7 +1940,7 @@ class UVPSpec(object):
         return scalar
 
 
-def combine_uvpspec(uvps, verbose=True):
+def combine_uvpspec(uvps, merge_history=True, verbose=True):
     """
     Combine (concatenate) multiple UVPSpec objects into a single object,
     combining along one of either spectral window [spw], baseline-pair-times
@@ -1954,6 +1954,8 @@ def combine_uvpspec(uvps, verbose=True):
     ----------
     uvps : list
         A list of UVPSpec objects to combine.
+    merge_history : bool
+        If True, merge all histories. Else use zeroth object's history.
 
     Returns
     -------
@@ -2227,7 +2229,10 @@ def combine_uvpspec(uvps, verbose=True):
         u.bl_vecs.append(uvps[l].bl_vecs[h])
     u.bl_vecs = np.array(u.bl_vecs)
     u.Ntimes = len(np.unique(u.time_avg_array))
-    u.history = "".join([uvp.history for uvp in uvps])
+    if merge_history:
+        u.history = "".join([uvp.history for uvp in uvps])
+    else:
+        u.history == uvps[0].history
     u.labels = np.array(u.labels, np.str)
 
     u.r_params = uvputils.compress_r_params(r_params)

--- a/hera_pspec/uvpspec.py
+++ b/hera_pspec/uvpspec.py
@@ -2232,7 +2232,7 @@ def combine_uvpspec(uvps, merge_history=True, verbose=True):
     if merge_history:
         u.history = "".join([uvp.history for uvp in uvps])
     else:
-        u.history == uvps[0].history
+        u.history = uvps[0].history
     u.labels = np.array(u.labels, np.str)
 
     u.r_params = uvputils.compress_r_params(r_params)

--- a/hera_pspec/uvpspec.py
+++ b/hera_pspec/uvpspec.py
@@ -1026,7 +1026,7 @@ class UVPSpec(object):
         assert spw_ind in self.spw_freq_array and spw_ind in self.spw_dly_array, \
             "spw {} not found in data".format(spw_ind)
         assert blpair in self.blpair_array, \
-            "blpair {} not found in data, blpairs are: {}".format(blpair, self.blpair_array)
+            "blpair {} not found in data".format(blpair)
         assert polpair in self.polpair_array, \
             "polpair {} not found in data".format(polpair)
 


### PR DESCRIPTION
Adds feature to optionally combine histories in `uvpspec.combine_uvpspec`. In the pspec pipeline, for example, keeping this on excessively duplicates the output file history, so we need a way to turn this off, which this PR does.

This also refactors the `combine_uvpspec` test where the `r_params` testing was thrown into the middle of the existing test: this PR pulls that apart into its own test for the sake of "atomic"-ness