### PR TITLE
revert test_uvp to 8/2019. made window_func non-req

### DIFF
--- a/hera_pspec/grouping.py
+++ b/hera_pspec/grouping.py
@@ -875,17 +875,17 @@ def fold_spectra(uvp):
             uvp.data_array[spw][:, Ndlys//2+1:, :] = np.mean([left, right], axis=0)
             uvp.data_array[spw][:, :Ndlys//2, :] = 0.0
             uvp.nsample_array[spw] *= 2.0
-            if store_window
-            leftleft = uvp.window_function_array[spw][:, 1:Ndlys//2, 1:Ndlys//2, :][:, ::-1, ::-1, :]
-            leftright = uvp.window_function_array[spw][:, 1:Ndlys//2, Ndlys//2+1:, :][:, ::-1, :, :]
-            rightleft = uvp.window_function_array[spw][:, Ndlys//2+1: , 1:Ndlys//2, :][:, :, ::-1, :]
-            rightright = uvp.window_function_array[spw][:, Ndlys//2+1:, Ndlys//2+1:, :]
-            uvp.window_function_array[spw][:, Ndlys//2+1:, Ndlys//2+1:, :] = .25*(leftleft\
-                                                                         +leftright\
-                                                                         +rightleft\
-                                                                         +rightright)
-            uvp.window_function_array[spw][:, :Ndlys//2, :, :] = 0.0
-            uvp.window_function_array[spw][:, :, :Ndlys//2, : :] = 0.0
+            if store_window:
+                leftleft = uvp.window_function_array[spw][:, 1:Ndlys//2, 1:Ndlys//2, :][:, ::-1, ::-1, :]
+                leftright = uvp.window_function_array[spw][:, 1:Ndlys//2, Ndlys//2+1:, :][:, ::-1, :, :]
+                rightleft = uvp.window_function_array[spw][:, Ndlys//2+1: , 1:Ndlys//2, :][:, :, ::-1, :]
+                rightright = uvp.window_function_array[spw][:, Ndlys//2+1:, Ndlys//2+1:, :]
+                uvp.window_function_array[spw][:, Ndlys//2+1:, Ndlys//2+1:, :] = .25*(leftleft\
+                                                                             +leftright\
+                                                                             +rightleft\
+                                                                             +rightright)
+                uvp.window_function_array[spw][:, :Ndlys//2, :, :] = 0.0
+                uvp.window_function_array[spw][:, :, :Ndlys//2, : :] = 0.0
 
             # fold covariance array if it exists.
             if hasattr(uvp,'cov_array'):

--- a/hera_pspec/grouping.py
+++ b/hera_pspec/grouping.py
@@ -875,7 +875,7 @@ def fold_spectra(uvp):
             uvp.data_array[spw][:, Ndlys//2+1:, :] = np.mean([left, right], axis=0)
             uvp.data_array[spw][:, :Ndlys//2, :] = 0.0
             uvp.nsample_array[spw] *= 2.0
-            if store_window:
+            if hasattr(uvp, 'window_function_array'):
                 leftleft = uvp.window_function_array[spw][:, 1:Ndlys//2, 1:Ndlys//2, :][:, ::-1, ::-1, :]
                 leftright = uvp.window_function_array[spw][:, 1:Ndlys//2, Ndlys//2+1:, :][:, ::-1, :, :]
                 rightleft = uvp.window_function_array[spw][:, Ndlys//2+1: , 1:Ndlys//2, :][:, :, ::-1, :]
@@ -915,16 +915,17 @@ def fold_spectra(uvp):
             uvp.data_array[spw][:, Ndlys//2+1:, :] = np.mean([left, right], axis=0)
             uvp.data_array[spw][:, :Ndlys//2, :] = 0.0
             uvp.nsample_array[spw] *= 2.0
-            leftleft = uvp.window_function_array[spw][:, :Ndlys//2, :Ndlys//2, :][:, ::-1, ::-1, :]
-            leftright = uvp.window_function_array[spw][:, :Ndlys//2, Ndlys//2+1:, :][:, ::-1, :, :]
-            rightleft = uvp.window_function_array[spw][:, Ndlys//2+1: , :Ndlys//2, :][:, :, ::-1, :]
-            rightright = uvp.window_function_array[spw][:, Ndlys//2+1:, Ndlys//2+1:, :]
-            uvp.window_function_array[spw][:, Ndlys//2+1:, Ndlys//2+1:, :] = .25*(leftleft\
-                                                                         +leftright\
-                                                                         +rightleft\
-                                                                         +rightright)
-            uvp.window_function_array[spw][:, :Ndlys//2, :, :] = 0.0
-            uvp.window_function_array[spw][:, :, :Ndlys//2, : :] = 0.0
+            if hasattr(uvp, 'window_function_array'):
+                leftleft = uvp.window_function_array[spw][:, :Ndlys//2, :Ndlys//2, :][:, ::-1, ::-1, :]
+                leftright = uvp.window_function_array[spw][:, :Ndlys//2, Ndlys//2+1:, :][:, ::-1, :, :]
+                rightleft = uvp.window_function_array[spw][:, Ndlys//2+1: , :Ndlys//2, :][:, :, ::-1, :]
+                rightright = uvp.window_function_array[spw][:, Ndlys//2+1:, Ndlys//2+1:, :]
+                uvp.window_function_array[spw][:, Ndlys//2+1:, Ndlys//2+1:, :] = .25*(leftleft\
+                                                                             +leftright\
+                                                                             +rightleft\
+                                                                             +rightright)
+                uvp.window_function_array[spw][:, :Ndlys//2, :, :] = 0.0
+                uvp.window_function_array[spw][:, :, :Ndlys//2, : :] = 0.0
 
             # fold covariance array if it exists.
             if hasattr(uvp,'cov_array'):

--- a/hera_pspec/grouping.py
+++ b/hera_pspec/grouping.py
@@ -422,8 +422,8 @@ def average_spectra(uvp_in, blpair_groups=None, time_avg=False,
                         / (np.sum(w_list, axis=0).clip(1e-40, np.inf)**2)
                     bpg_stats[stat] = np.sqrt(arr)
                     if store_window:
-                    bpg_window_function = np.sum(bpg_window_function, axis=0) \
-                                / (np.sum(w_list, axis=0).clip(1e-40, np.inf)[:,:,None])
+                        bpg_window_function = np.sum(bpg_window_function, axis=0) \
+                                    / (np.sum(w_list, axis=0).clip(1e-40, np.inf)[:,:,None])
                 # Append to lists (polarization)
                 pol_data.extend(bpg_data); pol_wgts.extend(bpg_wgts)
                 pol_ints.extend(bpg_ints); pol_nsmp.extend(bpg_nsmp)

--- a/hera_pspec/grouping.py
+++ b/hera_pspec/grouping.py
@@ -423,9 +423,9 @@ def average_spectra(uvp_in, blpair_groups=None, time_avg=False,
                     arr = np.sum(bpg_stats[stat], axis=0) \
                         / (np.sum(w_list, axis=0).clip(1e-40, np.inf)**2)
                     bpg_stats[stat] = np.sqrt(arr)
-                    if store_window:
-                        bpg_window_function = np.sum(bpg_window_function, axis=0) \
-                                    / (np.sum(w_list, axis=0).clip(1e-40, np.inf)[:,:,None])
+                if store_window:
+                    bpg_window_function = np.sum(bpg_window_function, axis=0) \
+                                / (np.sum(w_list, axis=0).clip(1e-40, np.inf)[:,:,None])
                 # Append to lists (polarization)
                 pol_data.extend(bpg_data); pol_wgts.extend(bpg_wgts)
                 pol_ints.extend(bpg_ints); pol_nsmp.extend(bpg_nsmp)

--- a/hera_pspec/pspecdata.py
+++ b/hera_pspec/pspecdata.py
@@ -3161,7 +3161,7 @@ def pspec_run(dsets, filename, dsets_std=None, cals=None, cal_flag=True,
               input_data_weight='identity', norm='I', taper='none',
               exclude_auto_bls=False, exclude_cross_bls=False, exclude_permutations=True,
               Nblps_per_group=None, bl_len_range=(0, 1e10),
-              bl_deg_range=(0, 180), bl_error_tol=1.0,
+              bl_deg_range=(0, 180), bl_error_tol=1.0, store_window=True,
               beam=None, cosmo=None, interleave_times=False, rephase_to_dset=None,
               trim_dset_lsts=False, broadcast_dset_flags=True,
               time_thresh=0.2, Jy2mK=False, overwrite=True, symmetric_taper=True,
@@ -3278,6 +3278,10 @@ def pspec_run(dsets, filename, dsets_std=None, cals=None, cal_flag=True,
 
     bl_error_tol : float
         Baseline vector error tolerance when constructing redundant groups.
+
+    store_window : bool
+        If True, store computed window functions (warning, these can be large!)
+        in UVPSpec objects.
 
     beam : PSpecBeam object, UVBeam object or string
         Beam model to use in OQE. Can be a PSpecBeam object or a filepath
@@ -3609,7 +3613,8 @@ def pspec_run(dsets, filename, dsets_std=None, cals=None, cal_flag=True,
                        spw_ranges=spw_ranges, n_dlys=n_dlys, r_params = r_params,
                        store_cov=store_cov, input_data_weight=input_data_weight,
                        norm=norm, taper=taper, history=history, verbose=verbose,
-                       cov_model=cov_model, filter_extensions=filter_extensions)
+                       cov_model=cov_model, filter_extensions=filter_extensions,
+                       store_window=store_window)
 
         # Store output
         psname = '{}_x_{}{}'.format(dset_labels[dset_idxs[0]],

--- a/hera_pspec/pspecdata.py
+++ b/hera_pspec/pspecdata.py
@@ -2283,9 +2283,9 @@ class PSpecData(object):
         return valid
 
     def pspec(self, bls1, bls2, dsets, pols, n_dlys=None,
-              input_data_weight='identity', norm='I', taper='none',
-              sampling=False, little_h=True, spw_ranges=None, symmetric_taper=True,
-              baseline_tol=1.0, store_cov=False, verbose=True, filter_extensions=None,
+              input_data_weight='identity', norm='I', taper='none', sampling=False,
+              little_h=True, spw_ranges=None, symmetric_taper=True, baseline_tol=1.0,
+              store_cov=False, store_window=True, verbose=True, filter_extensions=None,
               exact_norm=False, history='', r_params=None, cov_model='empirical'):
         """
         Estimate the delay power spectrum from a pair of datasets contained in
@@ -2366,17 +2366,21 @@ class PSpecData(object):
             (None) is to use the entire band provided in each dataset.
 
         symmetric_taper : bool, optional
-            speicfy if taper should be applied symmetrically to K-matrix (if true)
-            or on the left (if False). default is True
+            Specify if taper should be applied symmetrically to K-matrix (if true)
+            or on the left (if False). Default: True
 
         baseline_tol : float, optional
             Distance tolerance for notion of baseline "redundancy" in meters.
             Default: 1.0.
 
-        store_cov : boolean, optional
+        store_cov : bool, optional
             If True, calculate an analytic covariance between bandpowers
             given an input visibility noise model, and store the output
             in the UVPSpec object.
+
+        store_window : bool, optional
+            If True, store the window function of the bandpowers.
+            Default: True
 
         cov_model : string, optional
             How the covariances of the input data should be estimated.
@@ -2780,7 +2784,7 @@ class PSpecData(object):
                         pol_cov.extend(cov_pv)
                     
                     # store the window_function
-                    pol_window_function.extend(np.repeat(Wv[np.newaxis,:,:], qv.shape[1], axis=0).astype(np.complex128))
+                    pol_window_function.extend(np.repeat(Wv[np.newaxis,:,:], qv.shape[1], axis=0).astype(np.float64))
 
                     # Get baseline keys
                     if isinstance(blp, list):
@@ -2934,16 +2938,17 @@ class PSpecData(object):
 
         # fill data arrays
         uvp.data_array = data_array
-        if store_cov:
-            uvp.cov_array = cov_array
-            uvp.cov_model = cov_model
-
-        uvp.window_function_array = window_function_array
         uvp.integration_array = integration_array
         uvp.wgt_array = wgt_array
         uvp.nsample_array = dict(
                         [ (k, np.ones_like(uvp.integration_array[k], np.float))
                          for k in uvp.integration_array.keys() ] )
+        if store_cov:
+            uvp.cov_array = cov_array
+            uvp.cov_model = cov_model
+
+        if store_window:
+            uvp.window_function_array = window_function_array
 
         # run check
         uvp.check()

--- a/hera_pspec/pspecdata.py
+++ b/hera_pspec/pspecdata.py
@@ -1700,11 +1700,6 @@ class PSpecData(object):
         # Build M matrix according to specified mode
         if mode == 'H^-1':
             try:
-                # if condition number if above 1e17 take pinv
-                if np.linalg.cond(H) < 1e17:
-                    raise np.linalg.LinAlgError('cond(H) > 1e17 (Singular matrix), taking pinv')
-
-                # else take direct inverse
                 M = np.linalg.inv(H)
 
             except np.linalg.LinAlgError as err:

--- a/hera_pspec/pspecdata.py
+++ b/hera_pspec/pspecdata.py
@@ -1681,18 +1681,11 @@ class PSpecData(object):
 
         # Build M matrix according to specified mode
         if mode == 'H^-1':
-
             try:
-                M = np.linalg.inv(H)
+                M = np.linalg.pinv(H)
             except np.linalg.LinAlgError as err:
-                if 'Singular matrix' in str(err):
-                    M = np.linalg.pinv(H)
-                    raise_warning("Warning: Window function matrix is singular "
-                                  "and cannot be inverted, so using "
-                                  " pseudoinverse instead.")
-                else:
-                    raise np.linalg.LinAlgError("Linear algebra error with H matrix "
-                                                "during MW computation.")
+                raise np.linalg.LinAlgError("Linear algebra error with H matrix "
+                                            "during MW computation.")
 
             W = np.dot(M, H)
             W_norm = np.sum(W, axis=1)

--- a/hera_pspec/testing.py
+++ b/hera_pspec/testing.py
@@ -102,7 +102,7 @@ def build_vanilla_uvpspec(beam=None):
         # dimensions of the input visibilities, not the output delay spectra
         integration_array[s] = np.ones((Nblpairts, Npols), dtype=np.float)
         nsample_array[s] = np.ones((Nblpairts, Npols), dtype=np.float)
-        window_function_array[s] = np.ones((Nblpairts, Ndlys, Ndlys, Npols), dtype=np.complex)
+        window_function_array[s] = np.ones((Nblpairts, Ndlys, Ndlys, Npols), dtype=np.float64)
         cov_array[s] =np.moveaxis(np.array([[np.identity(Ndlys,dtype=np.complex)\
                                              for m in range(Nblpairts)]
                                              for n in range(Npols)]), 0, -1)
@@ -134,7 +134,7 @@ def build_vanilla_uvpspec(beam=None):
 
 def uvpspec_from_data(data, bl_grps, data_std=None, spw_ranges=None,
                       beam=None, taper='none', cosmo=None, n_dlys=None,
-                      r_params=None, verbose=False):
+                      r_params=None, verbose=False, **kwargs):
     """
     Build an example UVPSpec object from a visibility file and PSpecData.
 
@@ -184,6 +184,9 @@ def uvpspec_from_data(data, bl_grps, data_std=None, spw_ranges=None,
     verbose : bool, optional
         if True, report feedback to standard output. Default: False.
 
+    kwargs : dict, optional
+        Additional kwargs to pass to PSpecData.pspec()
+    
     Returns
     -------
     uvp : UVPSpec object
@@ -240,7 +243,7 @@ def uvpspec_from_data(data, bl_grps, data_std=None, spw_ranges=None,
     uvp = ds.pspec(bls1, bls2, (0, 1), (pol, pol), input_data_weight='identity',
                    spw_ranges=spw_ranges, taper=taper, verbose=verbose,
                    store_cov=store_cov, n_dlys=n_dlys, r_params=r_params,
-                   cov_model=cov_model)
+                   cov_model=cov_model, **kwargs)
 
     return uvp
 

--- a/hera_pspec/testing.py
+++ b/hera_pspec/testing.py
@@ -103,7 +103,7 @@ def build_vanilla_uvpspec(beam=None):
         integration_array[s] = np.ones((Nblpairts, Npols), dtype=np.float)
         nsample_array[s] = np.ones((Nblpairts, Npols), dtype=np.float)
         window_function_array[s] = np.ones((Nblpairts, Ndlys, Ndlys, Npols), dtype=np.float64)
-        cov_array[s] =np.moveaxis(np.array([[np.identity(Ndlys,dtype=np.complex)\
+        cov_array[s] = np.moveaxis(np.array([[np.identity(Ndlys,dtype=np.complex) \
                                              for m in range(Nblpairts)]
                                              for n in range(Npols)]), 0, -1)
 
@@ -133,8 +133,8 @@ def build_vanilla_uvpspec(beam=None):
 
 
 def uvpspec_from_data(data, bl_grps, data_std=None, spw_ranges=None,
-                      beam=None, taper='none', cosmo=None, n_dlys=None,
-                      r_params=None, verbose=False, **kwargs):
+                      data_weighting='identity', beam=None, taper='none', cosmo=None,
+                      n_dlys=None, r_params=None, verbose=False, **kwargs):
     """
     Build an example UVPSpec object from a visibility file and PSpecData.
 
@@ -155,6 +155,10 @@ def uvpspec_from_data(data, bl_grps, data_std=None, spw_ranges=None,
     spw_ranges : list, optional
         List of spectral window tuples. See PSpecData.pspec docstring for
         details. Default: None.
+
+    data_weighting : str, optional
+        R matrix specification in QE formalism. See PSpecData.pspec for details.
+        Default: 'identity'
 
     beam : PSpecBeamBase subclass or str, optional
         This can be a subclass of PSpecBeamBase of a string filepath to a
@@ -240,7 +244,7 @@ def uvpspec_from_data(data, bl_grps, data_std=None, spw_ranges=None,
         bls2.extend(_bls2)
 
     # run pspec
-    uvp = ds.pspec(bls1, bls2, (0, 1), (pol, pol), input_data_weight='identity',
+    uvp = ds.pspec(bls1, bls2, (0, 1), (pol, pol), input_data_weight=data_weighting,
                    spw_ranges=spw_ranges, taper=taper, verbose=verbose,
                    store_cov=store_cov, n_dlys=n_dlys, r_params=r_params,
                    cov_model=cov_model, **kwargs)

--- a/hera_pspec/tests/test_grouping.py
+++ b/hera_pspec/tests/test_grouping.py
@@ -287,7 +287,7 @@ def test_validate_bootstrap_errorbar():
                    taper='none', sampling=False, little_h=False, spw_ranges=[(0, 50)], verbose=False)
 
     # bootstrap resample
-    Nsamples = 1000
+    Nsamples = 100
     seed = 0
     uvp_avg, uvp_boots, uvp_wgts = grouping.bootstrap_resampled_error(uvp, time_avg=False, Nsamples=Nsamples,
                                                                       seed=seed, normal_std=True,

--- a/hera_pspec/tests/test_grouping.py
+++ b/hera_pspec/tests/test_grouping.py
@@ -81,6 +81,7 @@ class Test_grouping(unittest.TestCase):
         """
         Test average spectra behavior.
         """
+        ## Start file prep ##
         dfile = os.path.join(DATA_PATH, 'zen.all.xx.LST.1.06964.uvA')
         # Load into UVData objects
         uvd = UVData()
@@ -121,17 +122,32 @@ class Test_grouping(unittest.TestCase):
         errs = np.ones((uvp.Ntimes, uvp.Ndlys))
         for key in keys:
             uvp.set_stats("simple", key, errs)
-        blpair_groups = [[((24, 25), (37, 38)),((24, 25), (38, 39)), ((37, 38), (38, 39))]]
+        ## End file prep ##
+
+        # begin tests
+        blpair_groups = [blpairs]
         uvp_avg_ints_wgts = grouping.average_spectra(uvp, blpair_groups=blpair_groups,
                                                 error_field="noise", time_avg=True,inplace=False)
         uvp_avg_noise_wgts = grouping.average_spectra(uvp, time_avg=True, blpair_groups=blpair_groups,
                                                  error_weights="noise", inplace=False)
         uvp_avg_simple_wgts = grouping.average_spectra(uvp, blpair_groups=blpair_groups, time_avg=True, error_weights="simple", inplace=False)
-        nt.assert_true(np.all(np.isclose(uvp_avg_simple_wgts.stats_array["simple"][0][0,0,0], uvp.stats_array["simple"][0][0,0,0]/np.sqrt(uvp.Ntimes)/np.sqrt(len(blpairs)))))
-        # For using uniform error bars as weights, the error bar on the average is 1/sqrt{N} times the error bar on one single sample. 
-        assert(abs(uvp_avg_ints_wgts.stats_array["noise"][0][0,0,0]) < abs(uvp.stats_array["noise"][0][0,0,0]))
-        assert(abs(uvp_avg_noise_wgts.stats_array["noise"][0][0,0,0]) < abs(uvp.stats_array["noise"][0][0,0,0]))
+        # For using uniform error bars as weights, the error bar on the average is 1/sqrt{N} times the error bar on one single sample.
+        averaged_stat = uvp_avg_simple_wgts.stats_array["simple"][0][0, 0, 0]
+        initial_stat = uvp.stats_array["simple"][0][0, 0, 0] / np.sqrt(uvp.Ntimes) / np.sqrt(len(blpairs))
+        nt.assert_true(np.all(np.isclose(initial_stat, averaged_stat)))
         # For non-uniform weights, we test the error bar on the average power spectra should be smaller than one on single sample.
+        assert(abs(uvp_avg_ints_wgts.stats_array["noise"][0][0, 0, 0]) < abs(uvp.stats_array["noise"][0][0, 0, 0]))
+        assert(abs(uvp_avg_noise_wgts.stats_array["noise"][0][0, 0, 0]) < abs(uvp.stats_array["noise"][0][0, 0, 0]))
+
+        # test infinite variance on stats_array average: test it doesn't result in stats_array nans
+        # and that the avg effectively ignores its presence: e.g. check it matches initial over sqrt(Nblpairs - 1)
+        uvp_inf_var = copy.deepcopy(uvp)
+        initial_stat = uvp.get_stats('simple', (0, blpairs[0], 'xx'))
+        inf_var_stat = np.ones((uvp_inf_var.Ntimes, uvp_inf_var.Ndlys)) * np.inf
+        uvp_inf_var.set_stats('simple', (0, blpairs[1], 'xx'), inf_var_stat)
+        uvp_inf_var_avg = uvp_inf_var.average_spectra(blpair_groups=blpair_groups, error_weights='simple', inplace=False)
+        final_stat = uvp_inf_var_avg.get_stats('simple', (0, blpairs[0], 'xx'))
+        assert np.isclose(final_stat, initial_stat / np.sqrt(len(blpairs) - 1)).all()
 
     def test_sample_baselines(self):
         """

--- a/hera_pspec/tests/test_pspecdata.py
+++ b/hera_pspec/tests/test_pspecdata.py
@@ -1952,8 +1952,7 @@ def test_window_funcs():
     ds.set_taper('bh')
     bl = (37, 38)
     key = (0, bl, 'xx')
-    d = medfilt2d(uvd.get_data(bl).real, (1, 11)) \
-        + 1j * medfilt2d(uvd.get_data(bl).imag, (1, 11))
+    d = uvd.get_data(bl)
     C = np.cov(d[:, :20].T).real
     iC = np.linalg.pinv(C)
     # iterate over various R and M matrices and ensure

--- a/hera_pspec/tests/test_pspecdata.py
+++ b/hera_pspec/tests/test_pspecdata.py
@@ -1956,8 +1956,8 @@ def test_window_funcs():
     # get covariance model by median filtering
     d = medfilt2d(uvd.get_data(bl).real, (1, 11)) \
         + 1j * medfilt2d(uvd.get_data(bl).imag, (1, 11))
-    C = np.cov(d.T).real
-    iC = np.linalg.pinv(C[:20, :20])
+    C = np.cov(d[:, :20].T).real
+    iC = np.linalg.pinv(C)
     # iterate over various R and M matrices and ensure
     # normalization and dtype is consistent
     for data_weight in ['identity', 'iC']:

--- a/hera_pspec/tests/test_pspecdata.py
+++ b/hera_pspec/tests/test_pspecdata.py
@@ -1944,7 +1944,6 @@ def test_window_funcs():
     This is complementary to test_get_MW above.
     """
     # get a PSpecData
-    from scipy.signal import medfilt2d
     uvd = UVData()
     uvd.read_miriad(os.path.join(DATA_PATH, 'zen.even.xx.LST.1.28828.uvOCRSA'))
     beam = pspecbeam.PSpecBeamUV(os.path.join(DATA_PATH, "HERA_NF_dipole_power.beamfits"))
@@ -1953,7 +1952,6 @@ def test_window_funcs():
     ds.set_taper('bh')
     bl = (37, 38)
     key = (0, bl, 'xx')
-    # get covariance model by median filtering
     d = medfilt2d(uvd.get_data(bl).real, (1, 11)) \
         + 1j * medfilt2d(uvd.get_data(bl).imag, (1, 11))
     C = np.cov(d[:, :20].T).real

--- a/hera_pspec/tests/test_pspecdata.py
+++ b/hera_pspec/tests/test_pspecdata.py
@@ -677,10 +677,6 @@ class Test_PSpecData(unittest.TestCase):
                 for i in range(3):
                     self.assertAlmostEqual(norm[i], 1.)
 
-                # Check that a warning is raised when H matrix is not square
-                rectangle_H = np.ones((4,3))
-                nt.assert_raises(np.linalg.LinAlgError, self.ds.get_MW, random_G, rectangle_H, mode=mode)
-
                 # Check that the method ignores G
                 M, W = self.ds.get_MW(random_G, random_H, mode=mode)
                 M_other, W_other = self.ds.get_MW(random_H, random_H, mode=mode)
@@ -1948,15 +1944,20 @@ def test_window_funcs():
     This is complementary to test_get_MW above.
     """
     # get a PSpecData
+    from scipy.signal import medfilt2d
     uvd = UVData()
     uvd.read_miriad(os.path.join(DATA_PATH, 'zen.even.xx.LST.1.28828.uvOCRSA'))
     beam = pspecbeam.PSpecBeamUV(os.path.join(DATA_PATH, "HERA_NF_dipole_power.beamfits"))
     ds = pspecdata.PSpecData(dsets=[copy.deepcopy(uvd)], beam=beam)
     ds.set_spw((0, 20))
+    ds.set_taper('bh')
     bl = (37, 38)
     key = (0, bl, 'xx')
-    band_covar = np.eye(uvd.Nfreqs).astype(np.complex)  # for V^-1/2 norm
-    iC = np.linalg.pinv(np.cov(uvd.get_data(bl)[:, :20].T))
+    # get covariance model by median filtering
+    d = medfilt2d(uvd.get_data(bl).real, (1, 11)) \
+        + 1j * medfilt2d(uvd.get_data(bl).imag, (1, 11))
+    C = np.cov(d.T).real
+    iC = np.linalg.pinv(C[:20, :20])
     # iterate over various R and M matrices and ensure
     # normalization and dtype is consistent
     for data_weight in ['identity', 'iC']:
@@ -1969,16 +1970,16 @@ def test_window_funcs():
                 ds.clear_cache()
                 if data_weight == 'iC':
                     # fill R with iC
-                    ds._R[(0, (37, 38, 'xx'), 'iC', 'none', 0, 0, 20, True)] = iC
+                    ds._R[(0, (37, 38, 'xx'), 'iC', 'bh')] = iC
                 # compute G and H
                 Gv = ds.get_G(key, key, exact_norm=exact_norm, pol='xx')
                 Hv = ds.get_H(key, key, exact_norm=exact_norm, pol='xx')
                 Mv, Wv = ds.get_MW(Gv, Hv, mode=norm, exact_norm=exact_norm,
-                                   band_covar=band_covar)
+                                   band_covar=C)
                 # assert row-sum is normalized to 1
                 assert np.isclose(Wv.sum(axis=1).real, 1).all()
                 # assert this is a real matrix, even though imag is populated
-                assert np.isclose(Wv.imag, 0).all()
+                assert np.isclose(Wv.imag, 0, atol=1e-6).all()
 
 
 def test_get_argparser():

--- a/hera_pspec/tests/test_uvpspec.py
+++ b/hera_pspec/tests/test_uvpspec.py
@@ -763,7 +763,13 @@ def test_conj_blpair():
     nt.assert_equal(blpair, 102101104103)
     nt.assert_raises(ValueError, uvputils._conj_blpair, 102101103104, which='foo')
 
-def test_compatibility_read():
+def test_backwards_compatibility_read():
+    """This is a backwards compatibility test.
+    If it fails, your edits must be changed to make this test pass.
+    If the hera_pspec team decides to move forward and break
+    compatibility, this file can be overwritten
+    and the date of the file changed in the comment below.
+    """
     # test read in of a static test file dated 8/2019
     uvp = uvpspec.UVPSpec()
     uvp.read_hdf5(os.path.join(DATA_PATH, 'test_uvp.h5'))

--- a/hera_pspec/uvpspec_utils.py
+++ b/hera_pspec/uvpspec_utils.py
@@ -686,7 +686,7 @@ def _select(uvp, spws=None, bls=None, only_pairs_in_bls=False, blpairs=None,
             store_window = 'window_function_spw0' in h5file
         else:
             store_cov = hasattr(uvp, 'cov_array')
-            store_window = hasattr(uvp, window_function_array)
+            store_window = hasattr(uvp, 'window_function_array')
 
         # get stats_array keys if h5file
         if h5file is not None:

--- a/hera_pspec/uvpspec_utils.py
+++ b/hera_pspec/uvpspec_utils.py
@@ -82,12 +82,6 @@ def subtract_uvp(uvp1, uvp2, run_check=True, verbose=False):
                 uvp1.wgt_array[i][blp1_inds, :, :, j] /= \
                     uvp1.wgt_array[i][blp1_inds, :, :, j].max()
 
-                window1 = uvp1.get_window_function(key1)
-                window2 = uvp2.get_window_function(key2)
-                uvp1.window_function_array[i][blp1_inds, :, :, j] \
-                    = np.sqrt(window1.real**2 + window2.real**2) \
-                    + 1j*np.sqrt(window1.imag**2 + window2.imag**2)
-
                 # add stats in quadrature: real imag separately
                 if hasattr(uvp1, "stats_array") and hasattr(uvp2, "stats_array"):
                     for s in uvp1.stats_array.keys():
@@ -104,6 +98,15 @@ def subtract_uvp(uvp1, uvp2, run_check=True, verbose=False):
                     uvp1.cov_array[i][blp1_inds, :, :, j] \
                         = np.sqrt(cov1.real**2 + cov2.real**2) \
                         + 1j*np.sqrt(cov1.imag**2 + cov2.imag**2)
+
+                # same for window function
+                if (hasattr(uvp1, 'window_function_array') 
+                    and hasattr(uvp2, 'window_function_array')):
+                    window1 = uvp1.get_window_function(key1)
+                    window2 = uvp2.get_window_function(key2)
+                    uvp1.window_function_array[i][blp1_inds, :, :, j] \
+                        = np.sqrt(window1.real**2 + window2.real**2) \
+                        + 1j*np.sqrt(window1.imag**2 + window2.imag**2)
 
     # run check
     if run_check:
@@ -677,11 +680,13 @@ def _select(uvp, spws=None, bls=None, only_pairs_in_bls=False, blpairs=None,
         stats = odict()
         window_function = odict()
 
-        # determine if cov_array is stored
+        # determine if certain arrays are stored
         if h5file is not None:
             store_cov = 'cov_spw0' in h5file
+            store_window = 'window_function_spw0' in h5file
         else:
             store_cov = hasattr(uvp, 'cov_array')
+            store_window = hasattr(uvp, window_function_array)
 
         # get stats_array keys if h5file
         if h5file is not None:
@@ -704,11 +709,11 @@ def _select(uvp, spws=None, bls=None, only_pairs_in_bls=False, blpairs=None,
                 _wgts = h5file['wgt_spw{}'.format(s_old)]
                 _ints = h5file['integration_spw{}'.format(s_old)]
                 _nsmp = h5file['nsample_spw{}'.format(s_old)]
-                _window_function = h5file['window_function_spw{}'.format(s_old)]
-                # assign cov array
+                # assign non-required arrays
+                if store_window:
+                    _window_function = h5file['window_function_spw{}'.format(s_old)]
                 if store_cov:
                     _covs = h5file['cov_spw{}'.format(s_old)]
-                # assign stats array
                 _stat = odict()
                 for statname in statnames:
                     if statname not in stats:
@@ -722,8 +727,9 @@ def _select(uvp, spws=None, bls=None, only_pairs_in_bls=False, blpairs=None,
                 _wgts = uvp.wgt_array[s_old]
                 _ints = uvp.integration_array[s_old]
                 _nsmp = uvp.nsample_array[s_old]
-                _window_function = uvp.window_function_array[s_old]
-                # assign cov
+                # assign non-required arrays
+                if store_window:
+                    _window_function = uvp.window_function_array[s_old]
                 if store_cov:
                     _covs = uvp.cov_array[s_old]
                 # assign stats array
@@ -740,7 +746,8 @@ def _select(uvp, spws=None, bls=None, only_pairs_in_bls=False, blpairs=None,
                 wgts[s] = _wgts[blp_select, :, :, polpair_select]
                 ints[s] = _ints[blp_select, polpair_select]
                 nsmp[s] = _nsmp[blp_select, polpair_select]
-                window_function[s] = _window_function[blp_select, :, :, polpair_select]
+                if store_window:
+                    window_function[s] = _window_function[blp_select, :, :, polpair_select]
                 if store_cov:
                     cov[s] = _covs[blp_select, :, :, polpair_select]
                 for statname in statnames:
@@ -751,7 +758,8 @@ def _select(uvp, spws=None, bls=None, only_pairs_in_bls=False, blpairs=None,
                 wgts[s] = _wgts[blp_select, :, :, :][:, :, :, polpair_select]
                 ints[s] = _ints[blp_select, :][:, polpair_select]
                 nsmp[s] = _nsmp[blp_select, :][:, polpair_select]
-                window_function[s] = _window_function[blp_select, :, :, :][:, :, :, polpair_select]
+                if store_window:
+                    window_function[s] = _window_function[blp_select, :, :, :][:, :, :, polpair_select]
                 if store_cov:
                     cov[s] = _covs[blp_select, :, :, :][:, :, :, polpair_select]
                 for statname in statnames:
@@ -762,7 +770,8 @@ def _select(uvp, spws=None, bls=None, only_pairs_in_bls=False, blpairs=None,
         uvp.wgt_array = wgts
         uvp.integration_array = ints
         uvp.nsample_array = nsmp
-        uvp.window_function_array = window_function
+        if store_window:
+            uvp.window_function_array = window_function
         if len(stats) > 0:
             uvp.stats_array = stats
         if store_cov:


### PR DESCRIPTION
This reverts the `test_uvp.h5` file back to its form in 8/2019, and makes the `window_function_array` attribute of `UVPSpec` a non-required parameter. 

This also addresses #256 : I was getting weird H matrices b/c I was not setting Ndlys after setting spw_range. We now automatically set Ndlys upon a `ds.set_spw()` call so this does not happen.

Another thing I'm finding in adding these tests is a failure in `get_MW` with `mode='V^-1/2'`. The eigenvector decomposition performed leads to some small but negative eigenvalues. There is a warning put in when this happens, but it doesn't do anything about the negative values--and the result is that `1/sqrt(eigvals)` creates nans that then get propagated to the M and W matrices. I fix this by truncating these eigenvectors before taking `1/sqrt(eigvals)`.