### PR TITLE
fix: circular import with __version__

### DIFF
--- a/hera_pspec/__init__.py
+++ b/hera_pspec/__init__.py
@@ -6,7 +6,16 @@ try:
 except ImportError:
     from importlib_metadata import version, PackageNotFoundError
 
-from . import version, conversions, grouping, pspecbeam, plot, pstokes, testing, utils
+try:
+    from ._version import version as __version__
+except ModuleNotFoundError:  # pragma: no cover
+    try:
+        __version__ = version("hera_pspec")
+    except PackageNotFoundError:
+        # package is not installed
+        __version__ = "unknown"
+
+from . import conversions, grouping, pspecbeam, plot, pstokes, testing, utils
 from . import uvpspec_utils as uvputils
 
 from .uvpspec import UVPSpec
@@ -16,14 +25,7 @@ from .container import PSpecContainer
 from .parameter import PSpecParam
 from .pspecbeam import PSpecBeamUV, PSpecBeamGauss, PSpecBeamFromArray
 
-try:
-    from ._version import version as __version__
-except ModuleNotFoundError:  # pragma: no cover
-    try:
-        __version__ = version("hera_pspec")
-    except PackageNotFoundError:
-        # package is not installed
-        __version__ = "unknown"
+
 
 del version
 del PackageNotFoundError


### PR DESCRIPTION
Fixes a circular-import issue when importing `hera_pspec`. The init was importing a submodule which was importing `__version__` from the init, but `__version__` hadn't yet been defined in the init...