### PR TITLE
added min_EW_cut option to get_reds

### DIFF
--- a/hera_pspec/tests/test_utils.py
+++ b/hera_pspec/tests/test_utils.py
@@ -238,6 +238,11 @@ class Test_Utils(unittest.TestCase):
         nt.assert_true(np.all([_l > bl_len_range[0] and _l < bl_len_range[1] for _l in l]))
         nt.assert_true(np.all([_a > bl_deg_range[0] and _a < bl_deg_range[1] for _a in a]))
 
+        # min EW cut
+        r, l, a = utils.get_reds(uvd, bl_len_range=(14, 16), min_EW_cut=14)
+        nt.assert_true(len(l) == len(a) == 1)
+        nt.assert_true(np.isclose(a[0] % 180, 0, atol=1))
+
         # autos
         r, l, a = utils.get_reds(fname, xants=xants, add_autos=True)
         nt.assert_almost_equal(l[0], 0)
@@ -247,7 +252,6 @@ class Test_Utils(unittest.TestCase):
         # Check errors when wrong types input
         nt.assert_raises(TypeError, utils.get_reds, [1., 2.])
         
-
     def test_config_pspec_blpairs(self):
         # test basic execution
         uv_template = os.path.join(DATA_PATH, "zen.{group}.{pol}.LST.1.28828.uvOCRSA")

--- a/hera_pspec/tests/test_uvpspec.py
+++ b/hera_pspec/tests/test_uvpspec.py
@@ -82,6 +82,11 @@ class Test_UVPSpec(unittest.TestCase):
         # test get_blpairs
         blps = self.uvp.get_blpairs()
         nt.assert_equal(blps, [((1, 2), (1, 2)), ((2, 3), (2, 3)), ((1, 3), (1, 3))])
+        # test get_blpair_vecs
+        blp_vecs = self.uvp.get_blpair_blvecs()
+        assert blp_vecs.shape == (self.uvp.Nblpairs, 3)
+        blp_vecs2 = self.uvp.get_blpair_blvecs(use_second_bl=True)
+        assert np.isclose(blp_vecs, blp_vecs2).all()
         # test get_polpairs
         polpairs = self.uvp.get_polpairs()
         nt.assert_equal(polpairs, [('xx', 'xx')])

--- a/hera_pspec/utils.py
+++ b/hera_pspec/utils.py
@@ -1060,7 +1060,7 @@ def get_bl_lens_angs(blvecs, bl_error_tol=1.0):
 
 
 def get_reds(uvd, bl_error_tol=1.0, pick_data_ants=False, bl_len_range=(0, 1e4),
-             bl_deg_range=(0, 180), xants=None, add_autos=False, 
+             bl_deg_range=(0, 180), xants=None, add_autos=False, min_EW_cut=0,
              file_type='miriad'):
     """
     Given a UVData object, a Miriad filepath or antenna position dictionary,
@@ -1094,7 +1094,11 @@ def get_reds(uvd, bl_error_tol=1.0, pick_data_ants=False, bl_len_range=(0, 1e4),
 
     add_autos : bool
         If True, add into autocorrelation group to the redundant group list.
-    
+
+    min_EW_cut : float
+        Baselines with a projected East-West absolute baseline length in meters
+        less than this are not included in the output.
+
     file_type : str, optional
         File type of the input files. Default: 'miriad'.
 
@@ -1132,22 +1136,23 @@ def get_reds(uvd, bl_error_tol=1.0, pick_data_ants=False, bl_len_range=(0, 1e4),
     vecs = np.array([antpos_dict[r[0][0]] - antpos_dict[r[0][1]] for r in reds])
     lens, angs = get_bl_lens_angs(vecs, bl_error_tol=bl_error_tol)
 
+    # restrict baselines
+    _reds, _lens, _angs = [], [], []
+    for i, (l, a) in enumerate(zip(lens, angs)):
+        if l < bl_len_range[0] or l > bl_len_range[1]: continue
+        if a < bl_deg_range[0] or a > bl_deg_range[1]: continue
+        if np.abs(l * np.cos(a * np.pi / 180)) < min_EW_cut: continue
+        _reds.append(reds[i])
+        _lens.append(lens[i])
+        _angs.append(angs[i])
+    reds, lens, angs = _reds, _lens, _angs
+
     # put in autocorrs
     if add_autos:
         ants = antpos_dict.keys()
         reds = [list(zip(ants, ants))] + reds
         lens = np.insert(lens, 0, 0)
         angs = np.insert(angs, 0, 0)
-
-    # restrict baselines
-    _reds, _lens, _angs = [], [], []
-    for i, (l, a) in enumerate(zip(lens, angs)):
-        if l >= bl_len_range[0] and l <= bl_len_range[1]:
-            if a >= bl_deg_range[0] and a <= bl_deg_range[1]:
-                _reds.append(reds[i])
-                _lens.append(lens[i])
-                _angs.append(angs[i])
-    reds, lens, angs = _reds, _lens, _angs
 
     # filter based on xants
     if xants is not None:

--- a/hera_pspec/uvpspec.py
+++ b/hera_pspec/uvpspec.py
@@ -464,6 +464,38 @@ class UVPSpec(object):
 
         return blp_avg_sep
 
+    def get_blpair_blvecs(self, use_second_bl=False):
+        """
+        For each baseline-pair, get the baseline vector in ENU
+        frame of the first baseline in the pair. Ordering matches
+        self.get_blpairs()
+
+        Parameters
+        ----------
+        use_second_bl : bool
+            If True, return the vector of the second bl in the blpair.
+
+        Returns
+        -------
+        ndarray shape=(Nblpairs,)
+            vector in ENU frame of the baseline
+        """
+        # get list of bl vectors
+        bl_vecs = self.get_ENU_bl_vecs()
+        bl_array = self.bl_array.tolist()
+
+        # construct blpair_bls
+        i = 0
+        if use_second_bl:
+            i = 1
+        blpairs = _ordered_unique(self.blpair_array)
+        bls = [self.antnums_to_bl(self.blpair_to_antnums(blp)[i]) for blp in blpairs]
+        blp_blvecs = []
+        for bl in bls:
+            blp_blvecs.append(bl_vecs[bl_array.index(bl)])
+
+        return np.array(blp_blvecs)
+
     def get_kperps(self, spw, little_h=True):
         """
         Get transverse (perpendicular) cosmological wavevector for each


### PR DESCRIPTION
This adds some tools for getting down selecting on projected east-west baseline length in the `utils.get_reds()` method, which operates on UVData files. 

I also added the method `uvp.get_blpair_blvecs()`, which returns the baseline vector of the baseline-pair array (matching the order of `uvp.blpair_array`).
Although a single function for down selecting on a uvp object is not provided, this method makes it fairly straightforward to do so as
```
blp_vecs = uvp.get_blpair_blvecs()
uvp.select(blpairs=[blp for i, blp in enumerate(uvp.get_blpairs()) if abs(blp_vecs[i][0]) > my_blcut])
```
