### PR TITLE
fixed stats_array propagation bug in combine_uvpspec

### DIFF
--- a/hera_pspec/grouping.py
+++ b/hera_pspec/grouping.py
@@ -338,7 +338,8 @@ def average_spectra(uvp_in, blpair_groups=None, time_avg=False,
                     # Get squared statistic
                     errws = {}
                     for stat in stat_l:
-                        errws[stat] = (uvp.get_stats(stat, (spw, blp, p)))**2
+                        errws[stat] = uvp.get_stats(error_weights, (spw, blp, p))
+                        np.square(errws[stat], out=errws[stat], where=np.isfinite(errws[stat]))
                         # shape of errs: (Ntimes, Ndlys)
 
                     if use_error_weights:

--- a/hera_pspec/grouping.py
+++ b/hera_pspec/grouping.py
@@ -338,7 +338,7 @@ def average_spectra(uvp_in, blpair_groups=None, time_avg=False,
                     # Get squared statistic
                     errws = {}
                     for stat in stat_l:
-                        errws[stat] = uvp.get_stats(stat, (spw, blp, p))
+                        errws[stat] = uvp.get_stats(stat, (spw, blp, p)).copy()
                         np.square(errws[stat], out=errws[stat], where=np.isfinite(errws[stat]))
                         # shape of errs: (Ntimes, Ndlys)
 
@@ -351,7 +351,7 @@ def average_spectra(uvp_in, blpair_groups=None, time_avg=False,
                     # epsilon_avg = \sum{ (epsilon_i / (sigma_i)^4 } / ( \sum{ 1 / (sigma_i)^2 } )^2
                     # For reference: M. Tegmark 1997, The Astrophysical Journal Letters, 480, L87, Table 1, #3
                     # or J. Dillon 2014, Physical Review D, 89, 023002 , Equation 34.
-                        stat_val = uvp.get_stats(error_weights, (spw, blp, p))
+                        stat_val = uvp.get_stats(error_weights, (spw, blp, p)).copy()
                         np.square(stat_val, out=stat_val, where=np.isfinite(stat_val))
                         w = np.real(1. / stat_val.clip(1e-40, np.inf))
                         # shape of w: (Ntimes, Ndlys)
@@ -732,7 +732,7 @@ def spherical_average(uvp_in, kbins, bin_widths, blpair_groups=None, time_avg=Fa
 
             elif error_weights is not None:
                 # fill diagonal with by 1/stats_array^2 as weight
-                stat_weight = stats_array[error_weights][spw][:, dslice].real
+                stat_weight = stats_array[error_weights][spw][:, dslice].real.copy()
                 np.square(stat_weight, out=stat_weight, where=np.isfinite(stat_weight))
                 E[:, range(dstart, dstop), range(dstart, dstop)] = 1 / stat_weight.clip(1e-40, np.inf)
 
@@ -796,7 +796,7 @@ def spherical_average(uvp_in, kbins, bin_widths, blpair_groups=None, time_avg=Fa
             # bin stats: C_sph = H.T C_cyl H
             for stat in stats_array:
                 # get squared stat and clip infs b/c linalg doesn't like them
-                sq_stat = stats_array[stat][spw]
+                sq_stat = stats_array[stat][spw].copy()
                 np.square(sq_stat, out=sq_stat, where=np.isfinite(sq_stat))
                 # einsum is fast enough for this, and is more succinct than matmul
                 avg_stat = np.sqrt(np.einsum("ptik,tip,ptik->tkp", H, sq_stat.clip(0, 1e40), H))

--- a/hera_pspec/grouping.py
+++ b/hera_pspec/grouping.py
@@ -352,7 +352,7 @@ def average_spectra(uvp_in, blpair_groups=None, time_avg=False,
                     # or J. Dillon 2014, Physical Review D, 89, 023002 , Equation 34.
                         stat_val = uvp.get_stats(error_weights, (spw, blp, p))
                         np.square(stat_val, out=stat_val, where=np.isfinite(stat_val))
-                        w = np.real(1. / stat_val)
+                        w = np.real(1. / stat_val.clip(1e-40, np.inf))
                         # shape of w: (Ntimes, Ndlys)
                     else:
                     # Otherwise all arrays are averaged in a way weighted by the integration time,

--- a/hera_pspec/tests/test_grouping.py
+++ b/hera_pspec/tests/test_grouping.py
@@ -453,6 +453,8 @@ def test_spherical_average():
     # assert bins that weren't nulled still have proper window normalization
     for spw in sph2.spw_array:
         assert np.isclose(sph2.window_function_array[spw].sum(axis=2)[:, 3:, :], 1).all()
+    # assert resultant stats are not nan
+    assert (~np.isnan(sph2.stats_array['err'][0])).all()
 
     # exceptions
     nt.assert_raises(AssertionError, grouping.spherical_average, uvp, kbins, 1.0)

--- a/hera_pspec/tests/test_grouping.py
+++ b/hera_pspec/tests/test_grouping.py
@@ -122,10 +122,10 @@ class Test_grouping(unittest.TestCase):
         errs = np.ones((uvp.Ntimes, uvp.Ndlys))
         for key in keys:
             uvp.set_stats("simple", key, errs)
+        blpair_groups = [blpairs]
         ## End file prep ##
 
         # begin tests
-        blpair_groups = [blpairs]
         uvp_avg_ints_wgts = grouping.average_spectra(uvp, blpair_groups=blpair_groups,
                                                 error_field="noise", time_avg=True,inplace=False)
         uvp_avg_noise_wgts = grouping.average_spectra(uvp, time_avg=True, blpair_groups=blpair_groups,
@@ -139,7 +139,7 @@ class Test_grouping(unittest.TestCase):
         assert(abs(uvp_avg_ints_wgts.stats_array["noise"][0][0, 0, 0]) < abs(uvp.stats_array["noise"][0][0, 0, 0]))
         assert(abs(uvp_avg_noise_wgts.stats_array["noise"][0][0, 0, 0]) < abs(uvp.stats_array["noise"][0][0, 0, 0]))
 
-        # test infinite variance on stats_array average: test it doesn't result in stats_array nans
+        # test stats inf variance for all times, single blpair doesn't result in nans
         # and that the avg effectively ignores its presence: e.g. check it matches initial over sqrt(Nblpairs - 1)
         uvp_inf_var = copy.deepcopy(uvp)
         initial_stat = uvp.get_stats('simple', (0, blpairs[0], 'xx'))
@@ -148,6 +148,19 @@ class Test_grouping(unittest.TestCase):
         uvp_inf_var_avg = uvp_inf_var.average_spectra(blpair_groups=blpair_groups, error_weights='simple', inplace=False)
         final_stat = uvp_inf_var_avg.get_stats('simple', (0, blpairs[0], 'xx'))
         assert np.isclose(final_stat, initial_stat / np.sqrt(len(blpairs) - 1)).all()
+
+        # test infinite variance for single time, all blpairs doesn't result in nans
+        # and check that averaged stat for that time is inf (not zero)
+        uvp_inf_var = copy.deepcopy(uvp)
+        initial_stat = uvp.get_stats('simple', (0, blpairs[0], 'xx'))
+        inf_var_stat = np.ones((uvp_inf_var.Ntimes, uvp_inf_var.Ndlys))
+        inf_var_stat[0] = np.inf
+        for blp in blpairs:
+            uvp_inf_var.set_stats('simple', (0, blp, 'xx'), inf_var_stat)
+        uvp_inf_var_avg = uvp_inf_var.average_spectra(blpair_groups=blpair_groups, error_weights='simple', inplace=False)
+        final_stat = uvp_inf_var_avg.get_stats('simple', (0, blpairs[0], 'xx'))
+        assert np.isclose(final_stat[1:], initial_stat[1:] / np.sqrt(len(blpairs))).all()
+        assert np.all(~np.isfinite(final_stat[0]))
 
     def test_sample_baselines(self):
         """

--- a/hera_pspec/tests/test_uvpspec.py
+++ b/hera_pspec/tests/test_uvpspec.py
@@ -621,6 +621,14 @@ class Test_UVPSpec(unittest.TestCase):
         out = uvpspec.combine_uvpspec([uvp_a, uvp_b], merge_history=False, verbose=False)
         assert 'batwing' in out.history and not 'foobar' in out.history
 
+        # test no cov_array if cov_model is not consistent
+        uvp_a = copy.deepcopy(uvp1)
+        uvp_b = copy.deepcopy(uvp1)
+        uvp_b.cov_model = 'foo'
+        uvp_b.polpair_array = np.array([1414])
+        out = uvpspec.combine_uvpspec([uvp_a, uvp_b], verbose=False)
+        assert hasattr(out, 'cov_array') is False
+
     def test_combine_uvpspec_errors(self):
         # setup uvp build
         uvd = UVData()

--- a/hera_pspec/tests/test_uvpspec.py
+++ b/hera_pspec/tests/test_uvpspec.py
@@ -548,6 +548,7 @@ class Test_UVPSpec(unittest.TestCase):
             assert out.cov_array[spw].shape == (30, ndlys, ndlys, 2)
             assert out.stats_array['noise_err'][spw].shape == (30, ndlys, 2)
             assert out.window_function_array[spw].shape == (30, ndlys, ndlys, 2)
+            assert out.cov_model == 'empirical'
 
         # test concat across spw
         uvp2 = testing.uvpspec_from_data(uvd, bls, spw_ranges=[(85, 101)],

--- a/hera_pspec/tests/test_uvpspec.py
+++ b/hera_pspec/tests/test_uvpspec.py
@@ -507,6 +507,18 @@ class Test_UVPSpec(unittest.TestCase):
         nt.assert_equal(uvp.cosmo, new_cosmo2)
         nt.assert_true(hasattr(uvp, 'OmegaP'))
 
+    def _add_optionals(self, uvp):
+        """add dummy optional cov_array and stats_array to uvp"""
+        uvp.cov_array = odict()
+        uvp.cov_model = 'empirical'
+        stat = 'noise_err'
+        uvp.stats_array = odict({stat: odict()})
+        for spw in uvp.spw_array:
+            ndlys = uvp.get_spw_ranges(spw)[0][-1]
+            uvp.cov_array[spw] = np.empty((uvp.Nblpairts, ndlys, ndlys, uvp.Npols), np.complex128)
+            uvp.stats_array[stat][spw] = np.empty((uvp.Nblpairts, ndlys, uvp.Npols), np.complex128)
+        return uvp
+
     def test_combine_uvpspec(self):
         # setup uvp build
         uvd = UVData()
@@ -517,12 +529,10 @@ class Test_UVPSpec(unittest.TestCase):
         uvp1 = testing.uvpspec_from_data(uvd, bls, 
                                          spw_ranges=[(20, 30), (60, 90)], 
                                          beam=beam)
+        uvp1 = self._add_optionals(uvp1)
 
-        # test failure due to overlapping data
+        # test concat across pol
         uvp2 = copy.deepcopy(uvp1)
-        nt.assert_raises(AssertionError, uvpspec.combine_uvpspec, [uvp1, uvp2])
-
-        # test success across pol
         uvp2.polpair_array[0] = 1414
         out = uvpspec.combine_uvpspec([uvp1, uvp2], verbose=False)
         nt.assert_equal(out.Npols, 2)
@@ -532,48 +542,41 @@ class Test_UVPSpec(unittest.TestCase):
                        np.ones(10, dtype=np.float64))))
         nt.assert_true(np.all(np.isclose(out.get_integrations(key), 
                        190 * np.ones(10, dtype=np.float64), atol=5, rtol=2)))
-
-        # test multiple non-overlapping data axes
-        uvp2.freq_array[0] = 0.0
-        nt.assert_raises(AssertionError, uvpspec.combine_uvpspec, [uvp1, uvp2])
-
-        # test partial data overlap failure
-        uvp2 = testing.uvpspec_from_data(uvd, [(37, 38), (38, 39), (53, 54)],
-                                         spw_ranges=[(20, 30), (60, 90)],
-                                         beam=beam)
-        nt.assert_raises(AssertionError, uvpspec.combine_uvpspec, [uvp1, uvp2])
-        uvp2 = testing.uvpspec_from_data(uvd, bls,
-                                         spw_ranges=[(20, 30), (60, 105)],
-                                         beam=beam)
-        nt.assert_raises(AssertionError, uvpspec.combine_uvpspec, [uvp1, uvp2])
-        uvp2 = copy.deepcopy(uvp1)
-        uvp2.polpair_array[0] = 1414
-        uvp2 = uvpspec.combine_uvpspec([uvp1, uvp2], verbose=False)
-        nt.assert_raises(AssertionError, uvpspec.combine_uvpspec, [uvp1, uvp2])
+        # optionals
+        for spw in out.spw_array:
+            ndlys = out.get_spw_ranges(spw)[0][-1]
+            assert out.cov_array[spw].shape == (30, ndlys, ndlys, 2)
+            assert out.stats_array['noise_err'][spw].shape == (30, ndlys, 2)
+            assert out.window_function_array[spw].shape == (30, ndlys, ndlys, 2)
 
         # test concat across spw
         uvp2 = testing.uvpspec_from_data(uvd, bls, spw_ranges=[(85, 101)],
                                          beam=beam)
+        uvp2 = self._add_optionals(uvp2)
+
         out = uvpspec.combine_uvpspec([uvp1, uvp2], verbose=False)
         nt.assert_equal(out.Nspws, 3)
         nt.assert_equal(out.Nfreqs, 51)
         nt.assert_equal(out.Nspwdlys, 56)
+        # optionals
+        assert len(out.stats_array['noise_err']) == 3
+        assert len(out.window_function_array) == 3
+        assert len(out.cov_array) == 3
 
         # test concat across blpairts
         uvp2 = testing.uvpspec_from_data(uvd, [(53, 54), (67, 68)],
                                          spw_ranges=[(20, 30), (60, 90)],
                                          beam=beam)
+        uvp2 = self._add_optionals(uvp2)
         out = uvpspec.combine_uvpspec([uvp1, uvp2], verbose=False)
         nt.assert_equal(out.Nblpairs, 4)
         nt.assert_equal(out.Nbls, 5)
-
-        # test failure due to variable static metadata
-        uvp2.weighting = 'foo'
-        nt.assert_raises(AssertionError, uvpspec.combine_uvpspec, [uvp1, uvp2])
-        uvp2.weighting = 'identity'
-        del uvp2.OmegaP
-        del uvp2.OmegaPP
-        nt.assert_raises(AssertionError, uvpspec.combine_uvpspec, [uvp1, uvp2])
+        # optionals
+        for spw in out.spw_array:
+            ndlys = out.get_spw_ranges(spw)[0][-1]
+            assert out.cov_array[spw].shape == (40, ndlys, ndlys, 1)
+            assert out.stats_array['noise_err'][spw].shape == (40, ndlys, 1)
+            assert out.window_function_array[spw].shape == (40, ndlys, ndlys, 1)
 
         # test feed as strings
         uvp1 = testing.uvpspec_from_data(uvd, bls, spw_ranges=[(20, 30)], beam=beam)
@@ -588,7 +591,9 @@ class Test_UVPSpec(unittest.TestCase):
                 os.remove(ff)
 
         # test UVPSpec __add__
+        uvp2 = copy.deepcopy(uvp1)
         uvp3 = copy.deepcopy(uvp1)
+        uvp2.polpair_array[0] = 1414
         uvp3.polpair_array[0] = 1313
         out = uvp1 + uvp2 + uvp3
         nt.assert_equal(out.Npols, 3)
@@ -614,6 +619,50 @@ class Test_UVPSpec(unittest.TestCase):
         # w/o merge
         out = uvpspec.combine_uvpspec([uvp_a, uvp_b], merge_history=False, verbose=False)
         assert 'batwing' in out.history and not 'foobar' in out.history
+
+    def test_combine_uvpspec_errors(self):
+        # setup uvp build
+        uvd = UVData()
+        uvd.read_miriad(os.path.join(DATA_PATH, 'zen.even.xx.LST.1.28828.uvOCRSA'))
+        beam = pspecbeam.PSpecBeamUV(os.path.join(DATA_PATH,
+                                               "HERA_NF_dipole_power.beamfits"))
+        bls = [(37, 38), (38, 39), (52, 53)]
+        uvp1 = testing.uvpspec_from_data(uvd, bls, 
+                                         spw_ranges=[(20, 30), (60, 90)], 
+                                         beam=beam)
+
+        # test failure due to overlapping data
+        uvp2 = copy.deepcopy(uvp1)
+        nt.assert_raises(AssertionError, uvpspec.combine_uvpspec, [uvp1, uvp2])
+
+        # test multiple non-overlapping data axes
+        uvp2 = copy.deepcopy(uvp1)
+        uvp2.polpair_array[0] = 1414
+        uvp2.freq_array[0] = 0.0
+        nt.assert_raises(AssertionError, uvpspec.combine_uvpspec, [uvp1, uvp2])
+
+        # test partial data overlap failure
+        uvp2 = testing.uvpspec_from_data(uvd, [(37, 38), (38, 39), (53, 54)],
+                                         spw_ranges=[(20, 30), (60, 90)],
+                                         beam=beam)
+        nt.assert_raises(AssertionError, uvpspec.combine_uvpspec, [uvp1, uvp2])
+        uvp2 = testing.uvpspec_from_data(uvd, bls,
+                                         spw_ranges=[(20, 30), (60, 105)],
+                                         beam=beam)
+        nt.assert_raises(AssertionError, uvpspec.combine_uvpspec, [uvp1, uvp2])
+        uvp2 = copy.deepcopy(uvp1)
+        uvp2.polpair_array[0] = 1414
+        uvp2 = uvpspec.combine_uvpspec([uvp1, uvp2], verbose=False)
+        nt.assert_raises(AssertionError, uvpspec.combine_uvpspec, [uvp1, uvp2])
+
+        # test failure due to variable static metadata
+        uvp2.weighting = 'foo'
+        nt.assert_raises(AssertionError, uvpspec.combine_uvpspec, [uvp1, uvp2])
+        uvp2.weighting = 'identity'
+        del uvp2.OmegaP
+        del uvp2.OmegaPP
+        nt.assert_raises(AssertionError, uvpspec.combine_uvpspec, [uvp1, uvp2])
+
 
     def test_combine_uvpspec_r_params(self):
         # setup uvp build

--- a/hera_pspec/uvpspec.py
+++ b/hera_pspec/uvpspec.py
@@ -717,13 +717,6 @@ class UVPSpec(object):
         inplace : bool, optional
             If True edit and overwrite arrays in self, else make a copy of
             self and return. Default: True.
-
-        Notes
-        -----
-        window_function_array is not affected
-        stats_array is transformed as k^3 / (2pi^2) * stats_array
-        cov_array is transformed as F C F
-        where F = eye(Ndlys) * k^3 / (2pi^2)
         """
         # copy object
         if inplace:
@@ -739,16 +732,9 @@ class UVPSpec(object):
             k_mag = np.sqrt(k_perp[:, None, None]**2 + k_para[None, :, None]**2)
             # shape of (Nblpairts, spw_Ndlys, Npols)
             coeff = k_mag**3 / (2 * np.pi**2)
-            F = np.eye()
 
             # multiply into data
             uvp.data_array[spw] *= coeff
-
-            # multiply into optionals
-            if hasattr(uvp, 'stats_array'):
-                for stat in uvp.stats_array:
-                    uvp.stats_array[stat][spw] *= coeff
-            if hasattr(uvp, 'cov_array'):
 
         # edit units
         uvp.norm_units = "k^3 / (2pi^2)"


### PR DESCRIPTION
In `uvpspec.combine_uvpspec`, the optional attribute `stats_array` was not being propagated, even if it was filled by all input UVPSpec objects. This fixes that, and also asserts that for propagation of cov_array, all cov_model attributes of incoming uvps must match. Fixes #264 