### PR TITLE
Band truncation after filtering and consolidated covariance calculations. 

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
   - defaults
 dependencies:
   - aipy>=3.0.0rc2
-  - astropy>=2.0
+  - astropy>=2.0.16
   - h5py
   - matplotlib>=2.0
   - nose

--- a/hera_pspec/pspecdata.py
+++ b/hera_pspec/pspecdata.py
@@ -2159,8 +2159,13 @@ class PSpecData(object):
         \sum_gamma tr[Q^alt_alpha Q^alt_gamma] = N_freq**2
         is something that is true only when N_freqs = N_dlys.
 
-        In general, the result is still independent of alpha, but is
+        If the data weighting is equal to "identity",
+        then the result is independent of alpha, but is
         no longer given by N_freq**2. (Nor is it just N_dlys**2!)
+
+        If the data weighting is not equal to "identity" then
+        we generally need a separate scalar adjustment for each
+        alpha. 
 
         This function uses the state of self.taper in constructing adjustment.
         See PSpecData.pspec for details.
@@ -2184,8 +2189,8 @@ class PSpecData(object):
 
         Returns
         -------
-        adjustment : float
-
+        adjustment : float if the data_weighting is 'identity'
+                     1d array of floats with length spw_Ndlys otherwise.
         """
         if Gv is None: Gv = self.get_G(key1, key2)
         if Hv is None: Hv = self.get_H(key1, key2, sampling)

--- a/hera_pspec/pspecdata.py
+++ b/hera_pspec/pspecdata.py
@@ -67,7 +67,7 @@ class PSpecData(object):
         # r_params is a dictionary that stores parameters for
         # parametric R matrices.
         self.r_params = {}
-        self.r_params['filter_extension'] = [0, 0]
+        self.filter_extension = (0, 0)
         self.cov_regularization = 0.
         # set data weighting to identity by default
         # and taper to none by default
@@ -479,8 +479,8 @@ class PSpecData(object):
             Array of data from the requested UVData dataset and baseline.
         """
         dset, bl = self.parse_blkey(key)
-        spw = slice(self.spw_range[0]-self.r_params['filter_extension'][0],
-                    self.spw_range[1]+self.r_params['filter_extension'][1])
+        spw = slice(self.spw_range[0]-self.filter_extension[0],
+                    self.spw_range[1]+self.filter_extension[1])
         return self.dsets[dset].get_data(bl).T[spw]
 
     def dx(self, key):
@@ -502,8 +502,8 @@ class PSpecData(object):
         """
         assert isinstance(key, tuple)
         dset,bl = self.parse_blkey(key)
-        spw = slice(self.spw_range[0]-self.r_params['filter_extension'][0],
-                    self.spw_range[1]+self.r_params['filter_extension'][1])
+        spw = slice(self.spw_range[0]-self.filter_extension[0],
+                    self.spw_range[1]+self.filter_extension[1])
         return self.dsets_std[dset].get_data(bl).T[spw]
 
     def w(self, key):
@@ -524,8 +524,8 @@ class PSpecData(object):
             Array of weights for the requested UVData dataset and baseline.
         """
         dset, bl = self.parse_blkey(key)
-        spw = slice(self.spw_range[0]-self.r_params['filter_extension'][0],
-                    self.spw_range[1]+self.r_params['filter_extension'][1])
+        spw = slice(self.spw_range[0]-self.filter_extension[0],
+                    self.spw_range[1]+self.filter_extension[1])
         if self.wgts[dset] is not None:
             return self.wgts[dset].get_data(bl).T[spw]
         else:
@@ -808,7 +808,7 @@ class PSpecData(object):
         dset, bl = self.parse_blkey(key)
         key = (dset,) + (bl,)
         # parse key
-        Rkey = key + (self.data_weighting,) + (self.taper,) + tuple(self.r_params['filter_extension'])
+        Rkey = key + (self.data_weighting,) + (self.taper,) + tuple(self.filter_extension)
         if Rkey not in self._R:
             # form sqrt(taper) matrix
             if self.taper == 'none':
@@ -824,7 +824,7 @@ class PSpecData(object):
             # in sqrt for some reason)
             sqrtT[np.isnan(sqrtT)] = 0.0
             sqrtY[np.isnan(sqrtY)] = 0.0
-            fext = self.r_params['filter_extension']
+            fext = self.filter_extension
             #if we want to use a full-band filter, set the R-matrix to filter and then truncate.
             tmat = np.zeros((self.spw_Nfreqs,
                              self.spw_Nfreqs+np.sum(fext)),dtype=complex)
@@ -876,7 +876,7 @@ class PSpecData(object):
         filter_extension=list(filter_extension)
         filter_extension[0] = np.min([self.spw_range[0], filter_extension[0]])#clip extension to not extend beyond data range
         filter_extension[1] = np.min([self.spw_range[1], filter_extension[1]])#clip extension to not extend beyond data range
-        self.r_params['filter_extension'] = filter_extension
+        self.filter_extension = tuple(filter_extension)
 
     def set_weighting(self, data_weighting):
         """
@@ -2134,7 +2134,7 @@ class PSpecData(object):
     def pspec(self, bls1, bls2, dsets, pols, n_dlys=None,
               input_data_weight='identity', norm='I', taper='none',
               sampling=False, little_h=True, spw_ranges=None,
-              baseline_tol=1.0, store_cov=False, verbose=True,
+              baseline_tol=1.0, store_cov=False, verbose=True, filter_extensions=None,
               exact_norm=False, history='', r_params=None, cov_model='empirical'):
         """
         Estimate the delay power spectrum from a pair of datasets contained in
@@ -2229,6 +2229,9 @@ class PSpecData(object):
 
         verbose : bool, optional
             If True, print progress, warnings and debugging info to stdout.
+
+        filter_extensions : list of 2-tuple or 2-list, optional
+            Set number of channels to extend filtering width.
 
         exact_norm : bool, optional
             If True, estimates power spectrum using Q instead of Q_alt
@@ -2354,10 +2357,16 @@ class PSpecData(object):
         # configure spectral window selections
         if spw_ranges is None:
             spw_ranges = [(0, self.Nfreqs)]
-
-        # convert to list if only a tuple was given
         if isinstance(spw_ranges, tuple):
             spw_ranges = [spw_ranges,]
+
+        if filter_extensions is None:
+            filter_extensions = [(0, 0) for m in range(len(spw_ranges))]
+        # convert to list if only a tuple was given
+        if isinstance(filter_extensions, tuple):
+            filter_extensions = [filter_extensions,]
+
+        assert len(spw_ranges) == len(filter_extensions), "must provide same number of spw_ranges as filter_extensions"
 
         # Check that spw_ranges is list of len-2 tuples
         assert np.isclose([len(t) for t in spw_ranges], 2).all(), \
@@ -2414,14 +2423,13 @@ class PSpecData(object):
         sclr_arr = []
         blp_arr = []
         bls_arr = []
-
         # Loop over spectral windows
         for i in range(len(spw_ranges)):
             # set spectral range
             if verbose:
                 print( "\nSetting spectral range: {}".format(spw_ranges[i]))
             self.set_spw(spw_ranges[i])
-
+            self.set_filter_extension(filter_extensions[i])
             # set number of delay bins
             self.set_Ndlys(n_dlys[i])
 
@@ -2966,7 +2974,7 @@ def pspec_run(dsets, filename, dsets_std=None, cals=None, cal_flag=True,
               beam=None, cosmo=None, interleave_times=False, rephase_to_dset=None,
               trim_dset_lsts=False, broadcast_dset_flags=True,
               time_thresh=0.2, Jy2mK=False, overwrite=True,
-              file_type='miriad', verbose=True, store_cov=False,
+              file_type='miriad', verbose=True, store_cov=False, filter_extensions=None,
               history='', r_params=None, tsleep=0.1, maxiter=1, cov_model='empirical'):
     """
     Create a PSpecData object, run OQE delay spectrum estimation and write
@@ -3120,6 +3128,9 @@ def pspec_run(dsets, filename, dsets_std=None, cals=None, cal_flag=True,
     store_cov : boolean, optional
         If True, solve for covariance between bandpowers and store in
         output UVPSpec object.
+
+    filter_extensions : list of 2-tuple or 2-list, optional
+        Set number of channels to extend filtering width.
 
     overwrite : boolean
         If True, overwrite outputs if they exist on disk.
@@ -3398,7 +3409,7 @@ def pspec_run(dsets, filename, dsets_std=None, cals=None, cal_flag=True,
                        spw_ranges=spw_ranges, n_dlys=n_dlys, r_params = r_params,
                        store_cov=store_cov, input_data_weight=input_data_weight,
                        norm=norm, taper=taper, history=history, verbose=verbose,
-                       cov_model=cov_model)
+                       cov_model=cov_model, filter_extensions=filter_extensions)
 
         # Store output
         psname = '{}_x_{}{}'.format(dset_labels[dset_idxs[0]],
@@ -3460,6 +3471,7 @@ def get_pspec_run_argparser():
     a.add_argument("--cov_model", default='empirical', type=str, help="Model for computing covariance, currently supports empirical or dsets")
     a.add_argument("--psname_ext", default='', type=str, help="Extension for pspectra name in PSpecContainer.")
     a.add_argument("--verbose", default=False, action='store_true', help="Report feedback to standard output.")
+    a.add_argument("--filter_extensions", default=None, type=list_of_int_tuples, help="List of spw filter extensions wrapped in quotes. Ex:20 20, 40 40' ->> [(20, 20), (40, 40), ...]")
     return a
 
 

--- a/hera_pspec/pspecdata.py
+++ b/hera_pspec/pspecdata.py
@@ -867,7 +867,7 @@ class PSpecData(object):
                     raise ValueError("r_param not set for %s!"%str(r_param_key))
                 r_params = self.r_params[r_param_key]
                 if not 'filter_centers' in r_params or\
-                   not 'filter_widths' in r_params or\
+                   not 'filter_half_widths' in r_params or\
                    not  'filter_factors' in r_params:
                        raise ValueError("filtering parameters not specified!")
                 #This line retrieves a the psuedo-inverse of a lazy covariance
@@ -879,7 +879,7 @@ class PSpecData(object):
                                     df=np.median(np.diff(self.freqs)),
                                     filter_centers=r_params['filter_centers'],
                                     filter_half_widths=r_params['filter_half_widths'],
-                                    filter_factors=r_params['filter_factors']) * sqrtY) * sqrtT
+                                    filter_factors=r_params['filter_factors']) * sqrtY))
 
         return self._R[Rkey]
 

--- a/hera_pspec/pspecdata.py
+++ b/hera_pspec/pspecdata.py
@@ -899,6 +899,10 @@ class PSpecData(object):
         assert isinstance(filter_extension[0], int) and\
                isinstance(filter_extension[1], int), "filter extension must contain only integers"
         filter_extension=list(filter_extension)
+        if filter_extension[0] > self.spw_range[0]:
+            raise Warning("filter_extension[0] exceeds data spw_range. Defaulting to spw_range[0]!")
+        if filter_extension[1] > self.Nfreqs - self.spw_range[1]:
+            raise Warning("filter_extension[1] exceeds channels between spw_range[1] and Nfreqs. Defaulting to Nfreqs-spw_range[1]!")
         filter_extension[0] = np.min([self.spw_range[0], filter_extension[0]])#clip extension to not extend beyond data range
         filter_extension[1] = np.min([self.Nfreqs - self.spw_range[1], filter_extension[1]])#clip extension to not extend beyond data range
         self.filter_extension = tuple(filter_extension)

--- a/hera_pspec/pspecdata.py
+++ b/hera_pspec/pspecdata.py
@@ -900,7 +900,7 @@ class PSpecData(object):
                isinstance(filter_extension[1], int), "filter extension must contain only integers"
         filter_extension=list(filter_extension)
         filter_extension[0] = np.min([self.spw_range[0], filter_extension[0]])#clip extension to not extend beyond data range
-        filter_extension[1] = np.min([self.spw_range[1], filter_extension[1]])#clip extension to not extend beyond data range
+        filter_extension[1] = np.min([self.Nfreqs - self.spw_range[1], filter_extension[1]])#clip extension to not extend beyond data range
         self.filter_extension = tuple(filter_extension)
 
     def set_weighting(self, data_weighting):

--- a/hera_pspec/pspecdata.py
+++ b/hera_pspec/pspecdata.py
@@ -695,7 +695,7 @@ class PSpecData(object):
         key = (dset,) + (bl,)
 
         if key not in self._I:
-            self._I[key] = np.identity(self.spw_Nfreqs)
+            self._I[key] = np.identity(self.spw_Nfreqs + np.sum(self.filter_extension))
         return self._I[key]
 
     def iC(self, key, model='empirical'):

--- a/hera_pspec/pspecdata.py
+++ b/hera_pspec/pspecdata.py
@@ -2740,6 +2740,7 @@ class PSpecData(object):
         uvp.data_array = data_array
         if store_cov:
             uvp.cov_array = cov_array
+            uvp.cov_model = cov_model
         uvp.integration_array = integration_array
         uvp.wgt_array = wgt_array
         uvp.nsample_array = dict(
@@ -3441,7 +3442,7 @@ def get_pspec_run_argparser():
     a.add_argument("--bl_len_range", default=(0, 1e10), nargs='+', type=float, help="If blpairs is not provided, limit the baselines used based on their minimum and maximum length in meters.")
     a.add_argument("--bl_deg_range", default=(0, 180), nargs='+', type=float, help="If blpairs is not provided, limit the baseline used based on a min and max angle cut in ENU frame in degrees.")
     a.add_argument("--bl_error_tol", default=1.0, type=float, help="If blpairs is not provided, this is the error tolerance in forming redundant baseline groups in meters.")
-    a.add_argument("--store_cov", default=False, action='store_true', help="Compute and store covariance of bandpowers given dsets_std files.")
+    a.add_argument("--store_cov", default=False, action='store_true', help="Compute and store covariance of bandpowers given dsets_std files or empirical covarianc.")
     a.add_argument("--overwrite", default=False, action='store_true', help="Overwrite output if it exists.")
     a.add_argument("--cov_model", default='empirical', type=str, help="Model for computing covariance, currently supports empirical or dsets")
     a.add_argument("--psname_ext", default='', type=str, help="Extension for pspectra name in PSpecContainer.")

--- a/hera_pspec/pspecdata.py
+++ b/hera_pspec/pspecdata.py
@@ -73,7 +73,7 @@ class PSpecData(object):
         # and taper to none by default
         self.data_weighting = 'identity'
         self.taper = 'none'
-        self.symmetric_taper = False
+        self.symmetric_taper = True
         # Set all weights to None if wgts=None
         if wgts is None:
             wgts = [None for dset in dsets]
@@ -857,7 +857,7 @@ class PSpecData(object):
         key = (dset,) + (bl,)
         # parse key
         Rkey = key + (self.data_weighting,) + (self.taper,) + tuple(self.filter_extension,)\
-                   + (self.spw_Nfreqs,)
+                   + (self.spw_Nfreqs,) + (self.symmetric_taper,)
         if Rkey not in self._R:
             # form sqrt(taper) matrix
             if self.taper == 'none':
@@ -955,7 +955,7 @@ class PSpecData(object):
             filter_extensions will be clipped to not extend beyond data range.
         """
         if self.symmetric_taper and not filter_extension[0] == 0 and not filter_extension[1]==0:
-            raise Warning("You cannot set filter extensions greater then zero when symmetric_taper==True! Setting symmetric_taper==False!")
+            raise_warning("You cannot set filter extensions greater then zero when symmetric_taper==True! Setting symmetric_taper==False!")
             self.symmetric_taper = False
         assert isinstance(filter_extension, (list, tuple)), "filter_extension must a tuple or list"
         assert len(filter_extension) == 2, "filter extension must be length 2"

--- a/hera_pspec/pspecdata.py
+++ b/hera_pspec/pspecdata.py
@@ -937,7 +937,7 @@ class PSpecData(object):
             do you want to use a symmetric taper? True or False?
         """
         if use_symmetric_taper and (self.filter_extension[0] > 0 or self.filter_extension[1] > 0):
-            raise Warning("You cannot use a symmetric taper when there are nonzero filter extensions.")
+            raise ValueError("You cannot use a symmetric taper when there are nonzero filter extensions.")
         else:
             self.symmetric_taper = use_symmetric_taper
 

--- a/hera_pspec/pspecdata.py
+++ b/hera_pspec/pspecdata.py
@@ -2307,7 +2307,7 @@ class PSpecData(object):
             set, then error bars are estimated from the data by calculating the
             channel-channel covariance of each baseline over time and
             then applying the appropriate linear transformations to these
-            frequency-domain covariances. 
+            frequency-domain covariances.
 
         verbose : bool, optional
             If True, print progress, warnings and debugging info to stdout.

--- a/hera_pspec/pspecdata.py
+++ b/hera_pspec/pspecdata.py
@@ -2570,7 +2570,8 @@ class PSpecData(object):
                     # Check that number of non-zero weight chans >= n_dlys
                     key1_dof = np.sum(~np.isclose(self.Y(key1).diagonal(), 0.0))
                     key2_dof = np.sum(~np.isclose(self.Y(key2).diagonal(), 0.0))
-                    if key1_dof < self.spw_Ndlys or key2_dof < self.spw_Ndlys:
+                    if key1_dof - np.sum(self.filter_extension) < self.spw_Ndlys\
+                     or key2_dof - np.sum(self.filter_extension) < self.spw_Ndlys:
                         if verbose:
                             print("WARNING: Number of unflagged chans for key1 "
                                   "and/or key2 < n_dlys\n which may lead to "

--- a/hera_pspec/pspecdata.py
+++ b/hera_pspec/pspecdata.py
@@ -67,6 +67,7 @@ class PSpecData(object):
         # r_params is a dictionary that stores parameters for
         # parametric R matrices.
         self.r_params = {}
+        self.r_params['filter_extension'] = [0, 0]
         self.cov_regularization = 0.
         # set data weighting to identity by default
         # and taper to none by default
@@ -478,7 +479,8 @@ class PSpecData(object):
             Array of data from the requested UVData dataset and baseline.
         """
         dset, bl = self.parse_blkey(key)
-        spw = slice(self.spw_range[0], self.spw_range[1])
+        spw = slice(self.spw_range[0]-self.r_params['filter_extension'][0],
+                    self.spw_range[1]+self.r_params['filter_extension'][1])
         return self.dsets[dset].get_data(bl).T[spw]
 
     def dx(self, key):
@@ -500,8 +502,8 @@ class PSpecData(object):
         """
         assert isinstance(key, tuple)
         dset,bl = self.parse_blkey(key)
-        spw = slice(self.spw_range[0], self.spw_range[1])
-
+        spw = slice(self.spw_range[0]-self.r_params['filter_extension'][0],
+                    self.spw_range[1]+self.r_params['filter_extension'][1])
         return self.dsets_std[dset].get_data(bl).T[spw]
 
     def w(self, key):
@@ -522,8 +524,8 @@ class PSpecData(object):
             Array of weights for the requested UVData dataset and baseline.
         """
         dset, bl = self.parse_blkey(key)
-        spw = slice(self.spw_range[0], self.spw_range[1])
-
+        spw = slice(self.spw_range[0]-self.r_params['filter_extension'][0],
+                    self.spw_range[1]+self.r_params['filter_extension'][1])
         if self.wgts[dset] is not None:
             return self.wgts[dset].get_data(bl).T[spw]
         else:
@@ -805,22 +807,8 @@ class PSpecData(object):
         assert isinstance(key, tuple)
         dset, bl = self.parse_blkey(key)
         key = (dset,) + (bl,)
-        r_param_key = (self.data_weighting,) + key
-        if not r_param_key in self.r_params:
-            r_params = {}
-        else:
-            r_params = self.r_params[r_param_key]
-        #Allows for truncation after filtering and before Fourier transform
-        #to be encoded in R-params. Provides better signal loss properties and
-        #enables jackknifes between independent bands.
-        if not 'truncation_window' in r_params:
-            fstart = self.freqs[self.spw_range[0]]
-            fend = self.freqs[self.spw_range[1]-1]
-        else:
-            fstart = r_params['truncation_window']['start_frequency']
-            fend = r_params['truncation_window']['end_frequency']
         # parse key
-        Rkey = key + (self.data_weighting,) + (self.taper, fstart, fend)
+        Rkey = key + (self.data_weighting,) + (self.taper,) + tuple(self.r_params['filter_extension'])
         if Rkey not in self._R:
             # form sqrt(taper) matrix
             if self.taper == 'none':
@@ -836,18 +824,23 @@ class PSpecData(object):
             # in sqrt for some reason)
             sqrtT[np.isnan(sqrtT)] = 0.0
             sqrtY[np.isnan(sqrtY)] = 0.0
-
-            tmat = np.diag((np.logical_and(self.freqs[self.spw_range[0]:self.spw_range[1]]>=fstart,
-                            self.freqs[self.spw_range[0]:self.spw_range[1]]<=fend)).astype(np.complex))
-
+            fext = self.r_params['filter_extension']
+            #if we want to use a full-band filter, set the R-matrix to filter and then truncate.
+            tmat = np.zeros((self.spw_Nfreqs,
+                             self.spw_Nfreqs+np.sum(fext)),dtype=complex)
+            tmat[:,fext[0]:fext[0] + self.spw_Nfreqs] = np.identity(self.spw_Nfreqs,dtype=complex)
             # form R matrix
             if self.data_weighting == 'identity':
-                self._R[Rkey] = np.dot(tmat, sqrtT.T * sqrtY.T * self.I(key) * sqrtY * sqrtT)
+                self._R[Rkey] =  sqrtT.T ** 2. * np.dot(tmat, sqrtY.T * self.I(key) * sqrtY)
 
             elif self.data_weighting == 'iC':
-                self._R[Rkey] = np.dot(tmat, sqrtT.T * sqrtY.T * self.iC(key) * sqrtY * sqrtT)
+                self._R[Rkey] = sqrtT.T ** 2. * np.dot(tmat, sqrtY.T * self.iC(key) * sqrtY )
 
             elif self.data_weighting == 'sinc_downweight':
+                r_param_key = (self.data_weighting,) + key
+                if not r_param_key in self.r_params:
+                    raise ValueError("r_param not set for %s!"%str(r_param_key))
+                r_params = self.r_params[r_param_key]
                 if not 'filter_centers' in r_params or\
                    not 'filter_widths' in r_params or\
                    not  'filter_factors' in r_params:
@@ -856,14 +849,34 @@ class PSpecData(object):
                 #matrix given by dspec.sinc_downweight_mat_inv.
                 # Note that we multiply sqrtY inside of the pinv
                 #to apply flagging weights before taking psuedo inverse.
-                self._R[Rkey] = np.dot(tmat, sqrtT.T * np.linalg.pinv(sqrtY.T * \
-                dspec.sinc_downweight_mat_inv(nchan=self.spw_Nfreqs,
+                self._R[Rkey] = sqrtT.T ** 2. * np.dot(tmat, np.linalg.pinv(sqrtY.T * \
+                dspec.sinc_downweight_mat_inv(nchan=self.spw_Nfreqs + int(np.sum(fext)),
                                     df=np.median(np.diff(self.freqs)),
                                     filter_centers=r_params['filter_centers'],
                                     filter_half_widths=r_params['filter_half_widths'],
                                     filter_factors=r_params['filter_factors']) * sqrtY) * sqrtT
 
         return self._R[Rkey]
+
+    def set_filter_extension(self, filter_extension):
+        """
+        Set extensions to filtering matrix
+
+        Parameters
+        ----------
+        filter_extension: 2-tuple or 2-list
+            must be integers. Specify how many channels below spw_min/max
+            filter will be applied to data.
+            filter_extensions will be clipped to not extend beyond data range.
+        """
+        assert isinstance(filter_extension, (list, tuple)), "filter_extension must a tuple or list"
+        assert len(filter_extension) == 2, "filter extension must be length 2"
+        assert isinstance(filter_extension[0], int) and\
+               isinstance(filter_extension[1], int), "filter extension must contain only integers"
+        filter_extension=list(filter_extension)
+        filter_extension[0] = np.min([self.spw_range[0], filter_extension[0]])#clip extension to not extend beyond data range
+        filter_extension[1] = np.min([self.spw_range[1], filter_extension[1]])#clip extension to not extend beyond data range
+        self.r_params['filter_extension'] = filter_extension
 
     def set_weighting(self, data_weighting):
         """

--- a/hera_pspec/pspecdata.py
+++ b/hera_pspec/pspecdata.py
@@ -586,6 +586,13 @@ class PSpecData(object):
 
         model : string, optional
             Type of covariance model to calculate, if not cached. options=['empirical', 'dsets']
+            How the covariances of the input data should be estimated.
+            in 'dsets' mode, error bars are estimated from user-provided
+            per baseline and per channel standard deivations. If 'empirical' is
+            set, then error bars are estimated from the data by calculating the
+            channel-channel covariance of each baseline over time and
+            then applying the appropriate linear transformations to these
+            frequency-domain covariances.
 
         time_index : integer, compute covariance at specific time-step in dset
                        only supported if mode == 'dsets'
@@ -635,8 +642,13 @@ class PSpecData(object):
             subsequent indices specify the baseline index, in _key2inds format.
 
         model : string, optional
-            Type of covariance model to calculate, if not cached.
-            options=['empirical']
+            How the covariances of the input data should be estimated.
+            in 'dsets' mode, error bars are estimated from user-provided
+            per baseline and per channel standard deivations. If 'empirical' is
+            set, then error bars are estimated from the data by calculating the
+            channel-channel covariance of each baseline over time and
+            then applying the appropriate linear transformations to these
+            frequency-domain covariances.
 
         conj_1 : boolean, optional
             Whether to conjugate first copy of data in covar or not.
@@ -710,8 +722,13 @@ class PSpecData(object):
             subsequent indices specify the baseline index, in _key2inds format.
 
         model : string
-            Type of covariance model to calculate, if not cached.
-            options=['empirical']
+            How the covariances of the input data should be estimated.
+            in 'dsets' mode, error bars are estimated from user-provided
+            per baseline and per channel standard deivations. If 'empirical' is
+            set, then error bars are estimated from the data by calculating the
+            channel-channel covariance of each baseline over time and
+            then applying the appropriate linear transformations to these
+            frequency-domain covariances.
 
         Returns
         -------
@@ -820,6 +837,9 @@ class PSpecData(object):
         or a `sinc_downweight`
         depending on self.data_weighting, T is informed by self.taper and Y
         is taken from self.Y().
+
+        Right now, the data covariance can be identity ('I'), C^-1 ('iC'), or
+        dayenu weighting 'sinc_downweight'.
 
         Parameters
         ----------
@@ -1024,6 +1044,12 @@ class PSpecData(object):
 
         model : str, default: 'empirical'
             How the covariances of the input data should be estimated.
+            in 'dsets' mode, error bars are estimated from user-provided
+            per baseline and per channel standard deivations. If 'empirical' is
+            set, then error bars are estimated from the data by calculating the
+            channel-channel covariance of each baseline over time and
+            then applying the appropriate linear transformations to these
+             frequency-domain covariances.
 
         time_indices: list of indices of times to include or just a single time.
         default is None -> compute covariance for all times.
@@ -1489,6 +1515,12 @@ class PSpecData(object):
 
         model : str, default: 'empirical'
             How the covariances of the input data should be estimated.
+            in 'dsets' mode, error bars are estimated from user-provided
+            per baseline and per channel standard deivations. If 'empirical' is
+            set, then error bars are estimated from the data by calculating the
+            channel-channel covariance of each baseline over time and
+            then applying the appropriate linear transformations to these
+            frequency-domain covariances.
 
         time_index : integer, compute covariance at specific time-step in dset
                        only supported if mode == 'dsets'
@@ -2269,8 +2301,13 @@ class PSpecData(object):
             in the UVPSpec object.
 
         cov_model : string, optional
-            specifies how covariance are to be calculated. Currently supports
-            dsets and empirical
+            How the covariances of the input data should be estimated.
+            in 'dsets' mode, error bars are estimated from user-provided
+            per baseline and per channel standard deivations. If 'empirical' is
+            set, then error bars are estimated from the data by calculating the
+            channel-channel covariance of each baseline over time and
+            then applying the appropriate linear transformations to these
+            frequency-domain covariances. 
 
         verbose : bool, optional
             If True, print progress, warnings and debugging info to stdout.
@@ -3199,8 +3236,13 @@ def pspec_run(dsets, filename, dsets_std=None, cals=None, cal_flag=True,
         access when file may be locked temporarily by other processes).
 
     cov_model : string, optional
-        specifies how covariance are to be calculated. Currently supports
-        dsets and empirical
+        How the covariances of the input data should be estimated.
+        in 'dsets' mode, error bars are estimated from user-provided
+        per baseline and per channel standard deivations. If 'empirical' is
+        set, then error bars are estimated from the data by calculating the
+        channel-channel covariance of each baseline over time and
+        then applying the appropriate linear transformations to these
+        frequency-domain covariances.
 
     r_params: dict, optional
         Dictionary with parameters for weighting matrix. Required fields and

--- a/hera_pspec/testing.py
+++ b/hera_pspec/testing.py
@@ -74,6 +74,7 @@ def build_vanilla_uvpspec(beam=None):
     label1 = 'red'
     label2 = 'blue'
     r_params = ''
+    cov_model = 'dsets'
     labels = np.array([label1, label2])
     label_1_array = np.ones((Nspws, Nblpairts, Npols), np.int) * 0
     label_2_array = np.ones((Nspws, Nblpairts, Npols), np.int) * 1
@@ -115,7 +116,7 @@ def build_vanilla_uvpspec(beam=None):
               'norm', 'git_hash', 'nsample_array', 'time_avg_array',
               'lst_avg_array', 'cosmo', 'scalar_array', 'labels', 'norm_units',
               'labels', 'label_1_array', 'label_2_array', 'store_cov',
-              'cov_array', 'spw_dly_array', 'spw_freq_array']
+              'cov_array', 'spw_dly_array', 'spw_freq_array', 'cov_model']
 
     if beam is not None:
         params += ['OmegaP', 'OmegaPP', 'beam_freqs']
@@ -201,8 +202,10 @@ def uvpspec_from_data(data, bl_grps, data_std=None, spw_ranges=None,
         uvd_std = None
     if uvd_std is not None:
         store_cov = True
+        cov_model = "dsets"
     else:
         store_cov = False
+        cov_model = "empirical"
 
     # get pol
     pol = uvd.polarization_array[0]
@@ -234,7 +237,8 @@ def uvpspec_from_data(data, bl_grps, data_std=None, spw_ranges=None,
     # run pspec
     uvp = ds.pspec(bls1, bls2, (0, 1), (pol, pol), input_data_weight='identity',
                    spw_ranges=spw_ranges, taper=taper, verbose=verbose,
-                   store_cov=store_cov, n_dlys=n_dlys, r_params=r_params)
+                   store_cov=store_cov, n_dlys=n_dlys, r_params=r_params,
+                   cov_model=cov_model)
 
     return uvp
 

--- a/hera_pspec/tests/test_pspecdata.py
+++ b/hera_pspec/tests/test_pspecdata.py
@@ -748,10 +748,16 @@ class Test_PSpecData(unittest.TestCase):
         ds1.set_filter_extension((10,10))
         rm1 = self.ds.R(key1)
         rm2 = ds1.R(key2)
+        rm3 = ds1.R(key1)
         self.assertTrue(np.shape(rm2) == (ds1.spw_Nfreqs, self.ds.spw_Nfreqs))
         #check that all values that are not truncated match values of untrancated matrix.
         self.assertTrue(np.all(np.isclose(rm1[10:-10], rm2, atol=1e-6)))
-
+        #make sure no errors are thrown by get_V, get_E, etc...
+        ds1.get_unnormed_E(key1, key2)
+        ds1.get_unnormed_V(key1, key2)
+        h=ds1.get_H(key1, key2)
+        g=ds1.get_G(key1, key2)
+        ds1.get_MW(g, h)
 
     def test_q_hat(self):
         """
@@ -919,10 +925,13 @@ class Test_PSpecData(unittest.TestCase):
                     # In general, when R_1 != R_2, there is a more restricted
                     # symmetry where swapping R_1 and R_2 *and* taking the
                     # transpose gives the same result
-                    G_swapped = self.ds.get_G(key2, key1)
-                    G_diff_norm = np.linalg.norm(G - G_swapped.T)
-                    self.assertLessEqual(G_diff_norm,
-                                         matrix_scale * multiplicative_tolerance)
+                    #UPDATE: Taper now occurs after filter so this
+                    #symmetry only holds when taper = 'none'. 
+                    if taper_selection == 'none':
+                        G_swapped = self.ds.get_G(key2, key1)
+                        G_diff_norm = np.linalg.norm(G - G_swapped.T)
+                        self.assertLessEqual(G_diff_norm,
+                                             matrix_scale * multiplicative_tolerance)
 
 
     '''

--- a/hera_pspec/tests/test_pspecdata.py
+++ b/hera_pspec/tests/test_pspecdata.py
@@ -737,8 +737,8 @@ class Test_PSpecData(unittest.TestCase):
         key3 = [(0, 24, 38), (0, 24, 38)]
         key4 = [(1, 25, 38), (1, 25, 38)]
 
-        rpk1 = {'filter_centers':[0.],'filter_widths':[100e-9],'filter_factors':[1e-9]}
-        rpk2 = {'filter_centers':[0.],'filter_widths':[100e-9],'filter_factors':[1e-9]}
+        rpk1 = {'filter_centers':[0.],'filter_half_widths':[100e-9],'filter_factors':[1e-9]}
+        rpk2 = {'filter_centers':[0.],'filter_half_widths':[100e-9],'filter_factors':[1e-9]}
         self.ds.set_weighting('sinc_downweight')
         self.ds.set_r_param(key1,rpk1)
         self.ds.set_r_param(key2,rpk2)
@@ -926,7 +926,7 @@ class Test_PSpecData(unittest.TestCase):
                     # symmetry where swapping R_1 and R_2 *and* taking the
                     # transpose gives the same result
                     #UPDATE: Taper now occurs after filter so this
-                    #symmetry only holds when taper = 'none'. 
+                    #symmetry only holds when taper = 'none'.
                     if taper_selection == 'none':
                         G_swapped = self.ds.get_G(key2, key1)
                         G_diff_norm = np.linalg.norm(G - G_swapped.T)

--- a/hera_pspec/tests/test_pspecdata.py
+++ b/hera_pspec/tests/test_pspecdata.py
@@ -209,6 +209,36 @@ class Test_PSpecData(unittest.TestCase):
         nt.assert_raises(AssertionError, self.ds.add, [uv], None, cals=[None, None])
         nt.assert_raises(AssertionError, self.ds.add, [uv], None, labels=['foo', 'bar'])
 
+    def test_set_symmetric_taper(self):
+        """
+        Make sure that you can't set a symmtric taper with an truncated R matrix
+        """
+        self.ds = pspecdata.PSpecData(dsets=self.d, wgts=self.w)
+        Nfreq = self.ds.spw_Nfreqs
+        Ntime = self.ds.Ntimes
+        Ndlys = Nfreq - 3
+        self.ds.spw_Ndlys = Ndlys
+
+
+        # Set baselines to use for tests
+        key1 = (0, 24, 38)
+        key2 = (1, 25, 38)
+        key3 = [(0, 24, 38), (0, 24, 38)]
+        key4 = [(1, 25, 38), (1, 25, 38)]
+
+        rpk1 = {'filter_centers':[0.],'filter_half_widths':[100e-9],'filter_factors':[1e-9]}
+        rpk2 = {'filter_centers':[0.],'filter_half_widths':[100e-9],'filter_factors':[1e-9]}
+        self.ds.set_weighting('sinc_downweight')
+        self.ds.set_r_param(key1,rpk1)
+        self.ds.set_r_param(key2,rpk2)
+        ds1 = copy.deepcopy(self.ds)
+        ds1.set_spw((10,Nfreq-10))
+        ds1.set_filter_extension([10,10])
+        ds1.set_filter_extension((10,10))
+        rm1 = self.ds.R(key1)
+        self.ds.set_symmetric_taper(True)
+        nt.assert_raises(ValueError, ds1.set_symmetric_taper, True)
+
     def test_labels(self):
         """
         Test that dataset labels work.

--- a/hera_pspec/tests/test_pspecdata.py
+++ b/hera_pspec/tests/test_pspecdata.py
@@ -692,7 +692,7 @@ class Test_PSpecData(unittest.TestCase):
         Now test that analytic Error calculation gives Nchan^2
         """
         self.ds.set_weighting('identity')
-        qc = self.ds.cov_q_hat(key1, key2, model='dsets')ß
+        qc = self.ds.cov_q_hat(key1, key2, model='dsets')
         self.assertTrue(np.allclose(qc,
                         np.repeat(cov_analytic[np.newaxis, :, :], self.ds.Ntimes, axis=0), atol=1e-6))
         """

--- a/hera_pspec/tests/test_pspecdata.py
+++ b/hera_pspec/tests/test_pspecdata.py
@@ -758,6 +758,15 @@ class Test_PSpecData(unittest.TestCase):
         h=ds1.get_H(key1, key2)
         g=ds1.get_G(key1, key2)
         ds1.get_MW(g, h)
+        #make sure identity weighting isn't broken.
+        self.ds = pspecdata.PSpecData(dsets=self.d, wgts=self.w)
+        ds1 = copy.deepcopy(self.ds)
+        ds1.set_spw((10,Nfreq-10))
+        ds1.set_weighting('identity')
+        ds1.set_filter_extension([10,10])
+        rm1 = ds1.R(key1)
+
+
 
     def test_q_hat(self):
         """

--- a/hera_pspec/tests/test_pspecdata.py
+++ b/hera_pspec/tests/test_pspecdata.py
@@ -672,7 +672,7 @@ class Test_PSpecData(unittest.TestCase):
         key2 = (1, 25, 38)
         #print(cov_analytic)
 
-        for input_data_weight in ['identity']:#,'iC','sinc_downweight']:
+        for input_data_weight in ['identity','iC','sinc_downweight']:
             self.ds.set_weighting(input_data_weight)
             #check error raised
             if input_data_weight == 'sinc_downweight':
@@ -681,8 +681,10 @@ class Test_PSpecData(unittest.TestCase):
                 self.ds.set_r_param(key1,rpk)
                 self.ds.set_r_param(key2,rpk)
             for taper in taper_selection:
-                qc = self.ds.cov_q_hat(key1,key2)
-                print(qc)
+                qc = self.ds.cov_q_hat(key1,key2,model='dsets')
+                self.assertTrue(np.allclose(np.array(list(qc.shape)),
+                np.array([self.ds.Ntimes, self.ds.spw_Ndlys, self.ds.spw_Ndlys]), atol=1e-6))
+                qc = self.ds.cov_q_hat(key1,key2,model='empirical')
                 self.assertTrue(np.allclose(np.array(list(qc.shape)),
                 np.array([self.ds.Ntimes, self.ds.spw_Ndlys, self.ds.spw_Ndlys]), atol=1e-6))
 
@@ -690,18 +692,22 @@ class Test_PSpecData(unittest.TestCase):
         Now test that analytic Error calculation gives Nchan^2
         """
         self.ds.set_weighting('identity')
-        qc = self.ds.cov_q_hat(key1, key2)
+        qc = self.ds.cov_q_hat(key1, key2, model='dsets')
+        print('numerical')
+        print(qc[0,0,:])
+        print('analytic')
+        print(cov_analytic[0,:])
         self.assertTrue(np.allclose(qc,
                         np.repeat(cov_analytic[np.newaxis, :, :], self.ds.Ntimes, axis=0), atol=1e-6))
         """
         Test lists of keys
         """
         self.ds.set_weighting('identity')
-        qc=self.ds.cov_q_hat([key1], [key2], time_indices=[0])
+        qc=self.ds.cov_q_hat([key1], [key2], time_indices=[0], model='dsets')
         self.assertTrue(np.allclose(qc,
                         np.repeat(cov_analytic[np.newaxis, :, :], self.ds.Ntimes, axis=0), atol=1e-6))
-        self.assertRaises(ValueError, self.ds.cov_q_hat, key1, key2, 200)
-        self.assertRaises(ValueError, self.ds.cov_q_hat, key1, key2, "watch out!")
+        self.assertRaises(ValueError, self.ds.cov_q_hat, key1, key2, time_indices=200)
+        self.assertRaises(ValueError, self.ds.cov_q_hat, key1, key2, time_indices="watch out!")
 
 
     def test_cov_p_hat(self):

--- a/hera_pspec/tests/test_pspecdata.py
+++ b/hera_pspec/tests/test_pspecdata.py
@@ -1026,6 +1026,10 @@ class Test_PSpecData(unittest.TestCase):
         self.ds.spw_Ndlys = self.ds.spw_Nfreqs
         adjustment = self.ds.scalar_delay_adjustment(key1, key2, sampling=True)
         self.assertAlmostEqual(adjustment, 1.0)
+        self.ds.set_weighting('iC')
+        #if weighting is not identity, then the adjustment should be a vector.
+        adjustment = self.ds.scalar_delay_adjustment(key1, key2, sampling=True)
+        self.assertTrue(len(adjustment) == self.ds.spw_Ndlys)
 
     def test_scalar(self):
         self.ds = pspecdata.PSpecData(dsets=self.d, wgts=self.w, beam=self.bm)

--- a/hera_pspec/tests/test_pspecdata.py
+++ b/hera_pspec/tests/test_pspecdata.py
@@ -477,7 +477,7 @@ class Test_PSpecData(unittest.TestCase):
         ds_c = pspecdata.PSpecData(dsets=[uvd, uvd], wgts=[None, None], labels=['red', 'blue'], beam=self.bm)
         ds_c.spw_Ndlys = 10
         random_R = generate_pos_def_all_pos(ds_c.spw_Nfreqs)
-        wgt_matrix_dict = {} 
+        wgt_matrix_dict = {}
         wgt_matrix_dict[('red', (24, 25))] = random_R
         wgt_matrix_dict[('blue', (24, 25))] = random_R
         ds_c.set_R(wgt_matrix_dict)
@@ -672,7 +672,7 @@ class Test_PSpecData(unittest.TestCase):
         key2 = (1, 25, 38)
         #print(cov_analytic)
 
-        for input_data_weight in ['identity','iC','sinc_downweight']:
+        for input_data_weight in ['identity']:#,'iC','sinc_downweight']:
             self.ds.set_weighting(input_data_weight)
             #check error raised
             if input_data_weight == 'sinc_downweight':
@@ -682,6 +682,7 @@ class Test_PSpecData(unittest.TestCase):
                 self.ds.set_r_param(key2,rpk)
             for taper in taper_selection:
                 qc = self.ds.cov_q_hat(key1,key2)
+                print(qc)
                 self.assertTrue(np.allclose(np.array(list(qc.shape)),
                 np.array([self.ds.Ntimes, self.ds.spw_Ndlys, self.ds.spw_Ndlys]), atol=1e-6))
 

--- a/hera_pspec/tests/test_pspecdata.py
+++ b/hera_pspec/tests/test_pspecdata.py
@@ -692,11 +692,7 @@ class Test_PSpecData(unittest.TestCase):
         Now test that analytic Error calculation gives Nchan^2
         """
         self.ds.set_weighting('identity')
-        qc = self.ds.cov_q_hat(key1, key2, model='dsets')
-        print('numerical')
-        print(qc[0,0,:])
-        print('analytic')
-        print(cov_analytic[0,:])
+        qc = self.ds.cov_q_hat(key1, key2, model='dsets')ß
         self.assertTrue(np.allclose(qc,
                         np.repeat(cov_analytic[np.newaxis, :, :], self.ds.Ntimes, axis=0), atol=1e-6))
         """

--- a/hera_pspec/uvpspec.py
+++ b/hera_pspec/uvpspec.py
@@ -1,7 +1,7 @@
 import numpy as np
 from collections import OrderedDict as odict
 import os, copy, shutil, operator, ast, fnmatch
-from pyuvdata import utils as uvutils as uvutils
+from pyuvdata import utils as uvutils
 import h5py
 import warnings
 import json

--- a/hera_pspec/uvpspec.py
+++ b/hera_pspec/uvpspec.py
@@ -36,6 +36,8 @@ class UVPSpec(object):
                 'corresponding to that weighting.')
         self._r_params = PSpecParam("r_params", description = desc, expected_type = str)
         # Data attributes
+        desc = ("A string indicating what covariance model was used for calculating cov array. Only required if covariance is stored.")
+        self._cov_model = PSpecParam("cov_model", description=desc, expected_type=str)
         desc = "Power spectrum data dictionary with spw integer as keys and values as complex ndarrays."
         self._data_array = PSpecParam("data_array", description=desc, expected_type=np.complex128, form="(Nblpairts, spw_Ndlys, Npols)")
         desc = "Power spectrum covariance dictionary with spw integer as keys and values as complex ndarrays. "
@@ -116,7 +118,7 @@ class UVPSpec(object):
         # groups, which are used in __eq__
         self._immutables = ["Ntimes", "Nblpairts", "Nblpairs", "Nspwdlys",
                             "Nspwfreqs", "Nspws", "Ndlys", "Npols", "Nfreqs",
-                            "history", "r_params",
+                            "history", "r_params", "cov_model",
                             "Nbls", "channel_width", "weighting", "vis_units",
                             "norm", "norm_units", "taper", "cosmo", "beamfile",
                             'folded']
@@ -1981,7 +1983,6 @@ def combine_uvpspec(uvps, merge_history=True, verbose=True):
 
     # Store covariance only if all uvps have stored covariance.
     store_cov = np.all([hasattr(uvp, 'cov_array') for uvp in uvps])
-
     # Create new empty data arrays and fill spw arrays
     u.data_array = odict()
     u.integration_array = odict()
@@ -1989,6 +1990,8 @@ def combine_uvpspec(uvps, merge_history=True, verbose=True):
     u.nsample_array = odict()
     if store_cov:
         u.cov_array = odict()
+        #cov_model will track whether error bars are from cmobination of techniques
+        u.cov_model = ','.join([uvp.cov_model for uvp in uvps])
     u.scalar_array = np.empty((Nspws, Npols), np.float)
     u.freq_array, u.spw_array, u.dly_array = [], [], []
     u.spw_dly_array, u.spw_freq_array = [], []

--- a/hera_pspec/uvpspec.py
+++ b/hera_pspec/uvpspec.py
@@ -1,7 +1,7 @@
 import numpy as np
 from collections import OrderedDict as odict
 import os, copy, shutil, operator, ast, fnmatch
-from pyuvdata import uvutils as uvutils
+from pyuvdata import utils as uvutils as uvutils
 import h5py
 import warnings
 import json

--- a/hera_pspec/uvpspec.py
+++ b/hera_pspec/uvpspec.py
@@ -79,6 +79,7 @@ class UVPSpec(object):
         self._channel_width = PSpecParam("channel_width", description="width of visibility frequency channels in Hz.", expected_type=float)
         self._telescope_location = PSpecParam("telescope_location", description="telescope location in ECEF frame [meters]. To get it in Lat/Lon/Alt see pyuvdata.utils.LatLonAlt_from_XYZ().", expected_type=np.float64)
         self._weighting = PSpecParam("weighting", description="Form of data weighting used when forming power spectra.", expected_type=str)
+        self.set_symmetric_taper = PSpecParam("symmetric_taper", description="Specify whether Taper was applied symmetrically (True) or to the left(False).", expected_type=str)
         self._norm = PSpecParam("norm", description="Normalization method adopted in OQE (M matrix).", expected_type=str)
         self._taper = PSpecParam("taper", description='Taper function applied to visibility data before FT. See uvtools.dspec.gen_window for options."', expected_type=str)
         self._vis_units = PSpecParam("vis_units", description="Units of the original visibility data used to form the power spectra.", expected_type=str)
@@ -112,7 +113,8 @@ class UVPSpec(object):
                             "norm_units", "taper", "norm", "nsample_array",
                             "lst_avg_array", "time_avg_array", "folded",
                             "scalar_array", "labels", "label_1_array",
-                            "label_2_array", "spw_dly_array", "spw_freq_array"]
+                            "label_2_array", "spw_dly_array", "spw_freq_array",
+                            "symmetric_taper"]
 
         # All parameters must fall into one and only one of the following
         # groups, which are used in __eq__

--- a/hera_pspec/uvpspec_utils.py
+++ b/hera_pspec/uvpspec_utils.py
@@ -132,18 +132,16 @@ def compress_r_params(r_params_dict):
         r_params_index = -1
         for rp in r_params_dict:
             #do not include data set in tuple key
-            if not rp in ['filter_extension']:
-                already_in = False
-                for rpu in r_params_unique:
-                    if r_params_unique[rpu] == r_params_dict[rp]:
-                        r_params_unique_bls[rpu] += [rp,]
-                        already_in = True
-                if not already_in:
-                    r_params_index += 1
-                    r_params_unique[r_params_index] = copy.copy(r_params_dict[rp])
-                    r_params_unique_bls[r_params_index] = [rp,]
-            else:
-                r_params_unique[rp] = r_params_dict[rp]
+            already_in = False
+            for rpu in r_params_unique:
+                if r_params_unique[rpu] == r_params_dict[rp]:
+                    r_params_unique_bls[rpu] += [rp,]
+                    already_in = True
+            if not already_in:
+                r_params_index += 1
+                r_params_unique[r_params_index] = copy.copy(r_params_dict[rp])
+                r_params_unique_bls[r_params_index] = [rp,]
+
 
         for rpi in r_params_unique:
             r_params_unique[rpi]['baselines'] = r_params_unique_bls[rpi]
@@ -177,15 +175,12 @@ def decompress_r_params(r_params_str):
     if r_params_str != '' and not r_params_str is None:
         r_params = json.loads(r_params_str)
         for rpi in r_params:
-            if not rpi in ['filter_extension']:
-                rp_dict = {}
-                for r_field in r_params[rpi]:
-                    if not r_field == 'baselines':
-                        rp_dict[r_field] = r_params[rpi][r_field]
-                for blkey in r_params[rpi]['baselines']:
-                    decompressed_r_params[tuple(blkey)] = rp_dict
-            else:
-                decompress_r_params[rpi] = r_params[rpi]
+            rp_dict = {}
+            for r_field in r_params[rpi]:
+                if not r_field == 'baselines':
+                    rp_dict[r_field] = r_params[rpi][r_field]
+            for blkey in r_params[rpi]['baselines']:
+                decompressed_r_params[tuple(blkey)] = rp_dict
     else:
         decompressed_r_params = {}
     return decompressed_r_params

--- a/hera_pspec/uvpspec_utils.py
+++ b/hera_pspec/uvpspec_utils.py
@@ -132,15 +132,19 @@ def compress_r_params(r_params_dict):
         r_params_index = -1
         for rp in r_params_dict:
             #do not include data set in tuple key
-            already_in = False
-            for rpu in r_params_unique:
-                if r_params_unique[rpu] == r_params_dict[rp]:
-                    r_params_unique_bls[rpu] += [rp,]
-                    already_in = True
-            if not already_in:
-                r_params_index += 1
-                r_params_unique[r_params_index] = copy.copy(r_params_dict[rp])
-                r_params_unique_bls[r_params_index] = [rp,]
+            if not rp in ['filter_extension']:
+                already_in = False
+                for rpu in r_params_unique:
+                    if r_params_unique[rpu] == r_params_dict[rp]:
+                        r_params_unique_bls[rpu] += [rp,]
+                        already_in = True
+                if not already_in:
+                    r_params_index += 1
+                    r_params_unique[r_params_index] = copy.copy(r_params_dict[rp])
+                    r_params_unique_bls[r_params_index] = [rp,]
+            else:
+                r_params_unique[rp] = r_params_dict[rp]
+
         for rpi in r_params_unique:
             r_params_unique[rpi]['baselines'] = r_params_unique_bls[rpi]
         r_params_str = json.dumps(r_params_unique)
@@ -173,12 +177,15 @@ def decompress_r_params(r_params_str):
     if r_params_str != '' and not r_params_str is None:
         r_params = json.loads(r_params_str)
         for rpi in r_params:
-            rp_dict = {}
-            for r_field in r_params[rpi]:
-                if not r_field == 'baselines':
-                    rp_dict[r_field] = r_params[rpi][r_field]
-            for blkey in r_params[rpi]['baselines']:
-                decompressed_r_params[tuple(blkey)] = rp_dict
+            if not rpi in ['filter_extension']:
+                rp_dict = {}
+                for r_field in r_params[rpi]:
+                    if not r_field == 'baselines':
+                        rp_dict[r_field] = r_params[rpi][r_field]
+                for blkey in r_params[rpi]['baselines']:
+                    decompressed_r_params[tuple(blkey)] = rp_dict
+            else:
+                decompress_r_params[rpi] = r_params[rpi]
     else:
         decompressed_r_params = {}
     return decompressed_r_params


### PR DESCRIPTION
Addresses #226  by providing a way to truncate data after filtering (i.e. the inverse covariance step) that so filtering can be applied across the full data bandwidth to reduce signal loss and provide better foreground isolation while the power spectrum is calculated from frequencies with ~equal redshift. 

Also address #227  by consolidating get_unnormed_V and cov_q_hat. cov_q_hat is now a wrapper for get_unnormed_V and both support functionality for calculating bandpower covariances from user supplied uvdata objects or empirically from the data itself. By converting cov_q_hat to a wrapper, get_unnormed_V is now subjected to same tests that original cov_q_hat was validated by, showing that the two independent calculations (by Jianrong and I) are equivalent (a good consistency check). 

