### PR TITLE
Fix issue where coverage isn't actually being recorded in coverage.xml (resulting in 0% coverage recorded by codecov).

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,9 +54,9 @@ jobs:
         source activate $ENV_NAME
         export MPLBACKEND=agg
         #nosetests -P hera_pspec --with-coverage --cover-package=hera_pspec --verbose
-        pytest --pyargs hera_pspec --cov=hera_pspec --cov-config="./.coveragerc" \
+        pytest --cov=hera_pspec --cov-config="./.coveragerc" \
                --cov-report xml:"./coverage.xml" --junitxml="./test-reports/xunit.xml"
-               
+
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1
       with:

--- a/hera_pspec/tests/test_conversions.py
+++ b/hera_pspec/tests/test_conversions.py
@@ -4,13 +4,13 @@ import numpy as np
 import os
 import sys
 from hera_pspec.data import DATA_PATH
-from hera_pspec import conversions
+from .. import conversions
 
 
 class Test_Cosmo(unittest.TestCase):
 
     def setUp(self):
-        self.C = conversions.Cosmo_Conversions(Om_L=0.68440, Om_b=0.04911, 
+        self.C = conversions.Cosmo_Conversions(Om_L=0.68440, Om_b=0.04911,
                                                Om_c=0.26442, H0=100.0,
                                                Om_M=None, Om_k=None)
     def tearDown(self):
@@ -22,11 +22,11 @@ class Test_Cosmo(unittest.TestCase):
     def test_init(self):
         # test empty instance
         C = conversions.Cosmo_Conversions()
-        
+
         # test parameters exist
         C.Om_b
         C.H0
-        
+
         # test parameters get fed to class
         C = conversions.Cosmo_Conversions(H0=25.5)
         np.testing.assert_almost_equal(C.H0, 25.5)
@@ -57,24 +57,24 @@ class Test_Cosmo(unittest.TestCase):
     def test_little_h(self):
         # Test that putting in a really low value of H0 into the conversions object
         # has no effect on the result if little_h=True units are used
-        self.C = conversions.Cosmo_Conversions(Om_L=0.68440, Om_b=0.04911, 
+        self.C = conversions.Cosmo_Conversions(Om_L=0.68440, Om_b=0.04911,
                                                Om_c=0.26442, H0=25.12,
                                                Om_M=None, Om_k=None)
         np.testing.assert_almost_equal(self.C.f2z(100e6), 13.20405751)
         np.testing.assert_almost_equal(self.C.z2f(10.0), 129127795.54545455)
         np.testing.assert_almost_equal(self.C.E(10.0), 20.450997530682947)
         np.testing.assert_almost_equal(self.C.DC(10.0, little_h=True), 6499.708111027144)
-        np.testing.assert_almost_equal(self.C.DC(10.0, little_h=False), 
+        np.testing.assert_almost_equal(self.C.DC(10.0, little_h=False),
                                6499.708111027144*100./25.12)
         np.testing.assert_almost_equal(self.C.DM(10.0, little_h=True), 6510.2536925709637)
         np.testing.assert_almost_equal(self.C.DA(10.0, little_h=True), 591.84124477917851)
-        np.testing.assert_almost_equal(self.C.dRperp_dtheta(10.0, little_h=True), 
+        np.testing.assert_almost_equal(self.C.dRperp_dtheta(10.0, little_h=True),
                                6510.2536925709637)
-        np.testing.assert_almost_equal(self.C.dRpara_df(10.0, little_h=True), 
+        np.testing.assert_almost_equal(self.C.dRpara_df(10.0, little_h=True),
                                1.2487605057418872e-05)
-        np.testing.assert_almost_equal(self.C.dRpara_df(10.0, ghz=True, little_h=True), 
+        np.testing.assert_almost_equal(self.C.dRpara_df(10.0, ghz=True, little_h=True),
                                12487.605057418872)
-        np.testing.assert_almost_equal(self.C.X2Y(10.0, little_h=True), 
+        np.testing.assert_almost_equal(self.C.X2Y(10.0, little_h=True),
                                529.26719942209002)
 
     def test_params(self):

--- a/hera_pspec/tests/test_grouping.py
+++ b/hera_pspec/tests/test_grouping.py
@@ -3,9 +3,9 @@ import pytest
 import numpy as np
 import os
 from hera_pspec.data import DATA_PATH
-from hera_pspec import uvpspec, conversions, parameter, pspecbeam, pspecdata, testing, utils
-from hera_pspec import uvpspec_utils as uvputils
-from hera_pspec import grouping, container
+from .. import uvpspec, conversions, parameter, pspecbeam, pspecdata, testing, utils
+from .. import uvpspec_utils as uvputils
+from .. import grouping, container
 from pyuvdata import UVData
 from hera_cal import redcal
 import copy
@@ -25,7 +25,7 @@ class Test_grouping(unittest.TestCase):
 
     def runTest(self):
         pass
-    
+
     def test_group_baselines(self):
         """
         Test baseline grouping behavior.
@@ -37,12 +37,12 @@ class Test_grouping(unittest.TestCase):
         bls4 = [(0,i) for i in range(5)]
         bls5 = [(0,i) for i in range(13)]
         bls6 = [(0,i) for i in range(521)]
-        
+
         # Check that error is raised when more groups requested than baselines
         pytest.raises(ValueError, grouping.group_baselines, bls1, 2)
         pytest.raises(ValueError, grouping.group_baselines, bls2, 5)
         pytest.raises(ValueError, grouping.group_baselines, bls4, 6)
-        
+
         # Check that keep_remainder=False results in equal-sized blocks
         g1a = grouping.group_baselines(bls4, 2, keep_remainder=False, randomize=False)
         g1b = grouping.group_baselines(bls5, 5, keep_remainder=False, randomize=False)
@@ -50,25 +50,25 @@ class Test_grouping(unittest.TestCase):
         g2a = grouping.group_baselines(bls4, 2, keep_remainder=False, randomize=True)
         g2b = grouping.group_baselines(bls5, 5, keep_remainder=False, randomize=True)
         g2c = grouping.group_baselines(bls6, 10, keep_remainder=False, randomize=True)
-        
+
         # Loop over groups and check that blocks are equal in size
         gs = [g1a, g1b, g1c, g2a, g2b, g2c]
         for g in gs:
             assert (np.unique([len(grp) for grp in g]).size == 1)
-        
+
         # Check that total no. baselines is preserved with keep_remainder=False
         for bls in [bls1, bls2, bls3, bls4, bls5, bls6]:
             for ngrp in [1, 2, 5, 10, 45]:
                 for rand in [True, False]:
                     try:
-                        g = grouping.group_baselines(bls, ngrp, 
-                                                 keep_remainder=True, 
+                        g = grouping.group_baselines(bls, ngrp,
+                                                 keep_remainder=True,
                                                  randomize=rand)
                     except:
                         continue
                     count = np.sum([len(_g) for _g in g])
                     assert count == len(bls)
-        
+
         # Check that random seed works
         g1 = grouping.group_baselines(bls5, 3, randomize=True, seed=10)
         g2 = grouping.group_baselines(bls5, 3, randomize=True, seed=11)
@@ -104,32 +104,32 @@ class Test_grouping(unittest.TestCase):
         # change units of UVData objects
         ds.dsets[0].vis_units = 'mK'
         ds.dsets[1].vis_units = 'mK'
-        
+
         baselines = [(24,25), (37,38), (38,39)]
         # calculate all baseline pairs from group
         baselines1, baselines2, blpairs \
-            = utils.construct_blpairs(baselines, 
-                                      exclude_auto_bls=True, 
+            = utils.construct_blpairs(baselines,
+                                      exclude_auto_bls=True,
                                       exclude_permutations=True)
-                                      
-        uvp = ds.pspec(baselines1, baselines2, (0, 1), 
-                       [('xx', 'xx')], 
-                       spw_ranges=[(300, 350)], 
+
+        uvp = ds.pspec(baselines1, baselines2, (0, 1),
+                       [('xx', 'xx')],
+                       spw_ranges=[(300, 350)],
                        input_data_weight='identity',
-                       norm='I', 
-                       taper='blackman-harris', 
-                       store_cov=True, 
-                       cov_model="autos", 
+                       norm='I',
+                       taper='blackman-harris',
+                       store_cov=True,
+                       cov_model="autos",
                        verbose=False)
         keys = uvp.get_all_keys()
-        
+
         # Add the analytic noise to stat_array
         Pn = uvp.generate_noise_spectra(0, 'xx', 220)
         for key in keys:
             blp = uvp.antnums_to_blpair(key[1])
             error = Pn[blp]
             uvp.set_stats("noise", key, error)
-        
+
         # Add the simple error bar (all are set to be one) to stat_array
         errs = np.ones((uvp.Ntimes, uvp.Ndlys))
         for key in keys:
@@ -138,46 +138,46 @@ class Test_grouping(unittest.TestCase):
         ## End file prep ##
 
         # begin tests
-        uvp_avg_ints_wgts = grouping.average_spectra(uvp, 
+        uvp_avg_ints_wgts = grouping.average_spectra(uvp,
                                                      blpair_groups=blpair_groups,
-                                                     error_field="noise", 
-                                                     time_avg=True, 
+                                                     error_field="noise",
+                                                     time_avg=True,
                                                      inplace=False)
-        
-        uvp_avg_noise_wgts = grouping.average_spectra(uvp, 
-                                                      time_avg=True, 
+
+        uvp_avg_noise_wgts = grouping.average_spectra(uvp,
+                                                      time_avg=True,
                                                       blpair_groups=blpair_groups,
-                                                      error_weights="noise", 
+                                                      error_weights="noise",
                                                       inplace=False)
-        uvp_avg_simple_wgts = grouping.average_spectra(uvp, 
-                                                       blpair_groups=blpair_groups, 
-                                                       time_avg=True, 
-                                                       error_weights="simple", 
+        uvp_avg_simple_wgts = grouping.average_spectra(uvp,
+                                                       blpair_groups=blpair_groups,
+                                                       time_avg=True,
+                                                       error_weights="simple",
                                                        inplace=False)
-        
-        # For using uniform error bars as weights, the error bar on the average 
+
+        # For using uniform error bars as weights, the error bar on the average
         # is 1/sqrt{N} times the error bar on one single sample.
         averaged_stat = uvp_avg_simple_wgts.stats_array["simple"][0][0, 0, 0]
         initial_stat = uvp.stats_array["simple"][0][0, 0, 0] \
                      / np.sqrt(uvp.Ntimes) / np.sqrt(len(blpairs))
         assert np.all(np.isclose(initial_stat, averaged_stat))
-        
-        # For non-uniform weights, we test the error bar on the average power 
+
+        # For non-uniform weights, we test the error bar on the average power
         # spectra should be smaller than one on single sample.
         assert(  abs(uvp_avg_ints_wgts.stats_array["noise"][0][0, 0, 0]) \
                < abs(uvp.stats_array["noise"][0][0, 0, 0]))
         assert(  abs(uvp_avg_noise_wgts.stats_array["noise"][0][0, 0, 0]) \
                < abs(uvp.stats_array["noise"][0][0, 0, 0]))
 
-        # Test stats inf variance for all times, single blpair doesn't result 
-        # in nans and that the avg effectively ignores its presence: e.g. check 
+        # Test stats inf variance for all times, single blpair doesn't result
+        # in nans and that the avg effectively ignores its presence: e.g. check
         # it matches initial over sqrt(Nblpairs - 1)
         uvp_inf_var = copy.deepcopy(uvp)
         initial_stat = uvp.get_stats('simple', (0, blpairs[0], 'xx'))
         inf_var_stat = np.ones((uvp_inf_var.Ntimes, uvp_inf_var.Ndlys)) * np.inf
         uvp_inf_var.set_stats('simple', (0, blpairs[1], 'xx'), inf_var_stat)
-        uvp_inf_var_avg = uvp_inf_var.average_spectra(blpair_groups=blpair_groups, 
-                                                      error_weights='simple', 
+        uvp_inf_var_avg = uvp_inf_var.average_spectra(blpair_groups=blpair_groups,
+                                                      error_weights='simple',
                                                       inplace=False)
         final_stat = uvp_inf_var_avg.get_stats('simple', (0, blpairs[0], 'xx'))
         assert np.isclose(final_stat, initial_stat / np.sqrt(len(blpairs) - 1)).all()
@@ -206,15 +206,15 @@ class Test_grouping(unittest.TestCase):
         bls4 = [(0,i) for i in range(5)]
         bls5 = [(0,i) for i in range(13)]
         bls6 = [(0,i) for i in range(521)]
-        
+
         # Example grouped list
         g1 = grouping.group_baselines(bls5, 3, randomize=False)
-        
+
         # Check that returned length is the same as input length
         for bls in [bls1, bls2, bls3, bls4, bls5, bls6]:
             samp = grouping.sample_baselines(bls)
             assert len(bls) == len(samp)
-        
+
         # Check that returned length is the same for groups too
         samp = grouping.sample_baselines(g1)
         assert len(g1) == len(samp)
@@ -225,26 +225,26 @@ class Test_grouping(unittest.TestCase):
         """
         # Check that basic bootstrap averaging works
         blpair_groups = [list(np.unique(self.uvp.blpair_array)),]
-        uvp1, wgts = grouping.bootstrap_average_blpairs([self.uvp,], 
-                                                        blpair_groups, 
+        uvp1, wgts = grouping.bootstrap_average_blpairs([self.uvp,],
+                                                        blpair_groups,
                                                         time_avg=False)
-        
-        uvp2, wgts = grouping.bootstrap_average_blpairs([self.uvp,], 
-                                                        blpair_groups, 
+
+        uvp2, wgts = grouping.bootstrap_average_blpairs([self.uvp,],
+                                                        blpair_groups,
                                                         time_avg=True)
         assert uvp1[0].Nblpairs == 1
         assert uvp1[0].Ntimes == self.uvp.Ntimes
         assert uvp2[0].Ntimes == 1
-        
+
         # Total of weights assigned should equal total no. of blpairs
         assert np.sum(wgts) == np.array(blpair_groups).size
-        
+
         # Check that exceptions are raised when inputs are invalid
-        pytest.raises(AssertionError, grouping.bootstrap_average_blpairs, 
+        pytest.raises(AssertionError, grouping.bootstrap_average_blpairs,
                           [np.arange(5),], blpair_groups, time_avg=False)
-        pytest.raises(KeyError, grouping.bootstrap_average_blpairs, 
+        pytest.raises(KeyError, grouping.bootstrap_average_blpairs,
                           [self.uvp,], [[200200200200,],], time_avg=False)
-        
+
         # Reduce UVPSpec to only 3 blpairs and set them all to the same values
         _blpairs = list(np.unique(self.uvp.blpair_array)[:3])
         uvp3 = self.uvp.select(spws=0, inplace=False, blpairs=_blpairs)
@@ -253,20 +253,20 @@ class Test_grouping(unittest.TestCase):
         uvp3.data_array[0][2*Nt:] = uvp3.data_array[0][:Nt]
         uvp3.integration_array[0][Nt:2*Nt] = uvp3.integration_array[0][:Nt]
         uvp3.integration_array[0][2*Nt:] = uvp3.integration_array[0][:Nt]
-        
-        # Test that different bootstrap-sampled averages have the same value as 
-        # the normal average (since the data for all blpairs has been set to 
+
+        # Test that different bootstrap-sampled averages have the same value as
+        # the normal average (since the data for all blpairs has been set to
         # the same values for uvp3)
         np.random.seed(10)
-        uvp_avg = uvp3.average_spectra(blpair_groups=[_blpairs,], 
+        uvp_avg = uvp3.average_spectra(blpair_groups=[_blpairs,],
                                        time_avg=True, inplace=False)
         blpair = uvp_avg.blpair_array[0]
         for i in range(5):
-            # Generate multiple samples and make sure that they are all equal 
+            # Generate multiple samples and make sure that they are all equal
             # to the regular average (for the cloned data in uvp3)
             uvp4, wgts = grouping.bootstrap_average_blpairs(
-                                                     [uvp3,], 
-                                                     blpair_groups=[_blpairs,], 
+                                                     [uvp3,],
+                                                     blpair_groups=[_blpairs,],
                                                      time_avg=True)
             try:
                 ps_avg = uvp_avg.get_data((0, blpair, ('xx','xx')))
@@ -294,10 +294,10 @@ def test_bootstrap_resampled_error():
         os.remove("uvp.h5")
     uvp.write_hdf5("uvp.h5", overwrite=True)
     ua, ub, uw = grouping.bootstrap_resampled_error("uvp.h5", blpair_groups=None, Nsamples=10, seed=0, verbose=False)
-    
+
     # check number of boots
     assert len(ub) == 10
-    
+
     # check seed has been used properly
     assert uw[0][0][:5] == [1.0, 1.0, 0.0, 2.0, 1.0]
     assert uw[0][1][:5] == [2.0, 1.0, 1.0, 6.0, 1.0]
@@ -310,9 +310,9 @@ def test_bootstrap_resampled_error():
 
 def test_validate_bootstrap_errorbar():
     """
-    This is used to test the bootstrapping code against the Gaussian noise 
+    This is used to test the bootstrapping code against the Gaussian noise
     visibility simulator. The basic premise is that, if working properly,
-    Gaussian noise power spectra divided by their bootstrapped errorbars should 
+    Gaussian noise power spectra divided by their bootstrapped errorbars should
     have a standard deviation that converges to 1.
     """
     # get simulated noise in K-str
@@ -369,27 +369,27 @@ def test_bootstrap_run():
                            normal_std=True, robust_std=True, cintervals=[16, 84], keep_samples=True,
                            bl_error_tol=1.0, overwrite=True, add_to_history='hello!', verbose=False)
     spcs = psc.spectra("grp1")
-    
+
     # assert all bs samples were written
     assert (np.all(["uvp_bs{}".format(i) in spcs for i in range(100)]))
-    
+
     # assert average was written
     assert ("uvp_avg" in spcs and "uvp" in spcs)
-    
+
     # assert average only has one time and 3 blpairs
     uvp_avg = psc.get_pspec("grp1", "uvp_avg")
     assert uvp_avg.Ntimes == 1
     assert uvp_avg.Nblpairs == 3
-    
+
     # check avg file history
     assert ("hello!" in uvp_avg.history)
-    
+
     # assert original uvp is unchanged
     assert uvp == psc.get_pspec("grp1", 'uvp')
-    
+
     # check stats array
     np.testing.assert_array_equal([u'bs_cinterval_16.00', u'bs_cinterval_84.00', u'bs_robust_std', u'bs_std'], list(uvp_avg.stats_array.keys()))
-    
+
     for stat in [u'bs_cinterval_16.00', u'bs_cinterval_84.00', u'bs_robust_std', u'bs_std']:
         assert uvp_avg.get_stats(stat, (0, ((37, 38), (38, 39)), ('xx','xx'))).shape == (1, 50)
         assert (np.any(np.isnan(uvp_avg.get_stats(stat, (0, ((37, 38), (38, 39)), ('xx','xx')))))) == False
@@ -400,17 +400,17 @@ def test_bootstrap_run():
     if os.path.exists("ex.h5"):
         os.remove("ex.h5")
     psc = container.PSpecContainer("ex.h5", mode='rw', keep_open=False, swmr=False)
-    
+
     # test empty groups
     pytest.raises(AssertionError, grouping.bootstrap_run, "ex.h5")
-    
+
     # test bad filename
     pytest.raises(AssertionError, grouping.bootstrap_run, 1)
-    
+
     # test fed spectra doesn't exist
     psc.set_pspec("grp1", "uvp", uvp)
     pytest.raises(AssertionError, grouping.bootstrap_run, psc, spectra=['grp1/foo'])
-    
+
     # test assertionerror if SWMR
     psc = container.PSpecContainer("ex.h5", mode='rw', keep_open=False, swmr=True)
     pytest.raises(AssertionError, grouping.bootstrap_run, psc, spectra=['grp1/foo'])
@@ -433,7 +433,7 @@ def test_spherical_average():
     # create two polarization data
     uvd = UVData()
     uvd.read(os.path.join(DATA_PATH, 'zen.even.xx.LST.1.28828.uvOCRSA'))
-    
+
     # load other data, get reds and make UVPSpec
     beamfile = os.path.join(DATA_PATH, "HERA_NF_dipole_power.beamfits")
     cosmo = conversions.Cosmo_Conversions()
@@ -444,7 +444,7 @@ def test_spherical_average():
     uvp = testing.uvpspec_from_data(uvd, reds, spw_ranges=[(50, 75), (100, 125)], beam=beam, cosmo=cosmo)
     uvd.polarization_array[0] = -6
     uvp += testing.uvpspec_from_data(uvd, reds, spw_ranges=[(50, 75), (100, 125)], beam=beam, cosmo=cosmo)
-    
+
     # insert cov_array and stats_array
     uvp.cov_model = 'empirical'
     uvp.cov_array_real = {s: np.repeat(np.repeat(np.eye(uvp.Ndlys, dtype=np.float64)[None, : , :, None], uvp.Nblpairts, 0), uvp.Npols, -1)
@@ -460,7 +460,7 @@ def test_spherical_average():
     bin_widths = 0.25
     A = {}
     sph = grouping.spherical_average(uvp, kbins, bin_widths, add_to_history='checking 1 2 3', A=A)
-    
+
     # metadata
     assert sph.Nblpairs == 1
     assert 'checking 1 2 3' in sph.history
@@ -470,18 +470,18 @@ def test_spherical_average():
         # binning and normalization
         assert np.isclose(sph.get_kparas(spw), kbins).all()  # assert kbins are input kbins
         assert np.isclose(sph.window_function_array[spw].sum(axis=2), 1).all()  # assert window func is normalized
-        
+
         # check low k modes are greater than high k modes
         # this is a basic "averaged data smell test" in lieu of a known pspec to compare to
         assert np.all(sph.data_array[spw][:, 0, :].real / sph.data_array[spw][:, 10, :] > 1e3)
-        
+
         # assert errorbars are 1/sqrt(N) what they used to be
         assert np.isclose(np.sqrt(sph.cov_array_real[spw])[:, range(Nk), range(Nk)], 1/np.sqrt(A[spw].sum(axis=1))).all()
         assert np.isclose(sph.stats_array['err'][spw], 1/np.sqrt(A[spw].sum(axis=1))).all()
-    
+
     # bug check: time_avg_array was not down-selected to new Nblpairts
     assert sph.time_avg_array.size == sph.Nblpairts
-    
+
     # bug check: cov_array_imag was not updated
     assert sph.cov_array_real[0].shape == sph.cov_array_imag[0].shape
 
@@ -509,14 +509,14 @@ def test_spherical_average():
     uvp2 = copy.deepcopy(uvp)
     uvp2.set_stats_slice('err', 0, 1000, above=False, val=np.inf)
     sph2 = grouping.spherical_average(uvp2, kbins, bin_widths, error_weights='err')
-    
+
     # assert low k modes are zeroed!
-    assert np.isclose(sph2.data_array[0][:, :3, :], 0).all()  
-    
+    assert np.isclose(sph2.data_array[0][:, :3, :], 0).all()
+
     # assert bins that weren't nulled still have proper window normalization
     for spw in sph2.spw_array:
         assert np.isclose(sph2.window_function_array[spw].sum(axis=2)[:, 3:, :], 1).all()
-    
+
     # assert resultant stats are not nan
     assert (~np.isnan(sph2.stats_array['err'][0])).all()
 

--- a/hera_pspec/tests/test_noise.py
+++ b/hera_pspec/tests/test_noise.py
@@ -9,7 +9,7 @@ from collections import OrderedDict as odict
 from pyuvdata import UVData
 
 from hera_pspec.data import DATA_PATH
-from hera_pspec import uvpspec, conversions, pspecdata, pspecbeam, noise, testing, utils
+from .. import uvpspec, conversions, pspecdata, pspecbeam, noise, testing, utils
 
 
 class Test_Sensitivity(unittest.TestCase):
@@ -18,7 +18,7 @@ class Test_Sensitivity(unittest.TestCase):
     """
     def setUp(self):
         self.cosmo = conversions.Cosmo_Conversions()
-        self.beam = pspecbeam.PSpecBeamUV(os.path.join(DATA_PATH, 
+        self.beam = pspecbeam.PSpecBeamUV(os.path.join(DATA_PATH,
                                               'HERA_NF_pstokes_power.beamfits'))
         self.sense = noise.Sensitivity(beam=self.beam, cosmo=self.cosmo)
 
@@ -43,7 +43,7 @@ class Test_Sensitivity(unittest.TestCase):
         self.beam.cosmo = C
         sense.set_beam(self.beam)
         assert sense.cosmo.get_params() == sense.beam.cosmo.get_params()
-        
+
         bm = copy.deepcopy(self.beam)
         delattr(bm, 'cosmo')
         sense.set_beam(bm)
@@ -55,21 +55,21 @@ class Test_Sensitivity(unittest.TestCase):
         assert self.sense.pol == 'pI'
 
     def test_calc_P_N(self):
-        
+
         # calculate scalar
         freqs = np.linspace(150e6, 160e6, 100, endpoint=False)
         self.sense.calc_scalar(freqs, 'pI', num_steps=5000, little_h=True)
-        
-        # basic execution 
+
+        # basic execution
         k = np.linspace(0, 3, 10)
         Tsys = 500.0
         t_int = 10.7
-        P_N = self.sense.calc_P_N(Tsys, t_int, Ncoherent=1, Nincoherent=1, 
+        P_N = self.sense.calc_P_N(Tsys, t_int, Ncoherent=1, Nincoherent=1,
                                   form='Pk')
         assert isinstance(P_N, (float, np.float))
         assert np.isclose(P_N, 642386932892.2921)
         # calculate DelSq
-        Dsq = self.sense.calc_P_N(Tsys, t_int, k=k, Ncoherent=1, 
+        Dsq = self.sense.calc_P_N(Tsys, t_int, k=k, Ncoherent=1,
                                   Nincoherent=1, form='DelSq')
         assert Dsq.shape == (10,)
         assert Dsq[1] < P_N
@@ -89,18 +89,18 @@ def test_noise_validation():
 
     # generate noise
     seed = 0
-    uvd = testing.noise_sim(uvfile, Tsys, beam, seed=seed, whiten=True, 
+    uvd = testing.noise_sim(uvfile, Tsys, beam, seed=seed, whiten=True,
                             inplace=False, Nextend=9)
 
     # get redundant baseline group
-    reds, lens, angs = utils.get_reds(uvd, pick_data_ants=True, 
+    reds, lens, angs = utils.get_reds(uvd, pick_data_ants=True,
                                       bl_len_range=(10, 20),
                                       bl_deg_range=(0, 1))
-    bls1, bls2, blps = utils.construct_blpairs(reds[0], exclude_auto_bls=True, 
+    bls1, bls2, blps = utils.construct_blpairs(reds[0], exclude_auto_bls=True,
                                                exclude_permutations=True)
 
     # setup PSpecData
-    ds = pspecdata.PSpecData(dsets=[copy.deepcopy(uvd), copy.deepcopy(uvd)], 
+    ds = pspecdata.PSpecData(dsets=[copy.deepcopy(uvd), copy.deepcopy(uvd)],
                              wgts=[None, None], beam=beam)
     ds.Jy_to_mK()
 
@@ -109,7 +109,7 @@ def test_noise_validation():
                    taper='none', sampling=False, little_h=True, spw_ranges=[(0, 50)], verbose=False)
 
     # get noise spectra from one of the blpairs
-    P_N = list(uvp.generate_noise_spectra(0, ('xx','xx'), Tsys, 
+    P_N = list(uvp.generate_noise_spectra(0, ('xx','xx'), Tsys,
                                           blpairs=uvp.get_blpairs()[:1], num_steps=2000,
                                           component='real').values())[0][0, 0]
 
@@ -136,16 +136,16 @@ def test_analytic_noise():
     uvd.read(uvfile)
 
     # setup PSpecData
-    ds = pspecdata.PSpecData(dsets=[copy.deepcopy(uvd), copy.deepcopy(uvd)], 
+    ds = pspecdata.PSpecData(dsets=[copy.deepcopy(uvd), copy.deepcopy(uvd)],
                              wgts=[None, None], beam=beam,
                              dsets_std=[copy.deepcopy(uvd), copy.deepcopy(uvd)])
     ds.Jy_to_mK()
 
     # get pspec
-    reds, lens, angs = utils.get_reds(uvd, pick_data_ants=True, 
+    reds, lens, angs = utils.get_reds(uvd, pick_data_ants=True,
                                       bl_len_range=(10, 20),
                                       bl_deg_range=(0, 1))
-    bls1, bls2, blps = utils.construct_blpairs(reds[0], exclude_auto_bls=True, 
+    bls1, bls2, blps = utils.construct_blpairs(reds[0], exclude_auto_bls=True,
                                                exclude_permutations=True)
     taper = 'bh'
     Nchan = 20
@@ -173,7 +173,7 @@ def test_analytic_noise():
     frac_ratio = (cov_diag**0.5 - stats_diag) / stats_diag
     assert np.abs(frac_ratio).mean() < 0.01
 
-    # now compute unbiased P_SN and check that it matches P_N at high-k    
+    # now compute unbiased P_SN and check that it matches P_N at high-k
     utils.uvp_noise_error(uvp, auto_Tsys, err_type=['P_N','P_SN'], P_SN_correction=True)
     frac_ratio = (uvp.stats_array["P_SN"][0] - uvp.stats_array["P_N"][0]) / uvp.stats_array["P_N"][0]
     dlys = uvp.get_dlys(0) * 1e9
@@ -182,4 +182,3 @@ def test_analytic_noise():
 
     # clean up
     os.remove(os.path.join(DATA_PATH, "test_uvd.uvh5"))
-

--- a/hera_pspec/tests/test_plot.py
+++ b/hera_pspec/tests/test_plot.py
@@ -4,7 +4,7 @@ import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
 import os, copy, sys
-from hera_pspec import pspecdata, pspecbeam, conversions, plot, utils, grouping
+from .. import pspecdata, pspecbeam, conversions, plot, utils, grouping
 from hera_pspec.data import DATA_PATH
 from pyuvdata import UVData
 import glob
@@ -79,7 +79,7 @@ class Test_Plot(unittest.TestCase):
                         bls, exclude_permutations=False, exclude_auto_bls=True)
 
         # Calculate the power spectrum
-        self.uvp = self.ds.pspec(self.bls1, self.bls2, (0, 1), 
+        self.uvp = self.ds.pspec(self.bls1, self.bls2, (0, 1),
                                  ('xx','xx'), spw_ranges=[(300, 400), (600,721)],
                                  input_data_weight='identity', norm='I',
                                  taper='blackman-harris', verbose=False)
@@ -153,7 +153,7 @@ class Test_Plot(unittest.TestCase):
                                                  robust_std=False, verbose=False)
 
         f6 = plot.delay_spectrum(uvp_avg, uvp_avg.get_blpairs(), spw=0,
-                                pol=('xx','xx'), average_blpairs=False, 
+                                pol=('xx','xx'), average_blpairs=False,
                                 average_times=False,
                                 component='real', error='bs_std', lines=False,
                                 markers=True)
@@ -161,7 +161,7 @@ class Test_Plot(unittest.TestCase):
 
         # plot errorbar instead of pspec
         f7 = plot.delay_spectrum(uvp_avg, uvp_avg.get_blpairs(), spw=0,
-                                pol=('xx','xx'), average_blpairs=False, 
+                                pol=('xx','xx'), average_blpairs=False,
                                 average_times=False,
                                 component='real', lines=False,
                                 markers=True, plot_stats='bs_std')
@@ -188,7 +188,7 @@ class Test_Plot(unittest.TestCase):
         # Plot in Delta^2 units
         f2 = plot.delay_spectrum(self.uvp, [blps,], spw=0, pol=('xx','xx'),
                                   average_blpairs=True, average_times=True,
-                                  delay=False, deltasq=True, legend=True, 
+                                  delay=False, deltasq=True, legend=True,
                                   label_type='blpair')
         # Should contain 1 line and 1 legend
         elements = [(matplotlib.lines.Line2D, 1), (matplotlib.legend.Legend, 1)]
@@ -219,13 +219,13 @@ class Test_Plot(unittest.TestCase):
             uvp = uvp + _uvp
         pytest.raises(ValueError, plot.delay_spectrum, uvp, uvp.get_blpairs(), 0, 'xx')
 
-        f2 = plot.delay_spectrum(uvp, uvp.get_blpairs(), 0, ('xx','xx'), 
-                                 force_plot=True, label_type='blpairt', 
+        f2 = plot.delay_spectrum(uvp, uvp.get_blpairs(), 0, ('xx','xx'),
+                                 force_plot=True, label_type='blpairt',
                                  logscale=False, lines=True, markers=True)
         plt.close(f2)
 
         # exceptions
-        pytest.raises(ValueError, plot.delay_spectrum, uvp, 
+        pytest.raises(ValueError, plot.delay_spectrum, uvp,
                          uvp.get_blpairs()[:3], 0, ('xx','xx'),
                          label_type='foo')
 
@@ -266,8 +266,8 @@ class Test_Plot(unittest.TestCase):
 
         # Try some more arguments
         fig, axes = plt.subplots(1, len(blps))
-        plot.delay_waterfall(self.uvp, [blps,], spw=0, pol=('xx','xx'), 
-                             lst_in_hrs=False, 
+        plot.delay_waterfall(self.uvp, [blps,], spw=0, pol=('xx','xx'),
+                             lst_in_hrs=False,
                              times=np.unique(self.uvp.time_avg_array)[:10],
                              axes=axes, component='abs', title_type='blvec')
         plt.close()
@@ -278,9 +278,9 @@ class Test_Plot(unittest.TestCase):
             _uvp = copy.deepcopy(self.uvp)
             _uvp.blpair_array += i * 20
             uvp += _uvp
-        pytest.raises(ValueError, plot.delay_waterfall, uvp, 
+        pytest.raises(ValueError, plot.delay_waterfall, uvp,
                          uvp.get_blpairs(), 0, ('xx','xx'))
-        fig = plot.delay_waterfall(uvp, uvp.get_blpairs(), 0, ('xx','xx'), 
+        fig = plot.delay_waterfall(uvp, uvp.get_blpairs(), 0, ('xx','xx'),
                                    force_plot=True)
         plt.close()
 
@@ -294,7 +294,7 @@ class Test_Plot(unittest.TestCase):
 
         for d in ['data', 'flags', 'nsamples']:
             print("running on {}".format(d))
-            plot.plot_uvdata_waterfalls(uvd, basename, vmin=0, vmax=100, 
+            plot.plot_uvdata_waterfalls(uvd, basename, vmin=0, vmax=100,
                                         data=d, plot_mode='real')
 
             figfiles = glob.glob("test_waterfall_plots_3423523923_*_*.png")
@@ -306,9 +306,9 @@ class Test_Plot(unittest.TestCase):
         """ Tests for plot.delay_wedge """
         # construct new uvp
         reds, lens, angs = utils.get_reds(self.ds.dsets[0], pick_data_ants=True)
-        bls1, bls2, blps, _, _ = utils.calc_blpair_reds(self.ds.dsets[0], 
+        bls1, bls2, blps, _, _ = utils.calc_blpair_reds(self.ds.dsets[0],
                                                         self.ds.dsets[1],
-                                                        exclude_auto_bls=False, 
+                                                        exclude_auto_bls=False,
                                                         exclude_permutations=True)
         uvp = self.ds.pspec(bls1, bls2, (0, 1), ('xx','xx'),
                             spw_ranges=[(300, 350)],
@@ -316,51 +316,51 @@ class Test_Plot(unittest.TestCase):
                             taper='blackman-harris', verbose=False)
 
         # test basic delay_wedge call
-        f1 = plot.delay_wedge(uvp, 0, ('xx','xx'), blpairs=None, times=None, 
-                              fold=False, delay=True, rotate=False, 
-                              component='real', log10=False, loglog=False, 
-                              red_tol=1.0, center_line=False, 
-                              horizon_lines=False, title=None, ax=None, 
-                              cmap='viridis', figsize=(8, 6), deltasq=False, 
+        f1 = plot.delay_wedge(uvp, 0, ('xx','xx'), blpairs=None, times=None,
+                              fold=False, delay=True, rotate=False,
+                              component='real', log10=False, loglog=False,
+                              red_tol=1.0, center_line=False,
+                              horizon_lines=False, title=None, ax=None,
+                              cmap='viridis', figsize=(8, 6), deltasq=False,
                               colorbar=False, cbax=None, vmin=None, vmax=None,
-                              edgecolor='none', flip_xax=False, flip_yax=False, 
+                              edgecolor='none', flip_xax=False, flip_yax=False,
                               lw=2)
         plt.close()
 
         # specify blpairs and times
-        f2 = plot.delay_wedge(uvp, 0, ('xx','xx'), 
-                              blpairs=uvp.get_blpairs()[-5:], 
+        f2 = plot.delay_wedge(uvp, 0, ('xx','xx'),
+                              blpairs=uvp.get_blpairs()[-5:],
                               times=uvp.time_avg_array[:1],
                               fold=False, delay=True, component='imag',
                               rotate=False, log10=False, loglog=False, red_tol=1.0,
-                              center_line=False, horizon_lines=False, title=None, 
+                              center_line=False, horizon_lines=False, title=None,
                               ax=None, cmap='viridis',
-                              figsize=(8, 6), deltasq=False, colorbar=False, 
+                              figsize=(8, 6), deltasq=False, colorbar=False,
                               cbax=None, vmin=None, vmax=None,
-                              edgecolor='none', flip_xax=False, flip_yax=False, 
+                              edgecolor='none', flip_xax=False, flip_yax=False,
                               lw=2)
         plt.close()
 
         # fold, deltasq, cosmo and log10, loglog
-        f3 = plot.delay_wedge(uvp, 0, ('xx','xx'), blpairs=None, times=None, 
+        f3 = plot.delay_wedge(uvp, 0, ('xx','xx'), blpairs=None, times=None,
                               fold=True, delay=False, component='abs',
                               rotate=False, log10=True, loglog=True, red_tol=1.0,
-                              center_line=False, horizon_lines=False, 
+                              center_line=False, horizon_lines=False,
                               title='hello', ax=None, cmap='viridis',
-                              figsize=(8, 6), deltasq=True, colorbar=False, 
+                              figsize=(8, 6), deltasq=True, colorbar=False,
                               cbax=None, vmin=None, vmax=None,
-                              edgecolor='none', flip_xax=False, flip_yax=False, 
+                              edgecolor='none', flip_xax=False, flip_yax=False,
                               lw=2)
         plt.close()
 
         # colorbar, vranges, flip_axes, edgecolors, lines
-        f4 = plot.delay_wedge(uvp, 0, ('xx','xx'), blpairs=None, times=None, 
+        f4 = plot.delay_wedge(uvp, 0, ('xx','xx'), blpairs=None, times=None,
                               fold=False, delay=False, component='abs',
                               rotate=False, log10=True, loglog=False, red_tol=1.0,
-                              center_line=True, horizon_lines=True, title='hello', 
-                              ax=None, cmap='viridis', figsize=(8, 6), 
-                              deltasq=True, colorbar=True, cbax=None, vmin=6, 
-                              vmax=15, edgecolor='grey', flip_xax=True, 
+                              center_line=True, horizon_lines=True, title='hello',
+                              ax=None, cmap='viridis', figsize=(8, 6),
+                              deltasq=True, colorbar=True, cbax=None, vmin=6,
+                              vmax=15, edgecolor='grey', flip_xax=True,
                               flip_yax=True, lw=2, set_bl_tick_minor=True)
         plt.close()
 
@@ -368,20 +368,20 @@ class Test_Plot(unittest.TestCase):
         fig, ax = plt.subplots()
         cbax = fig.add_axes([0.85, 0.1, 0.05, 0.9])
         cbax.axis('off')
-        plot.delay_wedge(uvp, 0, ('xx','xx'), blpairs=None, times=None, 
+        plot.delay_wedge(uvp, 0, ('xx','xx'), blpairs=None, times=None,
                          fold=False, delay=True, component='abs',
                          rotate=True, log10=True, loglog=False, red_tol=10.0,
-                         center_line=False, horizon_lines=False, ax=ax, 
-                         cmap='viridis', figsize=(8, 6), deltasq=False, 
+                         center_line=False, horizon_lines=False, ax=ax,
+                         cmap='viridis', figsize=(8, 6), deltasq=False,
                          colorbar=True, cbax=cbax, vmin=None, vmax=None,
-                         edgecolor='none', flip_xax=False, flip_yax=False, 
+                         edgecolor='none', flip_xax=False, flip_yax=False,
                          lw=2, set_bl_tick_major=True)
         plt.close()
 
         # test exceptions
-        pytest.raises(ValueError, plot.delay_wedge, uvp, 0, ('xx','xx'), 
+        pytest.raises(ValueError, plot.delay_wedge, uvp, 0, ('xx','xx'),
                          component='foo')
         plt.close()
-        
+
 if __name__ == "__main__":
     unittest.main()

--- a/hera_pspec/tests/test_pspecbeam.py
+++ b/hera_pspec/tests/test_pspecbeam.py
@@ -2,7 +2,7 @@ import unittest, os
 import pytest
 import numpy as np
 import pyuvdata as uv
-from hera_pspec import pspecbeam, conversions
+from .. import pspecbeam, conversions
 from hera_pspec.data import DATA_PATH
 
 
@@ -22,7 +22,7 @@ class Test_DataSet(unittest.TestCase):
         bm = pspecbeam.PSpecBeamUV(beamfile)
 
     def test_UVbeam(self):
-        # Precomputed results in the following tests were done "by hand" using 
+        # Precomputed results in the following tests were done "by hand" using
         # iPython notebook "Scalar_dev2.ipynb" in tests directory
         pstokes_beamfile = os.path.join(DATA_PATH, "HERA_NF_pstokes_power.beamfits")
         beam = pspecbeam.PSpecBeamUV(pstokes_beamfile)
@@ -34,7 +34,7 @@ class Test_DataSet(unittest.TestCase):
 
         # check pI polarization
         scalar = beam.compute_pspec_scalar(lower_freq, upper_freq, num_freqs, pol='pI', num_steps=2000)
-        
+
         np.testing.assert_almost_equal(Om_p[0], 0.080082680885906782)
         np.testing.assert_almost_equal(Om_p[18], 0.031990943334017245)
         np.testing.assert_almost_equal(Om_p[-1], 0.03100215028171072)
@@ -48,9 +48,9 @@ class Test_DataSet(unittest.TestCase):
         # Check array dimensionality
         assert Om_p.ndim == 1
         assert Om_pp.ndim == 1
-        
+
         # convergence of integral
-        scalar_large_Nsteps = beam.compute_pspec_scalar(lower_freq, upper_freq, num_freqs, pol='pI', num_steps=10000) 
+        scalar_large_Nsteps = beam.compute_pspec_scalar(lower_freq, upper_freq, num_freqs, pol='pI', num_steps=10000)
         assert abs(scalar / scalar_large_Nsteps - 1.0) <= 1e-5
 
         # Check that user-defined cosmology can be specified
@@ -83,10 +83,10 @@ class Test_DataSet(unittest.TestCase):
 
         # Check that invalid polarizations raise an error
         pol = 'pZ'
-        pytest.raises(KeyError, beam.compute_pspec_scalar, 
+        pytest.raises(KeyError, beam.compute_pspec_scalar,
                          lower_freq, upper_freq, num_freqs, pol=pol)
         pol = 'XX'
-        pytest.raises(ValueError, beam.compute_pspec_scalar, 
+        pytest.raises(ValueError, beam.compute_pspec_scalar,
                          lower_freq, upper_freq, num_freqs, pol=pol)
 
         # check dipole beams work
@@ -112,12 +112,12 @@ class Test_DataSet(unittest.TestCase):
         upper_freq = 128.*10**6
         num_freqs = 20
         scalar = gauss.compute_pspec_scalar(lower_freq, upper_freq, num_freqs, pol='pI', num_steps=2000)
-        
+
         # Check that user-defined cosmology can be specified
-        bgauss = pspecbeam.PSpecBeamGauss(0.8, 
-                                 np.linspace(115e6, 130e6, 50, endpoint=False), 
+        bgauss = pspecbeam.PSpecBeamGauss(0.8,
+                                 np.linspace(115e6, 130e6, 50, endpoint=False),
                                  cosmo=conversions.Cosmo_Conversions())
-        
+
         # Check array dimensionality
         assert Om_p.ndim == 1
         assert Om_pp.ndim == 1
@@ -129,7 +129,7 @@ class Test_DataSet(unittest.TestCase):
         assert Om_pp[4] == Om_pp[0]
 
         assert abs(scalar/6392750120.8657961 - 1.0) <= 1e-4
-        
+
         # convergence of integral
         scalar_large_Nsteps = gauss.compute_pspec_scalar(lower_freq, upper_freq, num_freqs, num_steps=5000)
         assert abs(scalar / scalar_large_Nsteps - 1.0) <= 1e-5
@@ -137,7 +137,7 @@ class Test_DataSet(unittest.TestCase):
         # test taper execution
         scalar = gauss.compute_pspec_scalar(lower_freq, upper_freq, num_freqs, num_steps=5000, taper='blackman')
         assert abs(scalar / 22123832163.072491 - 1.0) <= 1e-8
-    
+
     def test_BeamFromArray(self):
         """
         Test PSpecBeamFromArray
@@ -147,79 +147,79 @@ class Test_DataSet(unittest.TestCase):
         Om_P = gauss.power_beam_int()
         Om_PP = gauss.power_beam_sq_int()
         beam_freqs = gauss.beam_freqs
-        
+
         # Array specs for tests
         lower_freq = 120.*10**6
         upper_freq = 128.*10**6
         num_freqs = 20
-        
+
         # Check that PSpecBeamFromArray can be instantiated
-        psbeam = pspecbeam.PSpecBeamFromArray(OmegaP=Om_P, OmegaPP=Om_PP, 
+        psbeam = pspecbeam.PSpecBeamFromArray(OmegaP=Om_P, OmegaPP=Om_PP,
                                               beam_freqs=beam_freqs)
-        
+
         psbeampol = pspecbeam.PSpecBeamFromArray(
                                 OmegaP={'pI': Om_P, 'pQ': Om_P},
                                 OmegaPP={'pI': Om_PP, 'pQ': Om_PP},
                                 beam_freqs=beam_freqs)
-        
+
         # Check that user-defined cosmology can be specified
-        bm2 = pspecbeam.PSpecBeamFromArray(OmegaP=Om_P, OmegaPP=Om_PP, 
+        bm2 = pspecbeam.PSpecBeamFromArray(OmegaP=Om_P, OmegaPP=Om_PP,
                                            beam_freqs=beam_freqs,
                                            cosmo=conversions.Cosmo_Conversions())
-        
+
         # Compare scalar calculation with Gaussian case
-        scalar = psbeam.compute_pspec_scalar(lower_freq, upper_freq, num_freqs, 
+        scalar = psbeam.compute_pspec_scalar(lower_freq, upper_freq, num_freqs,
                                              pol='pI', num_steps=2000)
-        g_scalar = gauss.compute_pspec_scalar(lower_freq, upper_freq, 
-                                                   num_freqs, pol='pI', 
+        g_scalar = gauss.compute_pspec_scalar(lower_freq, upper_freq,
+                                                   num_freqs, pol='pI',
                                                    num_steps=2000)
         np.testing.assert_array_almost_equal(scalar, g_scalar)
-        
+
         # Check that polarizations are recognized and invalid ones rejected
-        scalarp = psbeampol.compute_pspec_scalar(lower_freq, upper_freq, 
-                                                 num_freqs, pol='pQ', 
+        scalarp = psbeampol.compute_pspec_scalar(lower_freq, upper_freq,
+                                                 num_freqs, pol='pQ',
                                                  num_steps=2000)
-        
+
         # Test taper execution (same as Gaussian case)
-        scalar = psbeam.compute_pspec_scalar(lower_freq, upper_freq, num_freqs, 
+        scalar = psbeam.compute_pspec_scalar(lower_freq, upper_freq, num_freqs,
                                              num_steps=5000, taper='blackman')
         assert abs(scalar / 22123832163.072491 - 1.0) <= 1e-8
-        
+
         # Check that invalid init args raise errors
-        pytest.raises(TypeError, pspecbeam.PSpecBeamFromArray, OmegaP=Om_P, 
+        pytest.raises(TypeError, pspecbeam.PSpecBeamFromArray, OmegaP=Om_P,
                          OmegaPP={'pI': Om_PP}, beam_freqs=beam_freqs)
         pytest.raises(KeyError, pspecbeam.PSpecBeamFromArray,
                          OmegaP={'pI': Om_P, 'pQ': Om_P},
                          OmegaPP={'pI': Om_PP,},
                          beam_freqs=beam_freqs)
-        
+
         pytest.raises(KeyError, pspecbeam.PSpecBeamFromArray,
-                         OmegaP={'A': Om_P}, 
+                         OmegaP={'A': Om_P},
                          OmegaPP={'A': Om_PP,},
                          beam_freqs=beam_freqs)
-        
+
         pytest.raises(TypeError, pspecbeam.PSpecBeamFromArray,
                          OmegaP={'pI': Om_P,},
                          OmegaPP={'pI': 'string',},
                          beam_freqs=beam_freqs)
-        
+
         pytest.raises(ValueError, pspecbeam.PSpecBeamFromArray,
-                         OmegaP={'pI': Om_P}, 
+                         OmegaP={'pI': Om_P},
                          OmegaPP={'pI': Om_PP[:-2],},
                          beam_freqs=beam_freqs)
 
         pytest.raises(TypeError, pspecbeam.PSpecBeamFromArray,
-                         OmegaP=Om_P, 
+                         OmegaP=Om_P,
                          OmegaPP={'pI': Om_PP[:-2],},
                          beam_freqs=beam_freqs)
- 
+
         pytest.raises(KeyError, pspecbeam.PSpecBeamFromArray,
-                         OmegaP={'foo': Om_P}, 
+                         OmegaP={'foo': Om_P},
                          OmegaPP={'pI': Om_PP,},
                          beam_freqs=beam_freqs)
 
         pytest.raises(KeyError, pspecbeam.PSpecBeamFromArray,
-                         OmegaP={'pI': Om_P}, 
+                         OmegaP={'pI': Om_P},
                          OmegaPP={'foo': Om_PP,},
                          beam_freqs=beam_freqs)
 
@@ -230,18 +230,18 @@ class Test_DataSet(unittest.TestCase):
         # Check that invalid method args raise errors
         pytest.raises(KeyError, psbeam.power_beam_int, pol='blah')
         pytest.raises(KeyError, psbeam.power_beam_sq_int, pol='blah')
-        pytest.raises(KeyError, psbeam.add_pol, pol='A', 
+        pytest.raises(KeyError, psbeam.add_pol, pol='A',
                          OmegaP=Om_P, OmegaPP=Om_PP)
-        
+
         # Check that string works
         assert len(str(psbeam)) > 0
-    
+
     def test_PSpecBeamBase(self):
         """
         Test that base class can be instantiated.
         """
         bm1 = pspecbeam.PSpecBeamBase()
-        
+
         # Check that user-defined cosmology can be specified
         bm2 = pspecbeam.PSpecBeamBase(cosmo=conversions.Cosmo_Conversions())
 
@@ -254,7 +254,7 @@ class Test_DataSet(unittest.TestCase):
         OP, OPP = beam.get_Omegas([(-5,-5), (-6,-6)])
         assert OP.shape == (26, 2)
         assert OPP.shape == (26, 2)
-        
+
         pytest.raises(TypeError, beam.get_Omegas, 'xx')
         pytest.raises(NotImplementedError, beam.get_Omegas, [('pI','pQ'),])
 
@@ -265,32 +265,32 @@ class Test_DataSet(unittest.TestCase):
         freq     = np.linspace(130.0*1e6, 140.0*1e6, 10)
         nside    = beam.primary_beam.nside #uvbeam object
         beam_res = pspecbeam.PSpecBeamUV.beam_normalized_response(beam, pol='xx', freq=freq)
-        
+
         #tests for dimensions
         assert len(beam_res[1]) == len(freq)
         assert beam_res[0].ndim == 2
         assert np.shape(beam_res[0]) == (len(freq), (12*nside**2))
-        
+
         #tests for polarization
-        pytest.raises(ValueError, pspecbeam.PSpecBeamUV.beam_normalized_response, beam, pol='ll', freq=freq) 
+        pytest.raises(ValueError, pspecbeam.PSpecBeamUV.beam_normalized_response, beam, pol='ll', freq=freq)
 
         #test if it is a power beam
         efield_beamfile = os.path.join(DATA_PATH, "HERA_NF_efield.beamfits")
         beam_efield     = pspecbeam.PSpecBeamUV(efield_beamfile)
         beam_efield.primary_beam.beam_type='voltage'
-        pytest.raises(ValueError, pspecbeam.PSpecBeamUV.beam_normalized_response, beam_efield, pol='xx', freq=freq) 
+        pytest.raises(ValueError, pspecbeam.PSpecBeamUV.beam_normalized_response, beam_efield, pol='xx', freq=freq)
 
         #test for right axes
         beam_efield.primary_beam.beam_type='power'
         beam_efield.primary_beam.Naxes_vec=2
-        pytest.raises(ValueError, pspecbeam.PSpecBeamUV.beam_normalized_response, beam_efield, pol='xx', freq=freq) 
+        pytest.raises(ValueError, pspecbeam.PSpecBeamUV.beam_normalized_response, beam_efield, pol='xx', freq=freq)
 
         #test for peak normalization
         beam_efield.primary_beam.Naxes_vec=1
         beam_efield.primary_beam._data_normalization.value = 'area'
-        pytest.raises(ValueError, pspecbeam.PSpecBeamUV.beam_normalized_response, beam_efield, pol='xx', freq=freq) 
+        pytest.raises(ValueError, pspecbeam.PSpecBeamUV.beam_normalized_response, beam_efield, pol='xx', freq=freq)
 
         #test for the coordinate system
         beam_efield.primary_beam._data_normalization.value = 'peak'
         beam_efield.primary_beam.pixel_coordinate_system = 'cartesian'
-        pytest.raises(ValueError, pspecbeam.PSpecBeamUV.beam_normalized_response, beam_efield, pol='xx', freq=freq) 
+        pytest.raises(ValueError, pspecbeam.PSpecBeamUV.beam_normalized_response, beam_efield, pol='xx', freq=freq)

--- a/hera_pspec/tests/test_pstokes.py
+++ b/hera_pspec/tests/test_pstokes.py
@@ -2,7 +2,7 @@ import unittest
 import pytest
 import os, sys
 from hera_pspec.data import DATA_PATH
-from hera_pspec import pstokes 
+from .. import pstokes 
 import pyuvdata
 import pyuvdata.utils as uvutils
 import copy
@@ -22,21 +22,21 @@ class Test_pstokes(unittest.TestCase):
         self.uvd1.read_miriad(dset1)
         self.uvd2 = pyuvdata.UVData()
         self.uvd2.read_miriad(dset2)
-    
+
     def tearDown(self):
         pass
 
     def runTest(self):
         pass
-    
+
     def test_combine_pol(self):
         uvd1 = self.uvd1
         uvd2 = self.uvd2
-     
+
         # basic execution on pol strings
-        out1 = pstokes._combine_pol(uvd1, uvd2, 'XX', 'YY')   
+        out1 = pstokes._combine_pol(uvd1, uvd2, 'XX', 'YY')
         # again w/ pol ints
-        out2 = pstokes._combine_pol(uvd1, uvd2, -5, -6)   
+        out2 = pstokes._combine_pol(uvd1, uvd2, -5, -6)
         # assert equivalence
         assert out1 == out2
 
@@ -44,7 +44,7 @@ class Test_pstokes(unittest.TestCase):
         pytest.raises(AssertionError, pstokes._combine_pol, dset1, dset2, 'XX', 'YY' )
         pytest.raises(AssertionError, pstokes._combine_pol, uvd1, uvd2, 'XX', 1)
 
-    def test_construct_pstokes(self):   
+    def test_construct_pstokes(self):
         uvd1 = self.uvd1
         uvd2 = self.uvd2
 
@@ -53,7 +53,7 @@ class Test_pstokes(unittest.TestCase):
         uvdQ = pstokes.construct_pstokes(dset1=uvd1, dset2=uvd2, pstokes='pQ')
 
         # check exceptions
-        pytest.raises(AssertionError, pstokes.construct_pstokes, uvd1, 1)   
+        pytest.raises(AssertionError, pstokes.construct_pstokes, uvd1, 1)
 
         # check baselines
         uvd3 = uvd2.select(ant_str='auto', inplace=False)

--- a/hera_pspec/tests/test_testing.py
+++ b/hera_pspec/tests/test_testing.py
@@ -1,6 +1,6 @@
 import pytest
 from hera_pspec.data import DATA_PATH
-from hera_pspec import testing, uvpspec, conversions, pspecbeam, utils
+from .. import testing, uvpspec, conversions, pspecbeam, utils
 import os
 from pyuvdata import UVData, UVBeam
 import numpy as np

--- a/hera_pspec/tests/test_utils.py
+++ b/hera_pspec/tests/test_utils.py
@@ -3,7 +3,7 @@ import pytest
 import numpy as np
 import os, sys, copy
 from hera_pspec.data import DATA_PATH
-from hera_pspec import utils, testing
+from .. import utils, testing
 from collections import OrderedDict as odict
 from pyuvdata import UVData
 from hera_cal import redcal
@@ -25,7 +25,7 @@ def test_cov():
     cov = utils.cov(d1, w2, d2=d2, w2=w2)
     assert cov.shape == (60, 60)
     assert cov.dtype == np.complex
-    
+
     # test exception
     pytest.raises(TypeError, utils.cov, d1, w1*1j)
     pytest.raises(TypeError, utils.cov, d1, w1, d2=d2, w2=w2*1j)
@@ -249,10 +249,10 @@ class Test_Utils(unittest.TestCase):
         np.testing.assert_almost_equal(l[0], 0)
         np.testing.assert_almost_equal(a[0], 0)
         assert len(r) == 105
-        
+
         # Check errors when wrong types input
         pytest.raises(TypeError, utils.get_reds, [1., 2.])
-        
+
     def test_config_pspec_blpairs(self):
         # test basic execution
         uv_template = os.path.join(DATA_PATH, "zen.{group}.{pol}.LST.1.28828.uvOCRSA")
@@ -269,11 +269,11 @@ class Test_Utils(unittest.TestCase):
         # test xants
         groupings = utils.config_pspec_blpairs(uv_template, [('xx', 'xx')], [('even', 'odd')], xants=[0, 1, 2], verbose=False, exclude_auto_bls=True)
         assert len(list(groupings.values())[0]) == 9735
-        
+
         # test exclude_patterns
-        groupings = utils.config_pspec_blpairs(uv_template, 
-                                               [('xx', 'xx'), ('yy', 'yy')], 
-                                               [('even', 'odd'), ('even', 'odd')], 
+        groupings = utils.config_pspec_blpairs(uv_template,
+                                               [('xx', 'xx'), ('yy', 'yy')],
+                                               [('even', 'odd'), ('even', 'odd')],
                                                exclude_patterns=['1.288'],
                                                verbose=False, exclude_auto_bls=True)
         assert len(groupings) == 0

--- a/hera_pspec/tests/test_uvpspec.py
+++ b/hera_pspec/tests/test_uvpspec.py
@@ -4,8 +4,8 @@ import numpy as np
 import os
 import sys
 from hera_pspec.data import DATA_PATH
-from hera_pspec import uvpspec, conversions, parameter, pspecbeam, pspecdata, testing, utils
-from hera_pspec import uvpspec_utils as uvputils
+from .. import uvpspec, conversions, parameter, pspecbeam, pspecdata, testing, utils
+from .. import uvpspec_utils as uvputils
 import copy
 import h5py
 from collections import OrderedDict as odict
@@ -59,63 +59,63 @@ class Test_UVPSpec(unittest.TestCase):
         np.testing.assert_almost_equal(d[0,0], (101.1021011020000001+0j))
         d = self.uvp.get_data((0, 101102101102, 1515))
         np.testing.assert_almost_equal(d[0,0], (101.1021011020000001+0j))
-        
+
         # get_wgts
         w = self.uvp.get_wgts((0, ((1, 2), (1, 2)), ('xx','xx')))
         assert w.shape == (10, 50, 2) # should have Nfreq dim, not Ndlys
         assert w.dtype == np.float
         assert w[0,0,0] == 1.0
-        
+
         # get_integrations
         i = self.uvp.get_integrations((0, ((1, 2), (1, 2)), ('xx','xx')))
         assert i.shape == (10,)
         assert i.dtype == np.float
         np.testing.assert_almost_equal(i[0], 1.0)
-        
+
         # get nsample
         n = self.uvp.get_nsamples((0, ((1, 2), (1, 2)), ('xx', 'xx')))
         assert n.shape == (10,)
         assert n.dtype == np.float
         np.testing.assert_almost_equal(n[0], 1.0)
-        
+
         # get dly
         d = self.uvp.get_dlys(0)
         assert len(d) == 30
-        
+
         # get blpair seps
         blp = self.uvp.get_blpair_seps()
         assert len(blp) == 30
         assert(np.isclose(blp, 14.60, rtol=1e-1, atol=1e-1).all())
-        
+
         # get kvecs
         k_perp, k_para = self.uvp.get_kperps(0), self.uvp.get_kparas(0)
         assert len(k_perp) == 30
         assert len(k_para) == 30
-        
+
         # test key expansion
         key = (0, ((1, 2), (1, 2)), ('xx','xx'))
         d = self.uvp.get_data(key)
         assert d.shape == (10, 30)
-        
+
         # test key as dictionary
         key = {'spw':0, 'blpair':((1, 2), (1, 2)), 'polpair': ('xx','xx')}
         d = self.uvp.get_data(key)
         assert d.shape == (10, 30)
-        
+
         # test get_blpairs
         blps = self.uvp.get_blpairs()
         assert blps == [((1, 2), (1, 2)), ((2, 3), (2, 3)), ((1, 3), (1, 3))]
-        
+
         # test get_blpair_vecs
         blp_vecs = self.uvp.get_blpair_blvecs()
         assert blp_vecs.shape == (self.uvp.Nblpairs, 3)
         blp_vecs2 = self.uvp.get_blpair_blvecs(use_second_bl=True)
         assert np.isclose(blp_vecs, blp_vecs2).all()
-        
+
         # test get_polpairs
         polpairs = self.uvp.get_polpairs()
         assert polpairs == [('xx', 'xx')]
-        
+
         # test get all keys
         keys = self.uvp.get_all_keys()
         assert keys == [(0, ((1, 2), (1, 2)), ('xx', 'xx')),
@@ -149,7 +149,7 @@ class Test_UVPSpec(unittest.TestCase):
         red_bls = redcal.get_pos_reds(antpos, bl_error_tol=1.0)
         bls1, bls2, blpairs = utils.construct_blpairs(red_bls[3], exclude_auto_bls=True, exclude_permutations=True)
 
-        uvp = ds.pspec( bls1, bls2, (0, 1), [('xx', 'xx')], spw_ranges=spws, input_data_weight='identity', 
+        uvp = ds.pspec( bls1, bls2, (0, 1), [('xx', 'xx')], spw_ranges=spws, input_data_weight='identity',
          norm='I', taper='blackman-harris', store_cov = True, cov_model='autos', verbose=False)
 
         key = (0,blpairs[0],"xx")
@@ -226,7 +226,7 @@ class Test_UVPSpec(unittest.TestCase):
         uvd_std.data_array[:] = 1.0
         bls = [(37, 38), (38, 39), (52, 53)]
         uvp = testing.uvpspec_from_data(uvd, bls, data_std=uvd_std,
-                                        spw_ranges=[(20, 30), (60, 90)], 
+                                        spw_ranges=[(20, 30), (60, 90)],
                                         beam=beam)
         # dummy stats_array build
         Tsys = utils.uvd_to_Tsys(uvd, beam)
@@ -452,26 +452,26 @@ class Test_UVPSpec(unittest.TestCase):
         if os.path.exists('./ex.hdf5'): os.remove('./ex.hdf5')
         uvp.write_hdf5('./ex.hdf5', overwrite=True)
         assert os.path.exists('./ex.hdf5')
-        
+
         # test basic read
         uvp2 = uvpspec.UVPSpec()
         uvp2.read_hdf5('./ex.hdf5')
         assert uvp == uvp2
-        
+
         # test just meta
         uvp2 = uvpspec.UVPSpec()
         uvp2.read_hdf5('./ex.hdf5', just_meta=True)
-        assert hasattr(uvp2, 'Ntimes') 
+        assert hasattr(uvp2, 'Ntimes')
         assert hasattr(uvp2, 'data_array') == False
-        
+
         # test exception
         pytest.raises(IOError, uvp.write_hdf5, './ex.hdf5', overwrite=False)
-        
+
         # test partial I/O
         uvp.read_hdf5("./ex.hdf5", bls=[(1, 2)])
         assert uvp.Nblpairs == 1
         assert uvp.data_array[0].shape == (10, 30, 1)
-        
+
         # test just meta
         uvp.read_hdf5("./ex.hdf5", just_meta=True)
         assert uvp.Nblpairs == 3
@@ -559,7 +559,7 @@ class Test_UVPSpec(unittest.TestCase):
         pytest.raises(AssertionError, uvp.fold_spectra)
         assert len(uvp.get_dlys(0)) == 14
         assert(np.isclose(uvp.nsample_array[0], 2.0).all())
-        
+
         # also run the odd case
         uvd = UVData()
         uvd_std = UVData()
@@ -579,15 +579,15 @@ class Test_UVPSpec(unittest.TestCase):
                                          spw_ranges=[(0,17)], beam=beam)
         # Average then fold
         uvp_avg = uvp.average_spectra(time_avg=True, inplace=False)
-        
+
         # Fold averaged spectra
         uvp_avg_folded = copy.deepcopy(uvp_avg)
         uvp_avg_folded.fold_spectra()
-        
+
         # Fold then average
         uvp_folded = copy.deepcopy(uvp)
         uvp_folded.fold_spectra()
-        
+
         # Average folded spectra
         uvp_folded_avg = uvp_folded.average_spectra(time_avg=True, inplace=False)
         assert(np.allclose(uvp_avg_folded.get_data((0, ((37, 38), (38, 39)), 'xx')), uvp_folded_avg.get_data((0, ((37, 38), (38, 39)), 'xx')), rtol=1e-5))
@@ -608,24 +608,24 @@ class Test_UVPSpec(unittest.TestCase):
     def test_set_cosmology(self):
         uvp = copy.deepcopy(self.uvp)
         new_cosmo = conversions.Cosmo_Conversions(Om_L=0.0)
-        
+
         # test no overwrite
         uvp.set_cosmology(new_cosmo, overwrite=False)
         assert uvp.cosmo != new_cosmo
-        
+
         # test setting cosmology
         uvp.set_cosmology(new_cosmo, overwrite=True)
         assert uvp.cosmo == new_cosmo
         assert uvp.norm_units == 'h^-3 Mpc^3'
         assert (uvp.scalar_array>1.0).all()
         assert (uvp.data_array[0] > 1e5).all()
-        
+
         # test exception
         new_cosmo2 = conversions.Cosmo_Conversions(Om_L=1.0)
         del uvp.OmegaP
         uvp.set_cosmology(new_cosmo2, overwrite=True)
         assert uvp.cosmo != new_cosmo2
-        
+
         # try with new beam
         uvp.set_cosmology(new_cosmo2, overwrite=True, new_beam=self.beam)
         assert uvp.cosmo == new_cosmo2
@@ -638,8 +638,8 @@ class Test_UVPSpec(unittest.TestCase):
         beam = pspecbeam.PSpecBeamUV(os.path.join(DATA_PATH,
                                                "HERA_NF_dipole_power.beamfits"))
         bls = [(37, 38), (38, 39), (52, 53)]
-        uvp1 = testing.uvpspec_from_data(uvd, bls, 
-                                         spw_ranges=[(20, 30), (60, 90)], 
+        uvp1 = testing.uvpspec_from_data(uvd, bls,
+                                         spw_ranges=[(20, 30), (60, 90)],
                                          beam=beam)
         uvp1 = self._add_optionals(uvp1)
 
@@ -650,9 +650,9 @@ class Test_UVPSpec(unittest.TestCase):
         assert out.Npols == 2
         assert(len(set(out.polpair_array) ^ set([1515, 1414])) == 0)
         key = (0, ((37, 38), (38, 39)), ('xx','xx'))
-        assert(np.all(np.isclose(out.get_nsamples(key), 
+        assert(np.all(np.isclose(out.get_nsamples(key),
                        np.ones(10, dtype=np.float64))))
-        assert(np.all(np.isclose(out.get_integrations(key), 
+        assert(np.all(np.isclose(out.get_integrations(key),
                        190 * np.ones(10, dtype=np.float64), atol=5, rtol=2)))
         # optionals
         for spw in out.spw_array:
@@ -671,7 +671,7 @@ class Test_UVPSpec(unittest.TestCase):
         assert out.Nspws == 3
         assert out.Nfreqs == 51
         assert out.Nspwdlys == 56
-        
+
         # optionals
         assert len(out.stats_array['noise_err']) == 3
         assert len(out.window_function_array) == 3
@@ -685,7 +685,7 @@ class Test_UVPSpec(unittest.TestCase):
         out = uvpspec.combine_uvpspec([uvp1, uvp2], verbose=False)
         assert out.Nblpairs == 4
         assert out.Nbls == 5
-        
+
         # optionals
         for spw in out.spw_array:
             ndlys = out.get_spw_ranges(spw)[0][-1]
@@ -731,7 +731,7 @@ class Test_UVPSpec(unittest.TestCase):
         # w/ merge
         out = uvpspec.combine_uvpspec([uvp_a, uvp_b], merge_history=True, verbose=False)
         assert 'batwing' in out.history and 'foobar' in out.history
-        
+
         # w/o merge
         out = uvpspec.combine_uvpspec([uvp_a, uvp_b], merge_history=False, verbose=False)
         assert 'batwing' in out.history and not 'foobar' in out.history
@@ -751,8 +751,8 @@ class Test_UVPSpec(unittest.TestCase):
         beam = pspecbeam.PSpecBeamUV(os.path.join(DATA_PATH,
                                                "HERA_NF_dipole_power.beamfits"))
         bls = [(37, 38), (38, 39), (52, 53)]
-        uvp1 = testing.uvpspec_from_data(uvd, bls, 
-                                         spw_ranges=[(20, 30), (60, 90)], 
+        uvp1 = testing.uvpspec_from_data(uvd, bls,
+                                         spw_ranges=[(20, 30), (60, 90)],
                                          beam=beam)
 
         # test failure due to overlapping data
@@ -853,13 +853,13 @@ class Test_UVPSpec(unittest.TestCase):
         # test failure due to overlapping data
         uvp2 = copy.deepcopy(uvp1)
         pytest.raises(AssertionError, uvpspec.combine_uvpspec, [uvp1, uvp2])
-        
+
         # test success across pol
         uvp2.polpair_array[0] = 1414
         out = uvpspec.combine_uvpspec([uvp1, uvp2], verbose=False)
         assert out.Npols == 2
         assert len(set(out.polpair_array) ^ set([1515, 1414])) == 0
-        
+
         # test multiple non-overlapping data axes
         uvp2.freq_array[0] = 0.0
         pytest.raises(AssertionError, uvpspec.combine_uvpspec, [uvp1, uvp2])

--- a/hera_pspec/tests/test_uvpspec_utils.py
+++ b/hera_pspec/tests/test_uvpspec_utils.py
@@ -1,8 +1,8 @@
 import unittest
 import pytest
 import numpy as np
-from hera_pspec import uvpspec_utils as uvputils
-from hera_pspec import testing, pspecbeam, UVPSpec
+from .. import uvpspec_utils as uvputils
+from .. import testing, pspecbeam, UVPSpec
 from pyuvdata import UVData
 from hera_pspec.data import DATA_PATH
 import os
@@ -295,4 +295,3 @@ def test_r_param_compression():
 
     assert uvputils.compress_r_params({}) == ''
     assert uvputils.decompress_r_params('') == {}
-

--- a/hera_pspec/tests/test_version.py
+++ b/hera_pspec/tests/test_version.py
@@ -10,7 +10,7 @@ except:
     # Python 3
     from io import StringIO
 import hera_pspec
-from hera_pspec import version
+from .. import version
 import json
 
 


### PR DESCRIPTION
For reasons that are somewhat opaque to me, the existing pytest setup was not actually recording coverage (coverage files were produced, but all the lines were recorded as missed). By adjusting imports in the test files and removing a problematic arg, I think I've fixed this.