### PR TITLE
fixed pstokes multipol files construct_pstokes bug

### DIFF
--- a/hera_pspec/pstokes.py
+++ b/hera_pspec/pstokes.py
@@ -278,7 +278,7 @@ def construct_pstokes(dset1, dset2, pstokes='pI', run_check=True, antenna_nums=N
     assert req_pol2 in uvd2.polarization_array, \
         "Polarization {} not found in dset2 object".format(req_pol2)
     if uvd2.Npols > 1:
-        uvd2 = uvd2.select(polarizations=req_pol1, inplace=False)
+        uvd2 = uvd2.select(polarizations=req_pol2, inplace=False)
 
     # combining visibilities to form the desired Stokes visibilties
     uvdS = _combine_pol(uvd1=uvd1, uvd2=uvd2, pol1=req_pol1, pol2=req_pol2, 

--- a/hera_pspec/uvpspec.py
+++ b/hera_pspec/uvpspec.py
@@ -1416,9 +1416,10 @@ class UVPSpec(object):
             group.create_dataset("nsample_spw{}".format(i),
                                  data=self.nsample_array[i],
                                  dtype=np.float)
-            group.create_dataset("window_function_spw{}".format(i),
-                                 data=self.window_function_array[i],
-                                 dtype=np.float64)
+            if hasattr(self, "window_function_array"):
+                group.create_dataset("window_function_spw{}".format(i),
+                                     data=self.window_function_array[i],
+                                     dtype=np.float64)
             if hasattr(self, "cov_array"):
                 group.create_dataset("cov_spw{}".format(i),
                                      data=self.cov_array[i],


### PR DESCRIPTION
There was a pretty serious bug in `pstokes.construct_pstokes` where the right-hand polarization was not being selected properly from the input UVData object, see here #260.

Turns out this was only a problem when operating on multi-polarization files, which, while the code supported, was not being tested on, as at the time we used 1-pol files.
This PR fixes that bug and adds tests for the `construct_pstokes` method on our multi-pol files to catch this kind of bug going forward. Thanks @anguta for spotting this!