### PR TITLE
Fix bug in log messages.

### DIFF
--- a/hera_pspec/pspecdata.py
+++ b/hera_pspec/pspecdata.py
@@ -4123,7 +4123,7 @@ def pspec_run(dsets, filename, dsets_std=None, cals=None, cal_flag=True,
             assert 0 <= spw[0] < spw[1], f"spw_ranges must be a list of tuples of length 2, with both elements being non-negative integers of increasing value. Got {spw}"
             for dset in dsets:
                 assert spw[1] <= dset.Nfreqs, f"spw_range of {spw} out of range for dset {dset.filename[0]} with the second element being less than the number of frequencies in the data"
-            utils.log(f"Using spw_range: {dsets[0].freq_array[:, spw[0]] /1e6} - {dsets[0].freq_array[:, spw[1]]/1e6} MHz", verbose=verbose)
+            utils.log(f"Using spw_range: {dsets[0].freq_array[:, spw[0]] /1e6} - {dsets[0].freq_array[:, spw[1] - 1]/1e6} MHz", verbose=verbose)
 
     # read calibration if provided (calfits partial IO not yet supported)
     if cals is not None:


### PR DESCRIPTION
Errors are being caused by log message line trying to index with upper end of spw_range. The spw-ranges are meant to be inclusive for the base index and exclusive for the end-index (hence being allowed to range up to Nfreqs). Thus we should actually print spw[1] - 1 in the log-error message. If spw[1] = Nfreqs then an error will occur. 