### PR TITLE
get rid of nans from P_SN correction.

### DIFF
--- a/hera_pspec/utils.py
+++ b/hera_pspec/utils.py
@@ -1514,5 +1514,6 @@ def apply_P_SN_correction(uvp, P_SN='P_SN', P_N='P_N'):
         corr = 1 - (np.sqrt(1 / np.sqrt(np.pi) + 1) - 1) * p_n.real / p_sn.real.clip(1e-40, np.inf)
         corr[np.isclose(corr, 0)] = np.inf
         corr[corr < 0] = np.inf
+        corr[np.isnan(corr)] = np.inf
         # apply correction
         uvp.stats_array[P_SN][spw] *= corr


### PR DESCRIPTION
Fix bug in `P_SN` correction calculation where nans can be introduced if both P_N and P_SN are infinite. If this is the case, then P_SN should still be np.inf after correction but instead it is set to Nan since the calculation takes the ratio between P_N and P_SN and numpy assigns inf/inf=nan (offending line is at https://github.com/HERA-Team/hera_pspec/blob/e6b73604ed771b6c1d56b4cf0396ccda2d56635d/hera_pspec/utils.py#L1514 ) 

This PR sets all nans introduced by this step to infinty.