### PR TITLE
Avoid recomputing noise scalars in `utils.generate_noise_errors`

### DIFF
--- a/hera_pspec/utils.py
+++ b/hera_pspec/utils.py
@@ -1345,7 +1345,12 @@ def uvp_noise_error(uvp, auto_Tsys=None, err_type='P_N', precomp_P_N=None, P_SN_
     if precomp_P_N is None:
         lsts = np.unique(auto_Tsys.lst_array)
         freqs = auto_Tsys.freq_array[0]
-
+    # calculate scalars for spws and polpairs.
+    scalar = {}
+    for spw in uvp.spw_array:
+        for polpair in uvp.polpair_array:
+            scalar[(spw, polpair)] = uvp.compute_scalar(spw, polpair, num_steps=num_steps,
+                                        little_h=little_h, noise_scalar=True)
     # iterate over spectral window
     for spw in uvp.spw_array:
         # get spw properties
@@ -1387,7 +1392,7 @@ def uvp_noise_error(uvp, auto_Tsys=None, err_type='P_N', precomp_P_N=None, P_SN_
                         Tsys = interp1d(lsts[~Tflag], Tsys[~Tflag], kind='nearest', bounds_error=False, fill_value='extrapolate')(lst_avg)
 
                     # calculate P_N
-                    P_N = uvp.generate_noise_spectra(spw, polpair, Tsys, blpairs=[blp], form='Pk', component='real')[blp_int]
+                    P_N = uvp.generate_noise_spectra(spw, polpair, Tsys, blpairs=[blp], form='Pk', component='real', scalar=scalar[(spw, polpair)])[blp_int]
 
                 else:
                     P_N = uvp.get_stats(precomp_P_N, key)

--- a/hera_pspec/utils.py
+++ b/hera_pspec/utils.py
@@ -1301,7 +1301,7 @@ def uvd_to_Tsys(uvd, beam, Tsys_outfile=None):
     return uvd
 
 
-def uvp_noise_error(uvp, auto_Tsys=None, err_type='P_N', precomp_P_N=None, P_SN_correction=True):
+def uvp_noise_error(uvp, auto_Tsys=None, err_type='P_N', precomp_P_N=None, P_SN_correction=True,  num_steps_scalar=2000, little_h=True):
     """
     Calculate analytic thermal noise error for a UVPSpec object.
     Adds to uvp.stats_array inplace.
@@ -1334,6 +1334,15 @@ def uvp_noise_error(uvp, auto_Tsys=None, err_type='P_N', precomp_P_N=None, P_SN_
     P_SN_correctoin : bool, optional
         Apply correction factor if computing P_SN to account for double
         counting of noise.
+
+    num_steps_scalar : int, optional
+        Number of frequency steps to explicitly compute (and interpolate over) for integrand in scalar.
+        Default is 2000
+
+    little_h : bool, optional
+        Use little_h units in power spectrum.
+        Default is True.
+        
     """
     from hera_pspec import uvpspec_utils
 
@@ -1349,7 +1358,7 @@ def uvp_noise_error(uvp, auto_Tsys=None, err_type='P_N', precomp_P_N=None, P_SN_
     scalar = {}
     for spw in uvp.spw_array:
         for polpair in uvp.polpair_array:
-            scalar[(spw, polpair)] = uvp.compute_scalar(spw, polpair, num_steps=num_steps,
+            scalar[(spw, polpair)] = uvp.compute_scalar(spw, polpair, num_steps=num_steps_scalar,
                                         little_h=little_h, noise_scalar=True)
     # iterate over spectral window
     for spw in uvp.spw_array:

--- a/hera_pspec/uvpspec.py
+++ b/hera_pspec/uvpspec.py
@@ -368,7 +368,7 @@ class UVPSpec(object):
         one entry per baseline.
 
         In a `UVPSpec` object, the dictionary is compressed so that a single
-        `r_param` entry correspondsto multiple baselines and is stored as a
+        `r_param` entry corresponds to multiple baselines and is stored as a
         JSON format string.
 
         This function reads the compressed string and returns the dictionary

--- a/hera_pspec/uvpspec.py
+++ b/hera_pspec/uvpspec.py
@@ -1762,7 +1762,7 @@ class UVPSpec(object):
 
     def generate_noise_spectra(self, spw, polpair, Tsys, blpairs=None,
                                little_h=True, form='Pk', num_steps=2000,
-                               component='real'):
+                               component='real', scalar=None):
         """
         Generate the expected RMS noise power spectrum given a selection of
         spectral window, system temp. [K], and polarization. This estimate is
@@ -1826,6 +1826,11 @@ class UVPSpec(object):
             Options=['real', 'imag', 'abs'].
             If component is real or imag, divide by an extra factor of sqrt(2).
 
+        scalar : float
+            Optional noise scalar used to convert from Tsys to cosmological units
+            output from pspecbeam.compute_pspec_scalar(...,noise_scalar=True)
+            Default is None. If None provided, will calculate scalar in function.
+
         Returns
         -------
         P_N : dict
@@ -1845,8 +1850,9 @@ class UVPSpec(object):
         polpair_ind = self.polpair_to_indices(polpair)
 
         # Calculate scalar
-        scalar = self.compute_scalar(spw, polpair, num_steps=num_steps,
-                                     little_h=little_h, noise_scalar=True)
+        if scalar is None:
+            scalar = self.compute_scalar(spw, polpair, num_steps=num_steps,
+                                         little_h=little_h, noise_scalar=True)
 
         # Get k vectors
         if form == 'DelSq':


### PR DESCRIPTION
Closes #330 

`utils.uvp_noise_errors` now precomputes the normalization scalar before looping through blpairs. This avoids recomputing the noise scalar many times which significantly increases runtime.

loss in coverage is due to white space removal from an already uncovered line (so diff should actually be 100% covered).