### PR TITLE
Updated docstrings for get_H and scalar_delay_adjustment to reflect h…

### DIFF
--- a/hera_pspec/pspecdata.py
+++ b/hera_pspec/pspecdata.py
@@ -1439,15 +1439,7 @@ class PSpecData(object):
             H_ab = (1/2) Tr[R_1 Q_a^alt R_2 Q_b]
 
         (See HERA memo #44). As currently implemented, this approximates the
-        primary beam as frequency independent. Under this approximation, the
-        our H_ab is defined using the equation above *except* we have
-        Q^tapered rather than Q_b, where
-
-            \overline{Q}^{tapered,beta}
-            = e^{i 2pi eta_beta (nu_i - nu_j)} gamma(nu_i) gamma(nu_j)
-
-        where gamma is the tapering function. Again, see HERA memo #44 for
-        details.
+        primary beam as frequency independent.
 
         The sampling option determines whether one is assuming that the
         output points are integrals over k bins or samples at specific
@@ -2587,8 +2579,10 @@ class PSpecData(object):
     def scalar_delay_adjustment(self, key1=None, key2=None, sampling=False,
                                 Gv=None, Hv=None):
         """
-        Computes an adjustment factor for the pspec scalar that is needed
-        when the number of delay bins is not equal to the number of
+        Computes an adjustment factor for the pspec scalar. There are 
+        two reasons why this might be needed:
+
+        1) When the number of delay bins is not equal to the number of
         frequency channels.
 
         This adjustment is necessary because
@@ -2602,6 +2596,14 @@ class PSpecData(object):
         If the data weighting is not equal to "identity" then
         we generally need a separate scalar adjustment for each
         alpha.
+
+        2) Even when the number of delay bins is equal to the number
+        of frequency channels, there is an extra adjustment necessary
+        to account for tapering functions. The reason for this is that
+        our current code accounts for the tapering function in the
+        normalization matrix M *and* accounts for it again in the
+        pspec scalar. The adjustment provided by this function
+        essentially cancels out one of these extra copies.
 
         This function uses the state of self.taper in constructing adjustment.
         See PSpecData.pspec for details.


### PR DESCRIPTION
…ow we actually account for tapering in our code

This PR is in response to a scary moment where we thought that there was a bug in the pspec normalization. The code actually is correct, but some docstrings were misleading. I've updated the docstrings to (accurately) state that:

- Aside from the factors of the taper in `R1` and `R2`, the `get_H` function does not make any extra adjustments in normalization to account for the taper.
- There is, however, an extra factor of the taper that enters into `scalar_delay_adjustment`. This is needed for a correct power spectrum normalization, and we had implemented that in the function. However, we neglected to say that this was being done in the docstring.

@r-pascua reran the HERA validation test 0.1.0 with v0.3.0 with `hera_pspec` to show that the power spectrum is correctly normalized whether we use a taper or not. The result is good to the percent level vs Adam Lanman's analytic prediction for his simulated data. See attached file.

[new_hera_pspec_validation_test_result (1).pdf](https://github.com/HERA-Team/hera_pspec/files/6626449/new_hera_pspec_validation_test_result.1.pdf)
