### PR TITLE
cov_model and known_cov now parsed

### DIFF
--- a/hera_pspec/pspecdata.py
+++ b/hera_pspec/pspecdata.py
@@ -2770,8 +2770,8 @@ class PSpecData(object):
         adjustment : float if the data_weighting is 'identity'
                      1d array of floats with length spw_Ndlys otherwise.
         """
-        if Gv is None: Gv = self.get_G(key1, key2, cov_model=cov_model, known_cov=known_cov)
-        if Hv is None: Hv = self.get_H(key1, key2, sampling, cov_model=cov_model, known_cov=known_cov)
+        if Gv is None: Gv = self.get_G(key1, key2, cov_model=model, known_cov=known_cov)
+        if Hv is None: Hv = self.get_H(key1, key2, sampling, cov_model=model, known_cov=known_cov)
 
         # get ratio
         summed_G = np.sum(Gv, axis=1)


### PR DESCRIPTION
Resolves #327

- Added cos_model and known_cov arguments to functions related to data covariance in order to properly parsed the potential user-input covariance matrix/dictionary. These include: iC, cov_q_hat, q_hat, get_G, get_H, get_unnormed_V, get_analytic_covariance, scalar_delay_adujstement. 
- Added these parameters to each call on the above-listed functions. It clutters the code a little bit (also the docstrings), maybe we could consider making the cov_model and the known_cov dictionary attributes?
- Added checks at the start of pspec function: asserts if cov_model is a string and if known_cov is given, in case the str isn't among the existing models (['empirical', 'dsets', 'autos', 'foreground_dependent']); if known_cov is given, asserts if the input_data_weight is set to something else than 'identity' - if it is set to identity, then raise warning saying that the input covariance will not be used in the R matrix.

Tested the code with the identity matrix as data covariance. 
