### PR TITLE
Fix omitted bl_tol argument in call to utils.calc_blpair_reds

### DIFF
--- a/hera_pspec/pspecdata.py
+++ b/hera_pspec/pspecdata.py
@@ -3742,8 +3742,9 @@ def pspec_run(dsets, filename, dsets_std=None, cals=None, cal_flag=True,
         to use in utils.calc_blpair_reds. Total range is between 0 and 180
         degrees.
 
-    bl_error_tol : float
-        Baseline vector error tolerance when constructing redundant groups.
+    bl_error_tol : float, optional
+        Baseline vector error tolerance when constructing redundant groups. 
+        Default: 1.0.
 
     store_window : bool
         If True, store computed window functions (warning, these can be large!)
@@ -4086,7 +4087,8 @@ def pspec_run(dsets, filename, dsets_std=None, cals=None, cal_flag=True,
                                       exclude_permutations=exclude_permutations,
                                       Nblps_per_group=Nblps_per_group,
                                       bl_len_range=bl_len_range,
-                                      bl_deg_range=bl_deg_range)
+                                      bl_deg_range=bl_deg_range, 
+                                      bl_tol=bl_error_tol)
             bls1_list.append(bls1)
             bls2_list.append(bls2)
 


### PR DESCRIPTION
The `pspec_run` function wasn't passing the `bl_error_tol` argument to `utils.calc_blpair_reds`. One-line fix.