### PR TITLE
Fix the inconsistency between fold_spectra and average_spectra

### DIFF
--- a/hera_pspec/tests/test_uvpspec.py
+++ b/hera_pspec/tests/test_uvpspec.py
@@ -514,6 +514,20 @@ class Test_UVPSpec(unittest.TestCase):
         cov_folded = uvp1.get_cov((0, ((37, 38), (38, 39)), ('xx','xx')))
         data_folded = uvp1.get_data((0, ((37,38), (38, 39)), ('xx','xx')))
 
+        # Test fold_spectra method is consistent with average_spectra()
+        uvp = testing.uvpspec_from_data(uvd, bls, data_std=uvd_std,
+                                         spw_ranges=[(0,17)], beam=beam)
+        # Average then fold
+        uvp_avg = uvp.average_spectra(time_avg=True, inplace=False)
+        # Fold averaged spectra
+        uvp_avg_folded = copy.deepcopy(uvp_avg)
+        uvp_avg_folded.fold_spectra()
+        # Fold then average
+        uvp_folded = copy.deepcopy(uvp)
+        uvp_folded.fold_spectra()
+        # Average folded spectra
+        uvp_folded_avg = uvp_folded.average_spectra(time_avg=True, inplace=False)
+        nt.assert_equal(uvp_avg_folded.get_data((0, ((37, 38), (38, 39)), 'xx')).shape, uvp_folded_avg.get_data((0, ((37, 38), (38, 39)), 'xx')).shape) 
 
     def test_str(self):
         a = str(self.uvp)

--- a/hera_pspec/uvpspec.py
+++ b/hera_pspec/uvpspec.py
@@ -199,8 +199,8 @@ class UVPSpec(object):
         if component == 'real':
             if hasattr(self,'cov_array_real'):
                 if self.folded:
-                    Ndlys = self.data_array[spw].shape[1]
-                    return self.cov_array_real[spw][blpairts, Ndlys//2+1:, Ndlys//2+1:, polpair]
+                    Ndlys = np.count_nonzero(self.spw_dly_array == spw)
+                    return self.cov_array_real[spw][blpairts, -(Ndlys-Ndlys//2-1):, -(Ndlys-Ndlys//2-1):, polpair]
                 else:
                     return self.cov_array_real[spw][blpairts, :, :, polpair]
             else:
@@ -208,8 +208,8 @@ class UVPSpec(object):
         elif component == 'imag':
             if hasattr(self,'cov_array_imag'):
                 if self.folded:
-                    Ndlys = self.data_array[spw].shape[1]
-                    return self.cov_array_imag[spw][blpairts, Ndlys//2+1:, Ndlys//2+1:, polpair]
+                    Ndlys = np.count_nonzero(self.spw_dly_array == spw)
+                    return self.cov_array_imag[spw][blpairts, -(Ndlys-Ndlys//2-1):, -(Ndlys-Ndlys//2-1):, polpair]
                 else:
                     return self.cov_array_imag[spw][blpairts, :, :, polpair]
             else:
@@ -250,8 +250,8 @@ class UVPSpec(object):
         # Need to deal with folded data!
         # if data has been folded, return only positive delays
         if self.folded:
-            Ndlys = self.data_array[spw].shape[1]
-            return self.window_function_array[spw][blpairts, Ndlys//2+1:, Ndlys//2+1:, polpair]
+            Ndlys = np.count_nonzero(self.spw_dly_array == spw)
+            return self.window_function_array[spw][blpairts, -(Ndlys-Ndlys//2-1):, -(Ndlys-Ndlys//2-1):, polpair]
         else:
             return self.window_function_array[spw][blpairts, :, :, polpair]
 
@@ -288,8 +288,8 @@ class UVPSpec(object):
 
         # if data has been folded, return only positive delays
         if self.folded:
-            Ndlys = self.data_array[spw].shape[1]
-            return self.data_array[spw][blpairts, Ndlys//2+1:, polpair]
+            Ndlys = np.count_nonzero(self.spw_dly_array == spw)
+            return self.data_array[spw][blpairts, -(Ndlys-Ndlys//2-1):, polpair]
 
         # else return all delays
         else:
@@ -632,8 +632,8 @@ class UVPSpec(object):
 
         # if bandpowers have been folded, return only positive delays
         if self.folded:
-            Ndlys = statistic[spw].shape[1]
-            return statistic[spw][blpairts, Ndlys//2+1:, polpair]
+            Ndlys = np.count_nonzero(self.spw_dly_array == spw)
+            return statistic[spw][blpairts, -(Ndlys-Ndlys//2-1):, polpair]
         else:
             return statistic[spw][blpairts, :, polpair]
 


### PR DESCRIPTION
Current method like get_data(), get_window_function(), ... in uvpspec.py will lead to bugs on the shape of outputs when folding the averaged_spectra, compared to fold spectra first and then do the average.  