### PR TITLE
pspec_run blpair match typo

### DIFF
--- a/hera_pspec/pspecdata.py
+++ b/hera_pspec/pspecdata.py
@@ -3599,7 +3599,7 @@ def pspec_run(dsets, filename, dsets_std=None, cals=None, cal_flag=True,
             _bls2 = []
             for _bl1, _bl2 in zip(bls1, bls2):
                 if (_bl1 in dset1_bls or _bl1[::-1] in dset1_bls) \
-                    and (_bl2 in dset2_bls or _bls2[::-1] in dset2_bls):
+                    and (_bl2 in dset2_bls or _bl2[::-1] in dset2_bls):
                     _bls1.append(_bl1)
                     _bls2.append(_bl2)
 

--- a/hera_pspec/tests/test_pspecdata.py
+++ b/hera_pspec/tests/test_pspecdata.py
@@ -1875,6 +1875,16 @@ def test_pspec_run():
     assert ds.dsets[0].extra_keywords['calibration'] is not '""'
     assert 'cal: /' in uvp.history
 
+    # test w/ conjugated blpairs
+    dfile = os.path.join(DATA_PATH, "zen.2458116.30448.HH.uvh5")
+    ds = pspecdata.pspec_run([dfile, dfile], "./out.h5", cals=cfile, dsets_std=[dfile, dfile],
+                             verbose=False, overwrite=True, blpairs=[((24, 23), (25, 24))],
+                             pol_pairs=[('xx', 'xx')], interleave_times=False,
+                             file_type='uvh5', spw_ranges=[(100, 150)], cal_flag=True)
+    psc = container.PSpecContainer('./out.h5', 'rw')
+    uvp = psc.get_pspec('dset0_dset1', 'dset0_x_dset1')
+    assert uvp.Nblpairs == 1
+
     # test exceptions
     nt.assert_raises(AssertionError, pspecdata.pspec_run, 'foo', "./out.h5")
     nt.assert_raises(AssertionError, pspecdata.pspec_run, fnames, "./out.h5", blpairs=(1, 2), verbose=False)


### PR DESCRIPTION
a small typo that causes conjugated baseline to not be caught in pspec_run(). This is not a problem w/ any HERA data b/c baselines follow "low_hi" convention, but for simulated RIMEz data that do not conform to this, we found this bug. A unit test is added to ensure this is caught.