### PR TITLE
Fix issue with git clone in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,8 +44,8 @@ setup_args = {
         'astropy>=2.0',
         'pyyaml',
         'h5py',
-        'uvtools @ git+git://github.com/HERA-Team/uvtools',
-        'hera_cal @ git+git://github.com/HERA-Team/hera_cal'
+        'uvtools @ git+https://github.com/HERA-Team/uvtools',
+        'hera_cal @ git+https://github.com/HERA-Team/hera_cal'
     ],
     'include_package_data': True,
     'scripts': ['scripts/pspec_run.py', 'scripts/pspec_red.py',


### PR DESCRIPTION
Replaced `git clone git://github.com/HERA-Team/uvtools` calls with `git clone https://github.com/HERA-Team/uvtools` to allow checks to run properly. Otherwise, throws git error.