### PR TITLE
Fixes wedge plotting issue w/ baseline ordering

### DIFF
--- a/hera_pspec/grouping.py
+++ b/hera_pspec/grouping.py
@@ -7,6 +7,7 @@ from astropy import stats as astats
 import os
 
 from . import utils, version, uvpspec_utils as uvputils
+from .uvpspec import _ordered_unique
 
 def group_baselines(bls, Ngroups, keep_remainder=False, randomize=False,
                     seed=None):
@@ -196,10 +197,10 @@ def average_spectra(uvp_in, blpair_groups=None, time_avg=False,
             blpair_groups = new_blpair_grps
     else:
         # If not, each baseline pair is its own group
-        blpair_groups = [[blp] for blp in np.unique(uvp.blpair_array)]
+        blpair_groups = [[blp] for blp in _ordered_unique(uvp.blpair_array)]
         assert blpair_weights is None, "Cannot specify blpair_weights if "\
                                        "blpair_groups is None."
-        blpair_weights = [[1.,] for blp in np.unique(uvp.blpair_array)]
+        blpair_weights = [[1.,] for blp in _ordered_unique(uvp.blpair_array)]
 
     # Print warning if a blpair appears more than once in all of blpair_groups
     all_blpairs = [item for sublist in blpair_groups for item in sublist]
@@ -641,12 +642,12 @@ def bootstrap_average_blpairs(uvp_list, blpair_groups, time_avg=False,
                                                pols=True, inplace=False)
 
     # Loop over UVPSpec objects, looking for available blpairs in each
-    avail_blpairs = [np.unique(uvp.blpair_array) for uvp in uvp_list]
-    all_avail_blpairs = np.unique([blp for blplist in avail_blpairs
+    avail_blpairs = [_ordered_unique(uvp.blpair_array) for uvp in uvp_list]
+    all_avail_blpairs = _ordered_unique([blp for blplist in avail_blpairs
                                        for blp in blplist])
 
     # Check that all requested blpairs exist in at least one UVPSpec object
-    all_req_blpairs = np.unique([blp for grp in blpair_groups for blp in grp])
+    all_req_blpairs = _ordered_unique([blp for grp in blpair_groups for blp in grp])
     missing = []
     for blp in all_req_blpairs:
         if blp not in all_avail_blpairs: missing.append(blp)
@@ -668,7 +669,13 @@ def bootstrap_average_blpairs(uvp_list, blpair_groups, time_avg=False,
     for grp in blpair_groups:
 
         # Find which blpairs in this group are available in each UVPSpec object
-        avail = [np.intersect1d(grp, blp_list) for blp_list in avail_blpairs]
+        avail = []
+        for blp_list in avail_blpairs:
+            # np.intersect1d inherently sorts the output array, which can mess up blpair ordering
+            indices = np.intersect1d(grp, blp_list, return_indices=True)[1]
+            # this keeps inherent ordering of input blpair_groups
+            avail.append(np.array(grp)[np.unique(indices)])
+
         avail_flat = [blp for lst in avail for blp in lst]
         num_avail = len(avail_flat)
 

--- a/hera_pspec/plot.py
+++ b/hera_pspec/plot.py
@@ -384,7 +384,7 @@ def delay_waterfall(uvp, blpairs, spw, pol, component='abs-real',
 
     # assert component
     assert component in ['real', 'abs', 'imag', 'abs-real', 'abs-imag'], "Can't parse specified component {}".format(component)
-    fix_negval = compoent in ['real', 'imag'] and log
+    fix_negval = component in ['real', 'imag'] and log
 
     # Add ungrouped baseline-pairs into a group of their own (expected by the
     # averaging routines)
@@ -756,7 +756,7 @@ def delay_wedge(uvp, spw, pol, blpairs=None, times=None, fold=False, delay=True,
     assert isinstance(uvp, uvpspec.UVPSpec), "input uvp must be a UVPSpec object"
     assert isinstance(spw, (int, np.integer))
     assert isinstance(pol, (int, np.integer, tuple))
-    fix_negval = compoent in ['real', 'imag'] and log10
+    fix_negval = component in ['real', 'imag'] and log10
 
     # check pspec units for little h
     little_h = 'h^-3' in uvp.norm_units

--- a/hera_pspec/plot.py
+++ b/hera_pspec/plot.py
@@ -511,18 +511,15 @@ def delay_waterfall(uvp, blpairs, spw, pol, component='abs-real',
     # Get LST range: setting y-ticks is tricky due to LST wrapping...
     y = uvp_plt.lst_avg_array[
             uvp_plt.key_to_indices(list(waterfall.keys())[0])[1] ]
+    y = np.unwrap(y)
+    if y[0] > np.pi:
+        # if start is closer to 2pi than 0, lower axis by an octave
+        y -= 2 * np.pi
     if lst_in_hrs:
         lst_units = "Hr"
-        y = np.around(y * 24 / (2*np.pi), 2)
+        y *= 24 / (2 * np.pi)
     else:
         lst_units = "rad"
-        y = np.around(y, 3)
-    Ny = len(y)
-    if Ny <= 10:
-        Ny_thin = 1
-    else:
-        Ny_thin = int(round(Ny / 10.0))
-    Nx = len(x)
 
     # get baseline vectors
     blvecs = dict(zip([uvp_plt.bl_to_antnums(bl) for bl in uvp_plt.bl_array], uvp_plt.get_ENU_bl_vecs()))
@@ -561,7 +558,7 @@ def delay_waterfall(uvp, blpairs, spw, pol, component='abs-real',
             # plot waterfall
             cax = ax.matshow(waterfall[key], cmap=cmap, aspect='auto', 
                              vmin=vmin, vmax=vmax, 
-                             extent=[np.min(x), np.max(x), Ny, 0])
+                             extent=[x[0], x[-1], y[-1], y[0]])
 
             # ax config
             ax.xaxis.set_ticks_position('bottom')
@@ -588,8 +585,6 @@ def delay_waterfall(uvp, blpairs, spw, pol, component='abs-real',
             # configure left-column plots
             if j == 0:
                 # set yticks
-                ax.set_yticks(np.arange(Ny)[::Ny_thin])
-                ax.set_yticklabels(y[::Ny_thin])
                 ax.set_ylabel(r"LST [{}]".format(lst_units), fontsize=16)
             else:
                 ax.set_yticklabels([])

--- a/hera_pspec/plot.py
+++ b/hera_pspec/plot.py
@@ -296,12 +296,12 @@ def delay_spectrum(uvp, blpairs, spw, pol, average_blpairs=False,
         return fig
 
 
-def delay_waterfall(uvp, blpairs, spw, pol, component='real', 
+def delay_waterfall(uvp, blpairs, spw, pol, component='abs-real', 
                     average_blpairs=False, fold=False, delay=True, 
                     deltasq=False, log=True, lst_in_hrs=True,
                     vmin=None, vmax=None, cmap='YlGnBu', axes=None, 
                     figsize=(14, 6), force_plot=False, times=None, 
-                    title_type='blpair'):
+                    title_type='blpair', colorbar=True):
     """
     Plot a 1D delay spectrum waterfall (or spectra) for a group of baselines.
     
@@ -318,8 +318,9 @@ def delay_waterfall(uvp, blpairs, spw, pol, component='real',
         Which spectral window and polarization to plot.
     
     component : str
-        Component of complex spectra to plot, options=['abs', 'real', 'imag'].
-        Default: 'real'.
+        Component of complex spectra to plot, options=['abs', 'real', 'imag', 'abs-real', 'abs-imag'].
+        abs-real is abs(real(data)), whereas 'real' is real(data)
+        Default: 'abs-real'. 
 
     average_blpairs : bool, optional
         If True, average over the baseline pairs within each group.
@@ -370,6 +371,9 @@ def delay_waterfall(uvp, blpairs, spw, pol, component='real',
         blpair : "bls: {bl1} x {bl2}"
         blvec : "bl len {len} m & ang {ang} deg" 
 
+    colorbar : bool, optional
+        Whether to make a colorbar. Default: True
+
     Returns
     -------
     fig : matplotlib.pyplot.Figure
@@ -379,7 +383,8 @@ def delay_waterfall(uvp, blpairs, spw, pol, component='real',
     import matplotlib.pyplot as plt
 
     # assert component
-    assert component in ['real', 'abs', 'imag'], "Can't parse specified component {}".format(component)
+    assert component in ['real', 'abs', 'imag', 'abs-real', 'abs-imag'], "Can't parse specified component {}".format(component)
+    fix_negval = compoent in ['real', 'imag'] and log
 
     # Add ungrouped baseline-pairs into a group of their own (expected by the
     # averaging routines)
@@ -444,13 +449,26 @@ def delay_waterfall(uvp, blpairs, spw, pol, component='real',
             # set flagged power data to nan
             flags = np.isclose(uvp_plt.get_integrations(key), 0.0)
             power[flags, :] = np.nan
+
             # get component
             if component == 'abs':
-                waterfall[key] = np.abs(power)
+                power = np.abs(power)
             elif component == 'real':
-                waterfall[key] = np.real(power)
+                power = np.real(power)
+            elif component == 'abs-real':
+                power = np.abs(np.real(power))
             elif component == 'imag':
-                waterfall[key] = np.imag(power)
+                power = np.imag(power)
+            elif component == 'abs-imag':
+                power = np.abs(np.real(power))
+
+            # if real or imag and log is True, set negative values to near zero
+            # this is done so that one can use cmap.set_under() and cmap.set_bad() separately
+            if fix_negval:
+                power[power < 0] = np.abs(power).min() * 1e-6 + 1e-10
+
+            # assign to waterfall
+            waterfall[key] = power
 
             # If blpairs were averaged, only the first blpair in the group 
             # exists any more (so skip the rest)
@@ -557,8 +575,15 @@ def delay_waterfall(uvp, blpairs, spw, pol, component='real',
                     ax.set_title("bl len {len:0.2f} m & {ang:0.0f} deg".format(len=lens[0], ang=angs[0]), y=1)
 
             # set colorbar
-            cbar = ax.get_figure().colorbar(cax, ax=ax)
-            cbar.ax.tick_params(labelsize=14)
+            if colorbar:
+                if fix_negval:
+                    cb_extend = 'min'
+                else:
+                    cb_extend = 'neither'
+                cbar = ax.get_figure().colorbar(cax, ax=ax, extend=cb_extend)
+                cbar.ax.tick_params(labelsize=14)
+                if fix_negval:
+                    cbar.ax.set_title("$< 0$",y=-0.05, fontsize=16)
 
             # configure left-column plots
             if j == 0:
@@ -598,7 +623,7 @@ def delay_waterfall(uvp, blpairs, spw, pol, component='real',
 
 
 def delay_wedge(uvp, spw, pol, blpairs=None, times=None, fold=False, delay=True,
-                rotate=False, component='real', log10=True, loglog=False,
+                rotate=False, component='abs-real', log10=True, loglog=False,
                 red_tol=1.0, center_line=False, horizon_lines=False,
                 title=None, ax=None, cmap='viridis', figsize=(8, 6),
                 deltasq=False, colorbar=False, cbax=None, vmin=None, vmax=None,
@@ -646,8 +671,9 @@ def delay_wedge(uvp, spw, pol, blpairs=None, times=None, fold=False, delay=True,
         Default: False
 
     component : str, optional
-        Component of complex spectra to plot. Options=['real', 'imag', 'abs']
-        Default: 'real'.
+        Component of complex spectra to plot. Options=['real', 'imag', 'abs', 'abs-real', 'abs-imag']
+        abs-real is abs(real(data)), whereas 'real' is real(data)
+        Default: 'abs-real'.
 
     log10 : bool, optional
         If True, take log10 of data before plotting. Default: True
@@ -730,6 +756,7 @@ def delay_wedge(uvp, spw, pol, blpairs=None, times=None, fold=False, delay=True,
     assert isinstance(uvp, uvpspec.UVPSpec), "input uvp must be a UVPSpec object"
     assert isinstance(spw, (int, np.integer))
     assert isinstance(pol, (int, np.integer, tuple))
+    fix_negval = compoent in ['real', 'imag'] and log10
 
     # check pspec units for little h
     little_h = 'h^-3' in uvp.norm_units
@@ -791,22 +818,31 @@ def delay_wedge(uvp, spw, pol, blpairs=None, times=None, fold=False, delay=True,
         psunits = psunits.replace("beam normalization not specified", 
                                  r"{\rm unnormed}")
 
-    # get data casting
+    # get data with shape (Nblpairs, Ndlys)
+    data = [uvp.get_data((spw, blp, pol)).squeeze() for blp in blpairs]
+
+    # get component
     if component == 'real':
-        cast = np.real
+        data = np.real(data)
+    elif component == 'abs-real':
+        data = np.abs(np.real(data))
     elif component == 'imag':
-        cast = np.imag
+        data = np.imag(data)
+    elif component == 'abs-imag':
+        data = np.abs(np.imag(data))
     elif component == 'abs':
-        cast = np.abs
+        data = np.abs(data)
     else:
         raise ValueError("Did not understand component {}".format(component))
 
-    # get data with shape (Nblpairs, Ndlys)
-    data = cast([uvp.get_data((spw, blp, pol)).squeeze() for blp in blpairs])
+    # if real or imag and log is True, set negative values to near zero
+    # this is done so that one can use cmap.set_under() and cmap.set_bad() separately
+    if fix_negval:
+        data[data < 0] = np.abs(data).min() * 1e-6 + 1e-10
 
     # take log10
     if log10:
-        data = np.log10(np.abs(data))
+        data = np.log10(data)
 
     # loglog
     if loglog:
@@ -848,9 +884,13 @@ def delay_wedge(uvp, spw, pol, blpairs=None, times=None, fold=False, delay=True,
 
     # Add colorbar
     if colorbar:
+        if fix_negval:
+            cb_extend = 'min'
+        else:
+            cb_extend = 'neither'
         if cbax is None:
             cbax = ax
-        cbar = fig.colorbar(cax, ax=cbax)
+        cbar = fig.colorbar(cax, ax=cbax, extend=cb_extend)
         if deltasq:
             p = "\Delta^2"
         else:
@@ -864,6 +904,8 @@ def delay_wedge(uvp, spw, pol, blpairs=None, times=None, fold=False, delay=True,
         else:
             psunits = r"${}\ [{}]$".format(p, psunits)
         cbar.set_label(psunits, fontsize=14)
+        if fix_negval:
+            cbar.ax.set_title("$< 0$",y=-0.05, fontsize=16)
 
     # Configure tick labels
     if delay:

--- a/hera_pspec/pspecdata.py
+++ b/hera_pspec/pspecdata.py
@@ -348,7 +348,7 @@ class PSpecData(object):
         """
         #FIXME: Fix this to enable label keys
         # get iterable
-        key = uvutils.get_iterable(key)
+        key = uvutils._get_iterable(key)
         if isinstance(key, str):
             key = (key,)
 

--- a/hera_pspec/tests/test_uvpspec.py
+++ b/hera_pspec/tests/test_uvpspec.py
@@ -80,15 +80,15 @@ class Test_UVPSpec(unittest.TestCase):
         nt.assert_equal(d.shape, (10, 30))
         # test get_blpairs
         blps = self.uvp.get_blpairs()
-        nt.assert_equal(blps, [((1, 2), (1, 2)), ((1, 3), (1, 3)), ((2, 3), (2, 3))])
+        nt.assert_equal(blps, [((1, 2), (1, 2)), ((2, 3), (2, 3)), ((1, 3), (1, 3))])
         # test get_polpairs
         polpairs = self.uvp.get_polpairs()
         nt.assert_equal(polpairs, [('xx', 'xx')])
         # test get all keys
         keys = self.uvp.get_all_keys()
-        nt.assert_equal(keys, [(0, ((1, 2), (1, 2)), ('xx','xx')),
-                               (0, ((1, 3), (1, 3)), ('xx','xx')),
-                               (0, ((2, 3), (2, 3)), ('xx','xx'))])
+        nt.assert_equal(keys, [(0, ((1, 2), (1, 2)), ('xx', 'xx')),
+                               (0, ((2, 3), (2, 3)), ('xx', 'xx')),
+                               (0, ((1, 3), (1, 3)), ('xx', 'xx'))])
         # test omit_flags
         self.uvp.integration_array[0][self.uvp.blpair_to_indices(((1, 2), (1, 2)))[:2]] = 0.0
         nt.assert_equal(self.uvp.get_integrations((0, ((1, 2), (1, 2)), ('xx','xx')), omit_flags=True).shape, (8,))

--- a/hera_pspec/uvpspec.py
+++ b/hera_pspec/uvpspec.py
@@ -395,7 +395,7 @@ class UVPSpec(object):
         blp_avg_sep = np.empty(self.Nblpairts, np.float)
 
         # construct blpair_bls
-        blpairs = _unique_ordered(self.blpair_array)
+        blpairs = _ordered_unqique(self.blpair_array)
         bl1 = np.floor(blpairs / 1e6)
         blpair_bls = np.vstack([bl1, blpairs - bl1*1e6]).astype(np.int32).T
 
@@ -477,7 +477,7 @@ class UVPSpec(object):
         Returns a list of all blpair tuples in the data_array.
         """
         return [self.blpair_to_antnums(blp)
-                for blp in _unique_ordered(self.blpair_array)]
+                for blp in _ordered_unqique(self.blpair_array)]
 
     def get_polpairs(self):
         """
@@ -1702,7 +1702,7 @@ class UVPSpec(object):
 
         # get blpairs
         if blpairs is None:
-            blpairs = _unique_ordered(self.blpair_array)
+            blpairs = _ordered_unqique(self.blpair_array)
         elif isinstance(blpairs[0], tuple):
             blpairs = [self.antnums_to_blpair(blp) for blp in blpairs]
 

--- a/hera_pspec/uvpspec.py
+++ b/hera_pspec/uvpspec.py
@@ -2411,7 +2411,7 @@ def get_uvp_overlap(uvps, just_meta=True, verbose=True):
 
 def _ordered_unique(arr):
     """
-    Get the unique of an array while preserving order.
+    Get the unique elements of an array while preserving order.
     """
     arr = np.asarray(arr)
     _, idx = np.unique(arr, return_index=True)

--- a/hera_pspec/uvpspec.py
+++ b/hera_pspec/uvpspec.py
@@ -395,7 +395,7 @@ class UVPSpec(object):
         blp_avg_sep = np.empty(self.Nblpairts, np.float)
 
         # construct blpair_bls
-        blpairs = _ordered_unqique(self.blpair_array)
+        blpairs = _ordered_unique(self.blpair_array)
         bl1 = np.floor(blpairs / 1e6)
         blpair_bls = np.vstack([bl1, blpairs - bl1*1e6]).astype(np.int32).T
 
@@ -477,7 +477,7 @@ class UVPSpec(object):
         Returns a list of all blpair tuples in the data_array.
         """
         return [self.blpair_to_antnums(blp)
-                for blp in _ordered_unqique(self.blpair_array)]
+                for blp in _ordered_unique(self.blpair_array)]
 
     def get_polpairs(self):
         """
@@ -1702,7 +1702,7 @@ class UVPSpec(object):
 
         # get blpairs
         if blpairs is None:
-            blpairs = _ordered_unqique(self.blpair_array)
+            blpairs = _ordered_unique(self.blpair_array)
         elif isinstance(blpairs[0], tuple):
             blpairs = [self.antnums_to_blpair(blp) for blp in blpairs]
 

--- a/hera_pspec/uvpspec.py
+++ b/hera_pspec/uvpspec.py
@@ -377,7 +377,8 @@ class UVPSpec(object):
     def get_blpair_seps(self):
         """
         For each baseline-pair, get the average baseline separation in ENU
-        frame in meters.
+        frame in meters between its bl1 and bl2. Ordering matches
+        self.get_blpairs()
 
         Returns
         -------
@@ -394,7 +395,7 @@ class UVPSpec(object):
         blp_avg_sep = np.empty(self.Nblpairts, np.float)
 
         # construct blpair_bls
-        blpairs = np.unique(self.blpair_array)
+        blpairs = _unique_ordered(self.blpair_array)
         bl1 = np.floor(blpairs / 1e6)
         blpair_bls = np.vstack([bl1, blpairs - bl1*1e6]).astype(np.int32).T
 
@@ -476,7 +477,7 @@ class UVPSpec(object):
         Returns a list of all blpair tuples in the data_array.
         """
         return [self.blpair_to_antnums(blp)
-                for blp in np.unique(self.blpair_array)]
+                for blp in _unique_ordered(self.blpair_array)]
 
     def get_polpairs(self):
         """
@@ -1701,7 +1702,7 @@ class UVPSpec(object):
 
         # get blpairs
         if blpairs is None:
-            blpairs = np.unique(self.blpair_array)
+            blpairs = _unique_ordered(self.blpair_array)
         elif isinstance(blpairs[0], tuple):
             blpairs = [self.antnums_to_blpair(blp) for blp in blpairs]
 
@@ -2406,3 +2407,12 @@ def get_uvp_overlap(uvps, just_meta=True, verbose=True):
 
     return uvps, concat_ax, unique_spws, unique_blpts, \
            unique_polpairs, static_meta
+
+
+def _ordered_unique(arr):
+    """
+    Get the unique of an array while preserving order.
+    """
+    arr = np.asarray(arr)
+    _, idx = np.unique(arr, return_index=True)
+    return arr[np.sort(idx)]


### PR DESCRIPTION
When wedge plotting sometimes the baseline ordering is mixed up, so the wedge well doesn't really look wedge-like. Realized this happens because in `uvp.get_blpairs()` we do `np.unique()` which automatically resorts the baselines not by their length but by their id, which can mess things up. So I made `uvp.get_blpairs()` do a unique without re-sorting and also enforced this ordering anyways in the wedge plotting function.