### PR TITLE
metadata handling fixes in spherical_avg and combine_uvpspec

### DIFF
--- a/hera_pspec/grouping.py
+++ b/hera_pspec/grouping.py
@@ -584,8 +584,7 @@ def spherical_average(uvp_in, kbins, bin_widths, blpair_groups=None, time_avg=Fa
     
     error_weights : str, optional
         Error field to use as weights in averaging. Weight is 1/err^2.
-        This is the only error field that will be propagated to the final object.
-        If not specified perform a uniform average.
+        If not specified, perform a uniform average.
 
     add_to_history : str, optional
         String to append to object history
@@ -595,7 +594,9 @@ def spherical_average(uvp_in, kbins, bin_widths, blpair_groups=None, time_avg=Fa
         If False, user must ensure adopted h is consistent with uvp_in.cosmo
 
     A : dict, optional
-        Empty dict to populate with A matrix
+        Empty dict to populate with A matrix. This is useful for debugging,
+        or if you'd like to look at the A matrix used for the average.
+        Default is empty and not saved to globals.
 
     run_check : bool, optional
         If True, run UVPSpec.check() on resultant object
@@ -840,14 +841,14 @@ def spherical_average(uvp_in, kbins, bin_widths, blpair_groups=None, time_avg=Fa
     if store_window:
         uvp.window_function_array = window_function_array
 
-    # handle metadata
+    # handle spw metadata
     uvp.Nspwdlys = len(spw_dlys_array)
     uvp.Ndlys = len(dlys_array)
     uvp.dly_array = np.asarray(dlys_array)
     uvp.spw_dly_array = np.asarray(spw_dlys_array)
-    blp = uvp.blpair_array[0]  
 
-    # use first blpair as representative blpair
+    # handle baseline metadata: use first blpair as representative blpair
+    blp = uvp.blpair_array[0]  
     uvp.blpair_array = uvp.blpair_array[uvp.blpair_to_indices(blp)]
     uvp.Nblpairts = uvp.Ntimes
     uvp.Nblpairs = 1
@@ -856,8 +857,17 @@ def spherical_average(uvp_in, kbins, bin_widths, blpair_groups=None, time_avg=Fa
     uvp.bl_array = bl_array
     uvp.Nbls = len(bl_array)
 
-    # set bl_vecs mag to zero (k_mag comes purely from k_paras for spherically averaged uvp)
+    # set bl_vecs mag to zero
+    # k_mag stored as k_paras for spherically averaged uvp by convention!
     uvp.bl_vecs[:] = 0.0
+
+    # handle other metadata
+    uvp.time_avg_array = np.unique(uvp_in.time_avg_array)
+    uvp.time_1_array = np.unique(uvp_in.time_1_array)
+    uvp.time_2_array = np.unique(uvp_in.time_2_array)
+    uvp.lst_avg_array = np.unique(uvp_in.lst_avg_array)
+    uvp.lst_1_array = np.unique(uvp_in.lst_1_array)
+    uvp.lst_2_array = np.unique(uvp_in.lst_2_array)
 
     # Add to history
     uvp.history += version.history_string(notes=add_to_history)

--- a/hera_pspec/grouping.py
+++ b/hera_pspec/grouping.py
@@ -827,6 +827,7 @@ def spherical_average(uvp_in, kbins, bin_widths, blpair_groups=None, time_avg=Fa
             cm = np.moveaxis(cov_array_real[spw], -1, 0)
             cm = Ht @ cm @ H
             cov_array_real[spw] = np.moveaxis(cm, 0, -1)
+            cov_array_imag[spw] = np.zeros_like(cov_array_real[spw])
 
     # handle data arrays
     uvp.data_array = data_array
@@ -843,19 +844,22 @@ def spherical_average(uvp_in, kbins, bin_widths, blpair_groups=None, time_avg=Fa
 
     # handle spw metadata
     uvp.Nspwdlys = len(spw_dlys_array)
-    uvp.Ndlys = len(dlys_array)
+    uvp.Ndlys = len(np.unique(dlys_array))
     uvp.dly_array = np.asarray(dlys_array)
     uvp.spw_dly_array = np.asarray(spw_dlys_array)
 
     # handle baseline metadata: use first blpair as representative blpair
     blp = uvp.blpair_array[0]  
-    uvp.blpair_array = uvp.blpair_array[uvp.blpair_to_indices(blp)]
+    blp_inds = uvp.blpair_to_indices(blp)
+    uvp.blpair_array = uvp.blpair_array[blp_inds]
     uvp.Nblpairts = uvp.Ntimes
     uvp.Nblpairs = 1
     bl_array = np.unique([uvp.antnums_to_bl(an) for an in uvp.blpair_to_antnums(blp)])
     uvp.bl_vecs = np.asarray([uvp.bl_vecs[np.argmin(uvp.bl_array - bl)] for bl in bl_array])
     uvp.bl_array = bl_array
     uvp.Nbls = len(bl_array)
+    uvp.label_1_array = uvp.label_1_array[:, blp_inds]
+    uvp.label_2_array = uvp.label_2_array[:, blp_inds]
 
     # set bl_vecs mag to zero
     # k_mag stored as k_paras for spherically averaged uvp by convention!

--- a/hera_pspec/pspecdata.py
+++ b/hera_pspec/pspecdata.py
@@ -3329,9 +3329,9 @@ class PSpecData(object):
             if len(spw_polpair) == 0:
                 raise ValueError("None of the specified polarization pairs "
                                  "match that of the UVData objects")
-            self.set_filter_extension((0,0))
+            self.set_filter_extension((0, 0))
             # set filter_extension to be zero when ending the loop
-            
+
         # fill uvp object
         uvp = uvpspec.UVPSpec()
         uvp.symmetric_taper=symmetric_taper

--- a/hera_pspec/utils.py
+++ b/hera_pspec/utils.py
@@ -1329,11 +1329,6 @@ def uvp_noise_error(uvp, auto_Tsys, err_type='P_N', precomp_P_N=None):
     precomp_P_N : str
         If computing P_SN and P_N is already computed, use this key
         to index stats_array for P_N rather than computing it from auto_Tsys.
-
-    Returns
-    -------
-    UVPSpec object
-        input uvp with 'P_N' or 'P_SN' error in stats_array
     """
     from hera_pspec import uvpspec_utils
 

--- a/hera_pspec/uvpspec.py
+++ b/hera_pspec/uvpspec.py
@@ -2180,18 +2180,18 @@ def combine_uvpspec(uvps, merge_history=True, verbose=True):
         if store_stats:
             for stat in stored_stats:
                 u.stats_array[stat][i] = np.empty((Nblpairts, spw[3], Npols), np.complex128)
-        # Set frequencies and delays: if concat_ax == 'spw' this is changed below
-        if i == 0:
-            # assumes spw metadata are the same for all uvps
-            u.spw_array = uvps[0].spw_array.copy()
-            u.spw_freq_array = uvps[0].spw_freq_array.copy()
-            u.spw_dly_array = uvps[0].spw_dly_array.copy()
-            u.freq_array = uvps[0].freq_array.copy()
-            u.dly_array = uvps[0].dly_array.copy()
-            u.Nfreqs = len(np.unique(u.freq_array))
-            u.Nspwfreqs = len(u.spw_freq_array)
-            u.Ndlys = len(np.unique(u.dly_array))
-            u.Nspwdlys = len(u.spw_dly_array)
+
+    # Set frequencies and delays: if concat_ax == 'spw' this is changed below
+    # assumes spw metadata are the same for all uvps
+    u.spw_array = uvps[0].spw_array.copy()
+    u.spw_freq_array = uvps[0].spw_freq_array.copy()
+    u.spw_dly_array = uvps[0].spw_dly_array.copy()
+    u.freq_array = uvps[0].freq_array.copy()
+    u.dly_array = uvps[0].dly_array.copy()
+    u.Nfreqs = len(np.unique(u.freq_array))
+    u.Nspwfreqs = len(u.spw_freq_array)
+    u.Ndlys = len(np.unique(u.dly_array))
+    u.Nspwdlys = len(u.spw_dly_array)
 
     # other metadata
     u.polpair_array = np.array(new_polpairs)

--- a/hera_pspec/uvpspec.py
+++ b/hera_pspec/uvpspec.py
@@ -2163,7 +2163,7 @@ def combine_uvpspec(uvps, merge_history=True, verbose=True):
     u.freq_array, u.spw_array, u.dly_array = [], [], []
     u.spw_dly_array, u.spw_freq_array = [], []
 
-    # Loop over spectral windows
+    # Loop over new spectral windows and setup arrays
     for i, spw in enumerate(new_spws):
         # Initialize new arrays
         u.data_array[i] = np.empty((Nblpairts, spw[3], Npols), np.complex128)
@@ -2180,25 +2180,16 @@ def combine_uvpspec(uvps, merge_history=True, verbose=True):
         if store_stats:
             for stat in stored_stats:
                 u.stats_array[stat][i] = np.empty((Nblpairts, spw[3], Npols), np.complex128)
-        # Set frequencies and delays
-        spw_Nfreqs = spw[2]
-        spw_Ndlys = spw[3]
-        spw_freqs = np.linspace(*spw[:3], endpoint=False)
-        spw_dlys = np.fft.fftshift(
-                        np.fft.fftfreq(spw_Ndlys,
-                                       np.median(np.diff(spw_freqs)) ) )
-        u.spw_freq_array.extend(np.ones(spw_Nfreqs, np.int32) * i)
-        u.spw_dly_array.extend(np.ones(spw_Ndlys, np.int32) * i)
-        u.spw_array.extend([i])
-        u.freq_array.extend(spw_freqs)
-        u.dly_array.extend(spw_dlys)
+        # Set frequencies and delays: if concat_ax == 'spw' this is changed below
+        if i == 0:
+            # assumes spw metadata are the same for all uvps
+            u.spw_array = uvps[0].spw_array.copy()
+            u.spw_freq_array = uvps[0].spw_freq_array.copy()
+            u.spw_dly_array = uvps[0].spw_dly_array.copy()
+            u.freq_array = uvps[0].freq_array.copy()
+            u.dly_array = uvps[0].dly_array.copy()
 
-    # Convert to numpy arrays
-    u.spw_array = np.array(u.spw_array)
-    u.spw_freq_array = np.array(u.spw_freq_array)
-    u.spw_dly_array = np.array(u.spw_dly_array)
-    u.freq_array = np.array(u.freq_array)
-    u.dly_array = np.array(u.dly_array)
+    # other metadata
     u.polpair_array = np.array(new_polpairs)
 
     # Number of spectral windows, delays etc.
@@ -2256,10 +2247,25 @@ def combine_uvpspec(uvps, merge_history=True, verbose=True):
     # fill in data arrays depending on concat ax
     if concat_ax == 'spw':
 
+        u.spw_array = np.arange(Nspws, dtype=np.int32)
+        freq_array, dly_array = [], []
+        spw_freq_array, spw_dly_array = [], []
+
         # Concatenate spectral windows
         for i, spw in enumerate(new_spws):
+            # get index of this new spw in uvps and its spw index
             l = [spw in _u for _u in uvp_spws].index(True)
             m = [spw == _spw for _spw in uvp_spws[l]].index(True)
+
+            # freq metadata
+            spw_freq_inds = np.where(uvps[l].spw_freq_array == m)[0]
+            freq_array.extend(uvps[l].freq_array[spw_freq_inds])
+            spw_freq_array.extend(np.ones(len(spw_freq_inds), dtype=np.int32) * i)
+
+            # dly metadata
+            spw_dly_inds = np.where(uvps[l].spw_dly_array == m)[0]
+            dly_array.extend(uvps[l].dly_array[spw_dly_inds])
+            spw_dly_array.extend(np.ones(len(spw_dly_inds), dtype=np.int32) * i)
 
             # Lookup indices of new_blpts in the uvp_blpts[l] array
             blpts_idxs = uvputils._fast_lookup_blpairts(uvp_blpts[l], new_blpts)
@@ -2293,6 +2299,11 @@ def combine_uvpspec(uvps, merge_history=True, verbose=True):
                     if store_stats:
                         for stat in stored_stats:
                             u.stats_array[stat][i][j, :, k] = uvps[l].stats_array[stat][m][n, :, q]
+
+        u.freq_array = np.array(freq_array)
+        u.dly_array = np.array(dly_array)
+        u.spw_freq_array = np.array(spw_freq_array)
+        u.spw_dly_array = np.array(spw_dly_array)
 
         # Populate new LST, time, and blpair arrays
         for j, blpt in enumerate(new_blpts):

--- a/hera_pspec/uvpspec.py
+++ b/hera_pspec/uvpspec.py
@@ -2188,6 +2188,10 @@ def combine_uvpspec(uvps, merge_history=True, verbose=True):
             u.spw_dly_array = uvps[0].spw_dly_array.copy()
             u.freq_array = uvps[0].freq_array.copy()
             u.dly_array = uvps[0].dly_array.copy()
+            u.Nfreqs = len(np.unique(u.freq_array))
+            u.Nspwfreqs = len(u.spw_freq_array)
+            u.Ndlys = len(np.unique(u.dly_array))
+            u.Nspwdlys = len(u.spw_dly_array)
 
     # other metadata
     u.polpair_array = np.array(new_polpairs)
@@ -2196,10 +2200,6 @@ def combine_uvpspec(uvps, merge_history=True, verbose=True):
     u.Nspws = Nspws
     u.Nblpairts = Nblpairts
     u.Npols = Npols
-    u.Nfreqs = len(np.unique(u.freq_array))
-    u.Nspwdlys = len(u.spw_dly_array)
-    u.Nspwfreqs = len(u.spw_freq_array)
-    u.Ndlys = len(np.unique(u.dly_array))
 
     # Prepare time and label arrays
     u.time_1_array, u.time_2_array = np.empty(Nblpairts, np.float64), \
@@ -2304,6 +2304,10 @@ def combine_uvpspec(uvps, merge_history=True, verbose=True):
         u.dly_array = np.array(dly_array)
         u.spw_freq_array = np.array(spw_freq_array)
         u.spw_dly_array = np.array(spw_dly_array)
+        u.Nfreqs = len(np.unique(u.freq_array))
+        u.Nspwfreqs = len(u.spw_freq_array)
+        u.Ndlys = len(np.unique(u.dly_array))
+        u.Nspwdlys = len(u.spw_dly_array)
 
         # Populate new LST, time, and blpair arrays
         for j, blpt in enumerate(new_blpts):


### PR DESCRIPTION
This fixes some minor bugs in how metadata is propagated in our `spherical_average` and `combine_uvpspec` methods. 

- First, some of the `Nblpairts` arrays were not being down selected after spherical averaging (from Nblpairts -> Ntimes).

- Second, the when combining uvpspec objects the dly_array was being overwritten with a `fftfreq` call, which is only true if the pspectra have not been spherically averaged. This changes how the dly_array and freq_array are treated in the `combine_uvpspec` to simply propagate what's already in the input objects, which in hindsight is how we should have done this in the first place.

Tests are added to catch these bugs going forward...