### PR TITLE
Fix and clarify docstrings in pspec container

### DIFF
--- a/hera_pspec/container.py
+++ b/hera_pspec/container.py
@@ -355,11 +355,12 @@ class PSpecContainer(object):
 
         Parameters
         ----------
-        group : str, optional
+        group : str
             Which group the power spectrum belongs to.
 
         psname : str, optional
-            The name of the power spectrum to return.
+            The name of the power spectrum to return. If None, extract all
+            available power spectra.
         
         kwargs : dict
             UVPSpec.read_from_group partial IO keyword arguments


### PR DESCRIPTION
Just editing docstrings I find confusing or misleading enough that I need to read the code as I use them.