### PR TITLE
extra_info kwarg to utils.calc_blpair_reds

### DIFF
--- a/hera_pspec/container.py
+++ b/hera_pspec/container.py
@@ -584,13 +584,16 @@ def combine_psc_spectra(psc, groups=None, dset_split_str='_x_', ext_split_str='_
             try:
                 # merge
                 uvps = [psc.get_pspec(grp, uvp) for uvp in to_merge]
-                merged_uvp = uvpspec.combine_uvpspec(uvps, merge_history=merge_history, verbose=verbose)
+                if len(uvps) > 1:
+                    merged_uvp = uvpspec.combine_uvpspec(uvps, merge_history=merge_history, verbose=verbose)
+                else:
+                    merged_uvp = uvps[0]
                 # write to file
                 psc.set_pspec(grp, spc, merged_uvp, overwrite=True)
                 # if successful merge, remove uvps
-                for uvp in to_merge:
-                    if uvp != spc:
-                        del psc.data[grp][uvp]
+                for uvp_name in to_merge:
+                    if uvp_name != spc:
+                        del psc.data[grp][uvp_name]
             except Exception as exc:
                 # merge failed, so continue
                 if verbose:

--- a/hera_pspec/pspecdata.py
+++ b/hera_pspec/pspecdata.py
@@ -3312,7 +3312,7 @@ def pspec_run(dsets, filename, dsets_std=None, cals=None, cal_flag=True,
                                       exclude_permutations=exclude_permutations,
                                       Nblps_per_group=Nblps_per_group,
                                       bl_len_range=bl_len_range,
-                                      bl_deg_range=bl_deg_range )
+                                      bl_deg_range=bl_deg_range)
             bls1_list.append(bls1)
             bls2_list.append(bls2)
 

--- a/hera_pspec/tests/test_utils.py
+++ b/hera_pspec/tests/test_utils.py
@@ -153,12 +153,15 @@ class Test_Utils(unittest.TestCase):
         uvd.read_miriad(fname)
 
         # basic execution
-        (bls1, bls2, blps, xants1,
-         xants2) = utils.calc_blpair_reds(uvd, uvd, filter_blpairs=True, exclude_auto_bls=False, exclude_permutations=True)
+        (bls1, bls2, blps, xants1, xants2, rgrps, lens,
+         angs) = utils.calc_blpair_reds(uvd, uvd, filter_blpairs=True, extra_info=True,
+                                        exclude_auto_bls=False, exclude_permutations=True)
         nt.assert_equal(len(bls1), len(bls2), 15)
         nt.assert_equal(blps, list(zip(bls1, bls2)))
         nt.assert_equal(xants1, xants2)
         nt.assert_equal(len(xants1), 42)
+        nt.assert_equal(len(rgrps), len(bls1))  # assert rgrps matches bls1 shape
+        nt.assert_equal(np.max(rgrps), len(lens)-1)  # assert rgrps indexes lens / angs
 
         # test xant_flag_thresh
         (bls1, bls2, blps, xants1,

--- a/hera_pspec/utils.py
+++ b/hera_pspec/utils.py
@@ -972,6 +972,7 @@ def job_monitor(run_func, iterator, action_name, M=map, lf=None, maxiter=1,
 
     return failures
 
+
 def get_bl_lens_angs(blvecs, bl_error_tol=1.0):
     """
     Given a list of baseline vectors in ENU (TOPO) coords, get the

--- a/hera_pspec/utils.py
+++ b/hera_pspec/utils.py
@@ -240,7 +240,8 @@ def calc_blpair_reds(uvd1, uvd2, bl_tol=1.0, filter_blpairs=True,
         to keep in baseline selection
 
     extra_info : bool, optional
-        If True, return extra info on redundant group length and angle
+        If True, return three extra arrays containing
+        redundant baseline group indices, lengths and angles
 
     Returns
     -------
@@ -254,15 +255,14 @@ def calc_blpair_reds(uvd1, uvd2, bl_tol=1.0, filter_blpairs=True,
     xants1, xants2 : lists
         List of bad antenna integers for uvd1 and uvd2
 
-    if extra_info:
-        red_groups : list of integers
-            Lists index of redundant groups, indexing red_lens and red_angs
+    red_groups : list of integers, returned as extra_info
+        Lists index of redundant groups, indexing red_lens and red_angs
 
-        red_lens : list
-            List of baseline lengths [meters] with len of unique redundant groups
+    red_lens : list, returned as extra_info
+        List of baseline lengths [meters] with len of unique redundant groups
 
-        red_angs : list
-            List of baseline angles [degrees] (North of East in ENU)
+    red_angs : list, returned as extra_info
+        List of baseline angles [degrees] (North of East in ENU)
     """
     # get antenna positions
     antpos1, ants1 = uvd1.get_ENU_antpos(pick_data_ants=False)
@@ -349,6 +349,7 @@ def calc_blpair_reds(uvd1, uvd2, bl_tol=1.0, filter_blpairs=True,
             bls1, bls2 = _bls1, _bls2
             blps = list(zip(bls1, bls2))
 
+        # populate redundant group indices
         rinds = [j] * len(blps)
 
         # group if desired

--- a/hera_pspec/utils.py
+++ b/hera_pspec/utils.py
@@ -184,7 +184,8 @@ def calc_blpair_reds(uvd1, uvd2, bl_tol=1.0, filter_blpairs=True,
                      xant_flag_thresh=0.95, exclude_auto_bls=False,
                      exclude_cross_bls=False,
                      exclude_permutations=True, Nblps_per_group=None,
-                     bl_len_range=(0, 1e10), bl_deg_range=(0, 180)):
+                     bl_len_range=(0, 1e10), bl_deg_range=(0, 180),
+                     xants=None, extra_info=False):
     """
     Use hera_cal.redcal to get matching, redundant baseline-pair groups from
     uvd1 and uvd2 within the specified baseline tolerance, not including
@@ -200,12 +201,15 @@ def calc_blpair_reds(uvd1, uvd2, bl_tol=1.0, filter_blpairs=True,
         Baseline-vector redundancy tolerance in meters
 
     filter_blpairs : bool, optional
-        if True, calculate xants and filters-out baseline pairs based on
-        xant lists and actual baselines in the data.
+        if True, calculate xants (based on data flags) and filter-out baseline pairs
+        based on actual baselines in the data.
 
     xant_flag_thresh : float, optional
         Fraction of 2D visibility (per-waterfall) needed to be flagged to
         consider the entire visibility flagged.
+
+    xants : list, optional
+        Additional lilst of xants to hand flag, regardless of flags in the data.
 
     exclude_auto_bls: boolean, optional
         If True, exclude all bls crossed with itself from the blpairs list
@@ -223,7 +227,7 @@ def calc_blpair_reds(uvd1, uvd2, bl_tol=1.0, filter_blpairs=True,
         exclude_permutations = True, then blpairs = [11, 12, 13, 22, 23, 33].
         Furthermore, if exclude_auto_bls = True then 11, 22, and 33 are excluded.
 
-    Nblps_per_group : integer
+    Nblps_per_group : integer, optional
         Number of baseline-pairs to put into each sub-group. No grouping if None.
         Default: None
 
@@ -234,6 +238,9 @@ def calc_blpair_reds(uvd1, uvd2, bl_tol=1.0, filter_blpairs=True,
     bl_deg_range : tuple, optional
         len-2 tuple containing (minimum, maximum) baseline angle in degrees
         to keep in baseline selection
+
+    extra_info : bool, optional
+        If True, return extra info on redundant group length and angle
 
     Returns
     -------
@@ -246,6 +253,16 @@ def calc_blpair_reds(uvd1, uvd2, bl_tol=1.0, filter_blpairs=True,
 
     xants1, xants2 : lists
         List of bad antenna integers for uvd1 and uvd2
+
+    if extra_info:
+        red_groups : list of integers
+            Lists index of redundant groups, indexing red_lens and red_angs
+
+        red_lens : list
+            List of baseline lengths [meters] with len of unique redundant groups
+
+        red_angs : list
+            List of baseline angles [degrees] (North of East in ENU)
     """
     # get antenna positions
     antpos1, ants1 = uvd1.get_ENU_antpos(pick_data_ants=False)
@@ -298,13 +315,18 @@ def calc_blpair_reds(uvd1, uvd2, bl_tol=1.0, filter_blpairs=True,
         xants1 = sorted(xants1)
         xants2 = sorted(xants2)
 
+    # add hand-flagged xants if fed
+    if xants is not None:
+        xants1 += xants
+        xants2 += xants
+
     # construct redundant groups
     reds, lens, angs = get_reds(antpos, bl_error_tol=bl_tol, xants=xants1+xants2,
                                 bl_deg_range=bl_deg_range, bl_len_range=bl_len_range)
 
     # construct baseline pairs
-    baselines1, baselines2, blpairs = [], [], []
-    for r in reds:
+    baselines1, baselines2, blpairs, red_groups = [], [], [], []
+    for j, r in enumerate(reds):
         (bls1, bls2,
          blps) = construct_blpairs(r, exclude_auto_bls=exclude_auto_bls,
                                    exclude_cross_bls=exclude_cross_bls, group=False,
@@ -327,6 +349,8 @@ def calc_blpair_reds(uvd1, uvd2, bl_tol=1.0, filter_blpairs=True,
             bls1, bls2 = _bls1, _bls2
             blps = list(zip(bls1, bls2))
 
+        rinds = [j] * len(blps)
+
         # group if desired
         if Nblps_per_group is not None:
             Ngrps = int(np.ceil(float(len(blps)) / Nblps_per_group))
@@ -336,12 +360,18 @@ def calc_blpair_reds(uvd1, uvd2, bl_tol=1.0, filter_blpairs=True,
                     for i in range(Ngrps)]
             blps = [blps[Nblps_per_group*i:Nblps_per_group*(i+1)]
                     for i in range(Ngrps)]
+            rinds = [rinds[Nblps_per_group*i:Nblps_per_group*(i+1)]
+                    for i in range(Ngrps)]
 
         baselines1.extend(bls1)
         baselines2.extend(bls2)
         blpairs.extend(blps)
+        red_groups.extend(rinds)
 
-    return baselines1, baselines2, blpairs, xants1, xants2
+    if extra_info:
+        return baselines1, baselines2, blpairs, xants1, xants2, red_groups, lens, angs
+    else:
+        return baselines1, baselines2, blpairs, xants1, xants2
 
 
 def get_delays(freqs, n_dlys=None):


### PR DESCRIPTION
Brief PR: enables extra redundant group output from `utils.calc_blpair_reds` if requested. Usable by pspec pipe for redundant group handling.

To not break existing API, I made this output optional (default False)