### PR TITLE
updated calls to polstr2num w/ x_orientation

### DIFF
--- a/hera_pspec/pspecbeam.py
+++ b/hera_pspec/pspecbeam.py
@@ -452,6 +452,7 @@ class PSpecBeamUV(PSpecBeamBase):
             Frequencies [Hz] to interpolate onto.
         x_orientation: str, optional
             Orientation in cardinal direction east or north of X dipole.
+            Default keeps polarization in X and Y basis.
 
         Returns
         -------
@@ -583,6 +584,7 @@ class PSpecBeamFromArray(PSpecBeamBase):
 
         x_orientation : str, optional
             Orientation in cardinal direction east or north of X dipole.
+            Default keeps polarization in X and Y basis.
         """
         self.OmegaP = {}; self.OmegaPP = {}
         self.x_orientation = x_orientation

--- a/hera_pspec/pspecbeam.py
+++ b/hera_pspec/pspecbeam.py
@@ -432,7 +432,7 @@ class PSpecBeamUV(PSpecBeamBase):
             self.primary_beam.efield_to_power(inplace=True)
             self.primary_beam.peak_normalize()
 
-    def beam_normalized_response(self, pol='pI', freq=None):
+    def beam_normalized_response(self, pol='pI', freq=None, x_orientation=None):
         """
         Outputs beam response for given polarization as a function
         of pixels on the sky and input frequencies.
@@ -448,6 +448,10 @@ class PSpecBeamUV(PSpecBeamBase):
             'pI', 'pQ', 'pU', 'pV', 'XX', 'YY', 'XY', 'YX' 
             The output shape is (Nfreq, Npixels)
             Default: 'pI'
+        freq: array, optional
+            Frequencies [Hz] to interpolate onto.
+        x_orientation: str, optional
+            Orientation in cardinal direction east or north of X dipole.
 
         Returns
         -------
@@ -473,7 +477,7 @@ class PSpecBeamUV(PSpecBeamBase):
         beam_res = beam_res[0]
 
         if isinstance(pol, (str, np.str)):
-            pol = uvutils.polstr2num(pol)
+            pol = uvutils.polstr2num(pol, x_orientation=x_orientation)
         
         pol_array = self.primary_beam.polarization_array
         
@@ -541,7 +545,7 @@ class PSpecBeamUV(PSpecBeamBase):
 
 class PSpecBeamFromArray(PSpecBeamBase):
     
-    def __init__(self, OmegaP, OmegaPP, beam_freqs, cosmo=None):
+    def __init__(self, OmegaP, OmegaPP, beam_freqs, cosmo=None, x_orientation=None):
         """
         Primary beam model built from user-defined arrays for the integrals 
         over beam solid angle and beam solid angle squared.
@@ -576,8 +580,12 @@ class PSpecBeamFromArray(PSpecBeamBase):
         cosmo : conversions.Cosmo_Conversions object, optional
             Cosmology object. Uses the default cosmology object if not 
             specified. Default: None.
+
+        x_orientation : str, optional
+            Orientation in cardinal direction east or north of X dipole.
         """
         self.OmegaP = {}; self.OmegaPP = {}
+        self.x_orientation = x_orientation
         # these are allowed pols in AIPS polarization integer convention
         # see pyuvdata.utils.polstr2num() for details
         self.allowed_pols = [1, 2, 3, 4, -5, -6, -7, -8]
@@ -607,7 +615,7 @@ class PSpecBeamFromArray(PSpecBeamBase):
         for key in OmegaP.keys():
             # turn into pol integer if a pol string
             if isinstance(key, str):
-                new_key = uvutils.polstr2num(key)
+                new_key = uvutils.polstr2num(key, x_orientation=self.x_orientation)
                 OmegaP[new_key] = OmegaP.pop(key)
                 key = new_key
             # check its an allowed pol
@@ -616,7 +624,7 @@ class PSpecBeamFromArray(PSpecBeamBase):
         for key in OmegaPP.keys():
             # turn into pol integer if a pol string
             if isinstance(key, str):
-                new_key = uvutils.polstr2num(key)
+                new_key = uvutils.polstr2num(key, x_orientation=self.x_orientation)
                 OmegaPP[new_key] = OmegaPP.pop(key)
                 key = new_key
             # check its an allowed pol
@@ -666,7 +674,7 @@ class PSpecBeamFromArray(PSpecBeamBase):
         """
         # Type check
         if isinstance(pol, str):
-            pol = uvutils.polstr2num(pol)
+            pol = uvutils.polstr2num(pol, x_orientation=self.x_orientation)
 
         # Check for allowed polarization
         if pol not in self.allowed_pols:
@@ -711,7 +719,7 @@ class PSpecBeamFromArray(PSpecBeamBase):
         """
         # type check
         if isinstance(pol, str):
-            pol = uvutils.polstr2num(pol)
+            pol = uvutils.polstr2num(pol, x_orientation=self.x_orientation)
 
         if pol in self.OmegaP.keys():
             return self.OmegaP[pol]
@@ -740,7 +748,7 @@ class PSpecBeamFromArray(PSpecBeamBase):
         """
         # type check
         if isinstance(pol, str):
-            pol = uvutils.polstr2num(pol)
+            pol = uvutils.polstr2num(pol, x_orientation=self.x_orientation)
             
         if pol in self.OmegaPP.keys():
             return self.OmegaPP[pol]

--- a/hera_pspec/pspecdata.py
+++ b/hera_pspec/pspecdata.py
@@ -2063,11 +2063,14 @@ class PSpecData(object):
         err_msg = "polarization must be fed as len-2 tuple of strings or ints"
         assert isinstance(pol_pair, tuple), err_msg
 
+        # take x_orientation from first dset
+        x_orientation = self.dsets[0].x_orientation
+
         # convert elements to integers if fed as strings
         if isinstance(pol_pair[0], (str, np.str)):
-            pol_pair = (uvutils.polstr2num(pol_pair[0]), pol_pair[1])
+            pol_pair = (uvutils.polstr2num(pol_pair[0], x_orientation=x_orientation), pol_pair[1])
         if isinstance(pol_pair[1], (str, np.str)):
-            pol_pair = (pol_pair[0], uvutils.polstr2num(pol_pair[1]))
+            pol_pair = (pol_pair[0], uvutils.polstr2num(pol_pair[1], x_orientation=x_orientation))
 
         assert isinstance(pol_pair[0], (int, np.integer)), err_msg
         assert isinstance(pol_pair[1], (int, np.integer)), err_msg
@@ -2345,11 +2348,12 @@ class PSpecData(object):
         for p in pols:
             if isinstance(p, str):
                 # Convert string to pol-integer pair
-                p = (uvutils.polstr2num(p), uvutils.polstr2num(p))
+                p = (uvutils.polstr2num(p, x_orientation=self.dsets[0].x_orientation),
+                     uvutils.polstr2num(p, x_orientation=self.dsets[0].x_orientation))
             if isinstance(p[0], (str, np.str)):
-                p = (uvutils.polstr2num(p[0]), p[1])
+                p = (uvutils.polstr2num(p[0], x_orientation=self.dsets[0].x_orientation), p[1])
             if isinstance(p[1], (str, np.str)):
-                p = (p[0], uvutils.polstr2num(p[1]))
+                p = (p[0], uvutils.polstr2num(p[1], x_orientation=self.dsets[0].x_orientation))
             _pols.append(p)
         pols = _pols
 
@@ -2808,7 +2812,7 @@ class PSpecData(object):
                 indices = dset.antpair2ind(k[:2], ordered=False)
 
                 # get index in polarization_array for this polarization
-                polind = pol_list.index(uvutils.polstr2num(k[-1]))
+                polind = pol_list.index(uvutils.polstr2num(k[-1], x_orientation=self.dsets[0].x_orientation))
 
                 # insert into dset
                 dset.data_array[indices, 0, :, polind] = data[k]

--- a/hera_pspec/pstokes.py
+++ b/hera_pspec/pstokes.py
@@ -91,6 +91,7 @@ def _combine_pol(uvd1, uvd2, pol1, pol2, pstokes='pI', x_orientation=None):
 
     x_orientation: str, optional
         Orientation in cardinal direction east or north of X dipole.
+        Default keeps polarization in X and Y basis.
 
     Returns
     -------

--- a/hera_pspec/pstokes.py
+++ b/hera_pspec/pstokes.py
@@ -62,7 +62,7 @@ def miriad2pyuvdata(dset, antenna_nums=None, bls=None, polarizations=None,
     return uvd
 
 
-def _combine_pol(uvd1, uvd2, pol1, pol2, pstokes='pI'):
+def _combine_pol(uvd1, uvd2, pol1, pol2, pstokes='pI', x_orientation=None):
     """
     Combines UVData visibilities to form the desired pseudo-stokes visibilities.
     It returns UVData object containing the pseudo-stokes visibilities
@@ -89,6 +89,9 @@ def _combine_pol(uvd1, uvd2, pol1, pol2, pstokes='pI'):
         Pseudo stokes polarization to form, can be 'pI' or 'pQ' or 'pU' or 'pV'.
         Default: pI
 
+    x_orientation: str, optional
+        Orientation in cardinal direction east or north of X dipole.
+
     Returns
     -------
     uvdS : UVData object
@@ -100,9 +103,9 @@ def _combine_pol(uvd1, uvd2, pol1, pol2, pstokes='pI'):
 
     # convert pol1 and/or pol2 to integer if fed as a string
     if isinstance(pol1, (str, np.str)):
-        pol1 = pyuvdata.utils.polstr2num(pol1)
+        pol1 = pyuvdata.utils.polstr2num(pol1, x_orientation=x_orientation)
     if isinstance(pol2, (str, np.str)):
-        pol2 = pyuvdata.utils.polstr2num(pol2)
+        pol2 = pyuvdata.utils.polstr2num(pol2, x_orientation=x_orientation)
 
     # extracting data array from the UVData objects
     data1 = uvd1.data_array
@@ -117,7 +120,7 @@ def _combine_pol(uvd1, uvd2, pol1, pol2, pstokes='pI'):
 
     # convert pStokes to polarization integer if a string
     if isinstance(pstokes, (str, np.str)):
-        pstokes = pyuvdata.utils.polstr2num(pstokes)
+        pstokes = pyuvdata.utils.polstr2num(pstokes, x_orientation=x_orientation)
 
     # get string form of polarizations
     pol1_str = pyuvdata.utils.polnum2str(pol1)
@@ -232,7 +235,7 @@ def construct_pstokes(dset1, dset2, pstokes='pI', run_check=True, antenna_nums=N
 
     # convert pstokes to integer if fed as a string
     if isinstance(pstokes, (str, np.str)):
-        pstokes = pyuvdata.utils.polstr2num(pstokes)
+        pstokes = pyuvdata.utils.polstr2num(pstokes, x_orientation=dset1.x_orientation)
 
     # check if dset1 and dset2 habe the same spectral window
     spw1 = uvd1.spw_array
@@ -321,7 +324,7 @@ def filter_dset_on_stokes_pol(dsets, pstokes):
 
     # convert pstokes to integer if a string
     if isinstance(pstokes, (str, np.str)):
-        pstokes = pyuvdata.utils.polstr2num(pstokes)
+        pstokes = pyuvdata.utils.polstr2num(pstokes, x_orientation=dsets[0].x_orientation)
     assert pstokes in [1, 2, 3, 4], \
         "pstokes must be fed as a pseudo-Stokes parameter"
 

--- a/hera_pspec/tests/test_pspecdata.py
+++ b/hera_pspec/tests/test_pspecdata.py
@@ -1056,10 +1056,11 @@ class Test_PSpecData(unittest.TestCase):
         nt.assert_raises(ValueError, ds2.validate_datasets)
 
     def test_rephase_to_dset(self):
-        # generate two uvd objects w/ different LST grids
+        # get uvd
         uvd1 = copy.deepcopy(self.uvd)
-        uvd2 = uv.UVData()
-        uvd2.read_miriad(os.path.join(DATA_PATH, "zen.2458042.19263.xx.HH.uvXA"))
+
+        # give the uvd an x_orientation to test x_orientation propagation
+        uvd1.x_orienation = 'east'
 
         # null test: check nothing changes when dsets contain same UVData object
         ds = pspecdata.PSpecData(dsets=[copy.deepcopy(uvd1), copy.deepcopy(uvd1)], wgts=[None, None])

--- a/hera_pspec/uvpspec_utils.py
+++ b/hera_pspec/uvpspec_utils.py
@@ -379,6 +379,7 @@ def polpair_tuple2int(polpair, x_orientation=None):
 
     x_orientation: str, optional
         Orientation in cardinal direction east or north of X dipole.
+        Default keeps polarization in X and Y basis.
 
     Returns
     -------

--- a/hera_pspec/uvpspec_utils.py
+++ b/hera_pspec/uvpspec_utils.py
@@ -361,7 +361,7 @@ def polpair_int2tuple(polpair, pol_strings=False):
         return (pol1, pol2)
 
 
-def polpair_tuple2int(polpair):
+def polpair_tuple2int(polpair, x_orientation=None):
     """
     Convert a tuple pair of polarization strings/integers into
     an pol-pair integer.
@@ -376,6 +376,9 @@ def polpair_tuple2int(polpair):
     polpair : tuple, length 2
         A length-2 tuple containing a pair of polarization strings
         or integers, e.g. ('XX', 'YY') or (-5, -5).
+
+    x_orientation: str, optional
+        Orientation in cardinal direction east or north of X dipole.
 
     Returns
     -------
@@ -392,8 +395,8 @@ def polpair_tuple2int(polpair):
 
     # Convert strings to ints if necessary
     pol1, pol2 = polpair
-    if type(pol1) in (str, np.str): pol1 = polstr2num(pol1)
-    if type(pol2) in (str, np.str): pol2 = polstr2num(pol2)
+    if type(pol1) in (str, np.str): pol1 = polstr2num(pol1, x_orientation=x_orientation)
+    if type(pol2) in (str, np.str): pol2 = polstr2num(pol2, x_orientation=x_orientation)
 
     # Convert to polpair integer
     ppint = (20 + pol1)*100 + (20 + pol2)


### PR DESCRIPTION
A recent `pyuvdata` update switched 'xx' and 'yy' to 'ee' and 'nn' with a definition of `x_orientation`, which H1C files now conform to. This caused some of our calls of `polstr2num` to break without propagating the `x_orientation` attribute. This PR propagates that attribute to fix this in the various regions where `polstr2num` is required.