### PR TITLE
Fix issue running tests due to codecov version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,9 +58,8 @@ jobs:
                --cov-report xml:"./coverage.xml" --junitxml="./test-reports/xunit.xml"
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v3
       with:
-        token: ${{ secrets.CODECOV_TOKEN }}
         files: ./coverage.xml
         directory: ./coverage/reports/
         flags: unittests


### PR DESCRIPTION
Update tests workflow to `codecov` v3 and remove secret token (not required for public repos). Was causing checks to fail (only for macOS weirdly)