### PR TITLE
Unique time-keys  in `UVPSpec` objects based on `time_1_array` and `time_2_array` instead of the current `time_avg_array`

### DIFF
--- a/hera_pspec/grouping.py
+++ b/hera_pspec/grouping.py
@@ -541,7 +541,7 @@ def average_spectra(uvp_in, blpair_groups=None, time_avg=False,
 
     # Assign arrays and metadata to UVPSpec object
     uvp.Ntimes = len(np.unique(time_avg_arr))
-    uvp.Nblpairts = len(time_avg_arr)
+    uvp.Nbltpairs = len(time_avg_arr)
     uvp.Nblpairs = len(np.unique(blpair_arr))
     uvp.Nbls = len(bl_arr)
 
@@ -733,7 +733,7 @@ def spherical_average(uvp_in, kbins, bin_widths, blpair_groups=None, time_avg=Fa
         E = np.zeros((uvp.Ntimes, Ndlyblps, Ndlys, uvp.Npols), dtype=np.float64)
 
 
-        # get kperps for this spw: shape (Nblpairts,)
+        # get kperps for this spw: shape (Nbltpairs,)
         kperps = uvp.get_kperps(spw, little_h=True)
 
         # get kparas for this spw: shape (Ndlys,)
@@ -914,7 +914,7 @@ def spherical_average(uvp_in, kbins, bin_widths, blpair_groups=None, time_avg=Fa
     blp = uvp.blpair_array[0]
     blp_inds = uvp.blpair_to_indices(blp)
     uvp.blpair_array = uvp.blpair_array[blp_inds]
-    uvp.Nblpairts = uvp.Ntimes
+    uvp.Nbltpairs = uvp.Ntpairs
     uvp.Nblpairs = 1
     bl_array = np.unique([uvp.antnums_to_bl(an) for an in uvp.blpair_to_antnums(blp)])
     uvp.bl_vecs = np.asarray([uvp.bl_vecs[np.argmin(uvp.bl_array - bl)] for bl in bl_array])

--- a/hera_pspec/grouping.py
+++ b/hera_pspec/grouping.py
@@ -540,10 +540,11 @@ def average_spectra(uvp_in, blpair_groups=None, time_avg=False,
                         for bl in bl_arr])
 
     # Assign arrays and metadata to UVPSpec object
-    uvp.Ntimes = len(np.unique(time_avg_arr))
+    uvp.Ntimes = len(np.unique(np.hstack([time_1, time_2])))
     uvp.Nbltpairs = len(time_avg_arr)
     uvp.Nblpairs = len(np.unique(blpair_arr))
     uvp.Nbls = len(bl_arr)
+    uvp.Ntpairs = len(set((t1, t2) for t1, t2 in zip(time_1, time_2)))
 
     # Baselines
     uvp.bl_array = bl_arr

--- a/hera_pspec/plot.py
+++ b/hera_pspec/plot.py
@@ -501,7 +501,7 @@ def delay_waterfall(uvp, blpairs, spw, pol, component='abs-real',
         fig, axes = plt.subplots(Nside, Nside, figsize=figsize)
     
     # Ensure axes is an ndarray
-    if isinstance(axes, matplotlib.axes._subplots.Axes):
+    if isinstance(axes, matplotlib.axes.Axes):
         axes = np.array([[axes]])
     if isinstance(axes, list):
         axes = np.array(axes)

--- a/hera_pspec/plot.py
+++ b/hera_pspec/plot.py
@@ -384,6 +384,7 @@ def delay_waterfall(uvp, blpairs, spw, pol, component='abs-real',
     """
     import matplotlib
     import matplotlib.pyplot as plt
+    import matplotlib.axes
 
     # assert component
     assert component in ['real', 'abs', 'imag', 'abs-real', 'abs-imag'], "Can't parse specified component {}".format(component)

--- a/hera_pspec/pspecdata.py
+++ b/hera_pspec/pspecdata.py
@@ -234,6 +234,7 @@ class PSpecData(object):
                     break
 
         # Store no. frequencies and no. times
+        # We are still only supporting dsets with same number of times
         self.Nfreqs = self.dsets[0].Nfreqs
         self.Ntimes = self.dsets[0].Ntimes
 
@@ -3443,8 +3444,15 @@ class PSpecData(object):
                                      % (2*np.pi)
         uvp.blpair_array = np.array(blp_arr)
         uvp.Nblpairs = len(np.unique(blp_arr))
-        uvp.Ntimes = len(np.unique(time1))
-        uvp.Nblpairts = len(time1)
+        # Ntimes in a uvpspec object now means the total number of times.
+        # In all possible datasets that could be produced by pspecdata this
+        # is equal to Ntpairs or 2 x Ntpairs if we interleave
+        # but we have given upspec the capability to have this
+        # not necessarily be the same.
+        uvp.Ntimes = len(np.unique(np.hstack([uvp.time_1_array, uvp.time_2_array])))
+        uvp.Npairs = len(set([(t1, t2) for t1, t2 in zip(uvp.time_1_array, uvp.time_2_array)]))
+        uvp.Nbltpairs = len(set([(blp, t1, t2) for blp, t1, t2 in zip(uvp.blpair_array, uvp.time_1_array, uvp.time_2_array)]))
+        uvp.Ntpairs = len(set([(t1, t2) for t1, t2 in zip(uvp.time_1_array, uvp.time_2_array)]))
         bls_arr = sorted(set(bls_arr))
         uvp.bl_array = np.array([uvp.antnums_to_bl(bl) for bl in bls_arr])
         antpos = dict(zip(dset1.antenna_numbers, dset1.antenna_positions))
@@ -3475,9 +3483,9 @@ class PSpecData(object):
         label1 = self.labels[self.dset_idx(dsets[0])]
         label2 = self.labels[self.dset_idx(dsets[1])]
         uvp.labels = sorted(set([label1, label2]))
-        uvp.label_1_array = np.ones((uvp.Nspws, uvp.Nblpairts, uvp.Npols), int) \
+        uvp.label_1_array = np.ones((uvp.Nspws, uvp.Nbltpairs, uvp.Npols), int) \
                             * uvp.labels.index(label1)
-        uvp.label_2_array = np.ones((uvp.Nspws, uvp.Nblpairts, uvp.Npols), int) \
+        uvp.label_2_array = np.ones((uvp.Nspws, uvp.Nbltpairs, uvp.Npols), int) \
                             * uvp.labels.index(label2)
         uvp.labels = np.array(uvp.labels, str)
         uvp.r_params = uvputils.compress_r_params(r_params)

--- a/hera_pspec/pspecdata.py
+++ b/hera_pspec/pspecdata.py
@@ -3452,7 +3452,6 @@ class PSpecData(object):
         # not necessarily be the same.
         # Ntimes could still be the number of "average times" which might be useful for noise purposes. 
         uvp.Ntimes = len(np.unique(np.hstack([uvp.time_1_array, uvp.time_2_array])))
-        uvp.Npairs = len(set([(t1, t2) for t1, t2 in zip(uvp.time_1_array, uvp.time_2_array)]))
         uvp.Nbltpairs = len(set([(blp, t1, t2) for blp, t1, t2 in zip(uvp.blpair_array, uvp.time_1_array, uvp.time_2_array)]))
         uvp.Ntpairs = len(set([(t1, t2) for t1, t2 in zip(uvp.time_1_array, uvp.time_2_array)]))
         bls_arr = sorted(set(bls_arr))

--- a/hera_pspec/pspecdata.py
+++ b/hera_pspec/pspecdata.py
@@ -318,8 +318,8 @@ class PSpecData(object):
 
         # Check phase centers if phase type is phased
         if 'phased' in set(phase_types):
-            phase_ra = [d.phase_center_ra_degrees for d in self.dsets]
-            phase_dec = [d.phase_center_dec_degrees for d in self.dsets]
+            phase_ra = [d.phase_center_app_ra_degrees for d in self.dsets]
+            phase_dec = [d.phase_center_app_dec_degrees for d in self.dsets]
             max_diff_ra = np.max( [np.diff(d)
                                    for d in itertools.combinations(phase_ra, 2)])
             max_diff_dec = np.max([np.diff(d)

--- a/hera_pspec/pspecdata.py
+++ b/hera_pspec/pspecdata.py
@@ -3092,6 +3092,7 @@ class PSpecData(object):
         pols = _pols
 
         # initialize empty lists
+        # We should really pre-allocate arrays instead.
         data_array = odict()
         wgt_array = odict()
         integration_array = odict()
@@ -3449,6 +3450,7 @@ class PSpecData(object):
         # is equal to Ntpairs or 2 x Ntpairs if we interleave
         # but we have given upspec the capability to have this
         # not necessarily be the same.
+        # Ntimes could still be the number of "average times" which might be useful for noise purposes. 
         uvp.Ntimes = len(np.unique(np.hstack([uvp.time_1_array, uvp.time_2_array])))
         uvp.Npairs = len(set([(t1, t2) for t1, t2 in zip(uvp.time_1_array, uvp.time_2_array)]))
         uvp.Nbltpairs = len(set([(blp, t1, t2) for blp, t1, t2 in zip(uvp.blpair_array, uvp.time_1_array, uvp.time_2_array)]))

--- a/hera_pspec/testing.py
+++ b/hera_pspec/testing.py
@@ -61,6 +61,8 @@ def build_vanilla_uvpspec(beam=None):
     time_array = np.repeat(time_array, Nblpairs)
     time_1_array = time_array
     time_2_array = time_array
+    Ntpairs = len(set([(t1, t2) for t1, t2 in zip(time_1_array, time_2_array)]))
+    Nbltpairs = len(set([(blp, t1, t2) for blp, t1, t2 in zip(blpair_array, time_1_array, time_2_array)]))
     lst_array = np.repeat(lst_array, Nblpairs)
     lst_1_array = lst_array
     lst_2_array = lst_array
@@ -153,7 +155,8 @@ def build_vanilla_uvpspec(beam=None):
         "Nspwfreqs",
         "Nspws",
         "Nblpairs",
-        "Nblpairts",
+        "Nbltpairs",
+        "Ntpairs",
         "Npols",
         "Ndlys",
         "Nbls",

--- a/hera_pspec/tests/test_grouping.py
+++ b/hera_pspec/tests/test_grouping.py
@@ -130,7 +130,7 @@ class Test_grouping(unittest.TestCase):
             uvp.set_stats("noise", key, error)
 
         # Add the simple error bar (all are set to be one) to stat_array
-        errs = np.ones((uvp.Ntimes, uvp.Ndlys))
+        errs = np.ones((uvp.Ntpairs, uvp.Ndlys))
         for key in keys:
             uvp.set_stats("simple", key, errs)
         blpair_groups = [blpairs]
@@ -158,7 +158,7 @@ class Test_grouping(unittest.TestCase):
         # is 1/sqrt{N} times the error bar on one single sample.
         averaged_stat = uvp_avg_simple_wgts.stats_array["simple"][0][0, 0, 0]
         initial_stat = uvp.stats_array["simple"][0][0, 0, 0] \
-                     / np.sqrt(uvp.Ntimes) / np.sqrt(len(blpairs))
+                     / np.sqrt(uvp.Ntpairs) / np.sqrt(len(blpairs))
         assert np.all(np.isclose(initial_stat, averaged_stat))
 
         # For non-uniform weights, we test the error bar on the average power
@@ -173,7 +173,7 @@ class Test_grouping(unittest.TestCase):
         # it matches initial over sqrt(Nblpairs - 1)
         uvp_inf_var = copy.deepcopy(uvp)
         initial_stat = uvp.get_stats('simple', (0, blpairs[0], 'xx'))
-        inf_var_stat = np.ones((uvp_inf_var.Ntimes, uvp_inf_var.Ndlys)) * np.inf
+        inf_var_stat = np.ones((uvp_inf_var.Ntpairs, uvp_inf_var.Ndlys)) * np.inf
         uvp_inf_var.set_stats('simple', (0, blpairs[1], 'xx'), inf_var_stat)
         uvp_inf_var_avg = uvp_inf_var.average_spectra(blpair_groups=blpair_groups,
                                                       error_weights='simple',
@@ -185,7 +185,7 @@ class Test_grouping(unittest.TestCase):
         # and check that averaged stat for that time is inf (not zero)
         uvp_inf_var = copy.deepcopy(uvp)
         initial_stat = uvp.get_stats('simple', (0, blpairs[0], 'xx'))
-        inf_var_stat = np.ones((uvp_inf_var.Ntimes, uvp_inf_var.Ndlys))
+        inf_var_stat = np.ones((uvp_inf_var.Ntpairs, uvp_inf_var.Ndlys))
         inf_var_stat[0] = np.inf
         for blp in blpairs:
             uvp_inf_var.set_stats('simple', (0, blp, 'xx'), inf_var_stat)
@@ -220,8 +220,8 @@ class Test_grouping(unittest.TestCase):
                                                 normalize_weights=True,
                                                 inplace=False,
                                                 add_to_history='')
-        assert uvp_time_avg.Nblpairts == uvp_time_avg.Nblpairs
-        assert uvp_time_avg.window_function_array[0].shape[0] == uvp_time_avg.Nblpairts
+        assert uvp_time_avg.Nbltpairs == uvp_time_avg.Nblpairs
+        assert uvp_time_avg.window_function_array[0].shape[0] == uvp_time_avg.Nbltpairs
         blpair_groups, blpair_lens, _ = uvp.get_red_blpairs()
 
         # redundant average
@@ -234,7 +234,7 @@ class Test_grouping(unittest.TestCase):
                                                 normalize_weights=True,
                                                 inplace=False,
                                                 add_to_history='')
-        assert uvp_red_avg.Nblpairts == uvp_red_avg.Ntimes
+        assert uvp_red_avg.Nbltpairs == uvp_red_avg.Ntpairs
 
         # both + error_weights
         keys = uvp.get_all_keys()
@@ -292,8 +292,8 @@ class Test_grouping(unittest.TestCase):
                                                         blpair_groups,
                                                         time_avg=True)
         assert uvp1[0].Nblpairs == 1
-        assert uvp1[0].Ntimes == self.uvp.Ntimes
-        assert uvp2[0].Ntimes == 1
+        assert uvp1[0].Ntpairs == self.uvp.Ntpairs
+        assert uvp2[0].Ntpairs == 1
 
         # Total of weights assigned should equal total no. of blpairs
         assert np.sum(wgts) == np.array(blpair_groups).size
@@ -308,7 +308,7 @@ class Test_grouping(unittest.TestCase):
         _blpairs = list(np.unique(self.uvp.blpair_array)[:3])
         uvp3 = self.uvp.select(spws=0, inplace=False, blpairs=_blpairs)
 
-        Nt = uvp3.Ntimes
+        Nt = uvp3.Ntpairs
         uvp3.data_array[0][Nt:2*Nt] = uvp3.data_array[0][:Nt]
         uvp3.data_array[0][2*Nt:] = uvp3.data_array[0][:Nt]
         uvp3.integration_array[0][Nt:2*Nt] = uvp3.integration_array[0][:Nt]
@@ -438,7 +438,7 @@ def test_bootstrap_run():
 
     # assert average only has one time and 3 blpairs
     uvp_avg = psc.get_pspec("grp1", "uvp_avg")
-    assert uvp_avg.Ntimes == 1
+    assert uvp_avg.Ntpairs == 1
     assert uvp_avg.Nblpairs == 3
 
     # check avg file history
@@ -507,11 +507,11 @@ def test_spherical_average():
 
     # insert cov_array and stats_array
     uvp.cov_model = 'empirical'
-    uvp.cov_array_real = {s: np.repeat(np.repeat(np.eye(uvp.Ndlys, dtype=np.float64)[None, : , :, None], uvp.Nblpairts, 0), uvp.Npols, -1)
+    uvp.cov_array_real = {s: np.repeat(np.repeat(np.eye(uvp.Ndlys, dtype=np.float64)[None, : , :, None], uvp.Nbltpairs, 0), uvp.Npols, -1)
                         for s in range(uvp.Nspws)}
-    uvp.cov_array_imag = {s: np.repeat(np.repeat(np.eye(uvp.Ndlys, dtype=np.float64)[None, : , :, None], uvp.Nblpairts, 0), uvp.Npols, -1)
+    uvp.cov_array_imag = {s: np.repeat(np.repeat(np.eye(uvp.Ndlys, dtype=np.float64)[None, : , :, None], uvp.Nbltpairs, 0), uvp.Npols, -1)
                         for s in range(uvp.Nspws)}
-    uvp.stats_array = {'err': {s: np.ones((uvp.Nblpairts, uvp.Ndlys, uvp.Npols), dtype=np.complex128)
+    uvp.stats_array = {'err': {s: np.ones((uvp.Nbltpairs, uvp.Ndlys, uvp.Npols), dtype=np.complex128)
                                   for s in range(uvp.Nspws)}}
 
     # try a spherical average
@@ -539,8 +539,8 @@ def test_spherical_average():
         assert np.isclose(np.sqrt(sph.cov_array_real[spw])[:, range(Nk), range(Nk)], 1/np.sqrt(A[spw].sum(axis=1))).all()
         assert np.isclose(sph.stats_array['err'][spw], 1/np.sqrt(A[spw].sum(axis=1))).all()
 
-    # bug check: time_avg_array was not down-selected to new Nblpairts
-    assert sph.time_avg_array.size == sph.Nblpairts
+    # bug check: time_avg_array was not down-selected to new Nbltpairs
+    assert sph.time_avg_array.size == sph.Nbltpairs
 
     # bug check: cov_array_imag was not updated
     assert sph.cov_array_real[0].shape == sph.cov_array_imag[0].shape
@@ -552,7 +552,7 @@ def test_spherical_average():
 
     # try time average
     sph = grouping.spherical_average(uvp, kbins, bin_widths, time_avg=True)
-    assert sph.Ntimes == 1
+    assert sph.Ntpairs == 1
 
     # try weighting by stats_array
     sph = grouping.spherical_average(uvp, kbins, bin_widths, error_weights='err')

--- a/hera_pspec/tests/test_noise.py
+++ b/hera_pspec/tests/test_noise.py
@@ -178,7 +178,7 @@ def test_analytic_noise():
     frac_ratio = (uvp.stats_array["P_SN"][0] - uvp.stats_array["P_N"][0]) / uvp.stats_array["P_N"][0]
     dlys = uvp.get_dlys(0) * 1e9
     select = np.abs(dlys) > 3000
-    assert np.abs(frac_ratio[:, select].mean()) < 1 / np.sqrt(uvp.Nblpairts)
+    assert np.abs(frac_ratio[:, select].mean()) < 1 / np.sqrt(uvp.Nbltpairs)
 
     # test single time
     uvp.select(times=uvp.time_avg_array[:1], inplace=True)
@@ -187,7 +187,7 @@ def test_analytic_noise():
     frac_ratio = (uvp.stats_array["P_SN"][0] - uvp.stats_array["P_N"][0]) / uvp.stats_array["P_N"][0]
     dlys = uvp.get_dlys(0) * 1e9
     select = np.abs(dlys) > 3000
-    assert np.abs(frac_ratio[:, select].mean()) < 1 / np.sqrt(uvp.Nblpairts)
+    assert np.abs(frac_ratio[:, select].mean()) < 1 / np.sqrt(uvp.Nbltpairs)
 
     # clean up
     os.remove(os.path.join(DATA_PATH, "test_uvd.uvh5"))

--- a/hera_pspec/tests/test_plot.py
+++ b/hera_pspec/tests/test_plot.py
@@ -215,7 +215,9 @@ class Test_Plot(unittest.TestCase):
         for i in range(3):
             # build-up a large uvpspec object
             _uvp = copy.deepcopy(uvp)
-            _uvp.time_avg_array += (i+1)**2
+            _uvp.time_avg_array += 0 # don't change avg time to make sure this is ok.
+            _uvp.time_1_array += (i+1)**2 
+            _uvp.time_2_array += (i+1)**2
             uvp = uvp + _uvp
         pytest.raises(ValueError, plot.delay_spectrum, uvp, uvp.get_blpairs(), 0, 'xx')
 

--- a/hera_pspec/tests/test_plot.py
+++ b/hera_pspec/tests/test_plot.py
@@ -108,7 +108,7 @@ class Test_Plot(unittest.TestCase):
         # Average over baseline-pairs but keep the time bins intact
         f2 = plot.delay_spectrum(self.uvp, [blps,], spw=0, pol=('xx','xx'),
                                   average_blpairs=True, average_times=False)
-        elements = [(matplotlib.lines.Line2D, self.uvp.Ntimes),]
+        elements = [(matplotlib.lines.Line2D, self.uvp.Ntpairs),]
         assert axes_contains(f2.axes[0], elements)
         plt.close(f2)
 

--- a/hera_pspec/tests/test_uvpspec.py
+++ b/hera_pspec/tests/test_uvpspec.py
@@ -1028,5 +1028,13 @@ def test_backwards_compatibility_read():
     # test read in of a static test file dated 8/2019
     uvp = uvpspec.UVPSpec()
     uvp.read_hdf5(os.path.join(DATA_PATH, 'test_uvp.h5'))
+    for dattr in uvp._meta_deprecated:
+        with pytest.raises(AttributeError) as excinfo:
+            raise AttributeError("'UVPSpec' object has no attribute")
+        assert "'UVPSpec' object has no attribute" in str(excinfo.value)
+    for dattr in uvp._meta_dsets_deprecated:
+        with pytest.raises(AttributeError) as excinfo:
+            raise AttributeError("'UVPSpec' object has no attribute")
+        assert "'UVPSpec' object has no attribute" in str(excinfo.value)
     # assert check does not fail
     uvp.check()

--- a/hera_pspec/tests/test_uvpspec.py
+++ b/hera_pspec/tests/test_uvpspec.py
@@ -53,9 +53,9 @@ class Test_UVPSpec(unittest.TestCase):
         uvp.stats_array = odict({stat: odict()})
         for spw in uvp.spw_array:
             ndlys = uvp.get_spw_ranges(spw)[0][-1]
-            uvp.cov_array_real[spw] = np.empty((uvp.Nblpairts, ndlys, ndlys, uvp.Npols), np.float64)
-            uvp.cov_array_imag[spw] = np.empty((uvp.Nblpairts, ndlys, ndlys, uvp.Npols), np.float64)
-            uvp.stats_array[stat][spw] = np.empty((uvp.Nblpairts, ndlys, uvp.Npols), np.complex128)
+            uvp.cov_array_real[spw] = np.empty((uvp.Nbltpairs, ndlys, ndlys, uvp.Npols), np.float64)
+            uvp.cov_array_imag[spw] = np.empty((uvp.Nbltpairs, ndlys, ndlys, uvp.Npols), np.float64)
+            uvp.stats_array[stat][spw] = np.empty((uvp.Nbltpairs, ndlys, uvp.Npols), np.complex128)
         return uvp
 
     def test_param(self):
@@ -591,7 +591,7 @@ class Test_UVPSpec(unittest.TestCase):
         uvp.get_exact_window_functions(ftbeam=self.ft_file,
                                        inplace=True)
         assert uvp.exact_windows
-        assert uvp.window_function_array[0].shape[0] == uvp.Nblpairts
+        assert uvp.window_function_array[0].shape[0] == uvp.Nbltpairs
         # if not exact window function, array dim is 4
         assert uvp.window_function_array[0].ndim == 5
 

--- a/hera_pspec/tests/test_uvpspec_utils.py
+++ b/hera_pspec/tests/test_uvpspec_utils.py
@@ -237,7 +237,7 @@ def test_conj_blpair():
     pytest.raises(ValueError, uvputils._conj_blpair, 102101103104, which='foo')
 
 
-def test_fast_is_in():
+def test_is_in():
     blps = [ 102101103104, 102101103104, 102101103104, 102101103104,
              101102104103, 101102104103, 101102104103, 101102104103,
              102101104103, 102101104103, 102101104103, 102101104103 ]
@@ -246,7 +246,7 @@ def test_fast_is_in():
               0.1, 0.15, 0.3, 0.3, ]
     src_blpts = np.array(list(zip(blps, times)))
 
-    assert uvputils._fast_is_in(src_blpts, [(101102104103, 0.2)])[0]
+    assert uvputils._is_in(src_blpts, [(101102104103, 0.2)])[0]
 
 
 def test_fast_lookup_blpairts():

--- a/hera_pspec/utils.py
+++ b/hera_pspec/utils.py
@@ -1415,8 +1415,11 @@ def uvp_noise_error(uvp, auto_Tsys=None, auto_Tsys_int=None, err_type='P_N', pre
             times_blp_1 = auto_Tsys.time_array[auto_Tsys.antpair2ind(blp[0][0], blp[0][0])]
             times_blp_2 = auto_Tsys.time_array[auto_Tsys.antpair2ind(blp[1][0], blp[1][0])]
 
-            tinds1 = [np.where(np.isclose(times_blp_1, t, atol=1e-6)[0][0] for t in time_1_selection)]
-            tinds2 = [np.where(np.isclose(times_blp_2, t, atol=1e-6)[0][0] for t in time_2_selection)]
+            # This time matching is at roughly 1 second tolerance.
+            # Interleaves with < 1 second cadence could run into trouble.
+            # I don't anticipate this being a problem with HERA's 10 second interleave time.
+            tinds1 = [np.where(np.isclose(times_blp_1, t, atol=1e-5, rtol=0))[0][0] for t in time_1_selection]
+            tinds2 = [np.where(np.isclose(times_blp_2, t, atol=1e-5, rtol=0))[0][0] for t in time_2_selection]
             
             # iterate over polarization
             for polpair in uvp.polpair_array:
@@ -1437,6 +1440,7 @@ def uvp_noise_error(uvp, auto_Tsys=None, auto_Tsys_int=None, err_type='P_N', pre
                             auto_Tsys.get_flags(blp[0][1], blp[0][1], pol)[tinds1, spw_start:spw_stop] + \
                             auto_Tsys.get_flags(blp[1][0], blp[1][0], pol)[tinds2, spw_start:spw_stop] + \
                             auto_Tsys.get_flags(blp[1][1], blp[1][1], pol)[tinds2, spw_start:spw_stop]
+                    
                     # average over frequency
                     if np.all(Tflag):
                         # fully flagged
@@ -1451,6 +1455,7 @@ def uvp_noise_error(uvp, auto_Tsys=None, auto_Tsys_int=None, err_type='P_N', pre
                         else:
                             Tsys = Tsys[0]
 
+                            
                     # calculate P_N
                     P_N = uvp.generate_noise_spectra(spw, polpair, Tsys, blpairs=[blp], form='Pk', component='real', scalar=scalar[(spw, polpair)])[blp_int]
 

--- a/hera_pspec/utils.py
+++ b/hera_pspec/utils.py
@@ -1333,7 +1333,7 @@ def uvd_to_Tsys(uvd, beam, Tsys_outfile=None):
 
     return uvd
 
-def uvp_noise_error(uvp, auto_Tsys=None, auto_Tsys_int=None, err_type='P_N', precomp_P_N=None, P_SN_correction=True,  num_steps_scalar=2000, little_h=True):
+def uvp_noise_error(uvp, auto_Tsys=None, err_type='P_N', precomp_P_N=None, P_SN_correction=True,  num_steps_scalar=2000, little_h=True):
     """
     Calculate analytic thermal noise error for a UVPSpec object.
     Adds to uvp.stats_array inplace.
@@ -1349,7 +1349,7 @@ def uvp_noise_error(uvp, auto_Tsys=None, auto_Tsys_int=None, err_type='P_N', pre
         Holds autocorrelation Tsys estimates in Kelvin (see uvd_to_Tsys)
         for all antennas and polarizations involved in uvp power spectra.
         Needed for P_N computation, not needed if feeding precomp_P_N.
-        If power spectra were computed from interleaved times then the supplied auto_Tsys should include all of the times that are pesent in all of the pairs.
+        If power spectra were computed from interleaved times then the supplied auto_Tsys should include all of the times that are present in all of the pairs.
 
 
     err_type : str or list of str, options = ['P_N', 'P_SN']

--- a/hera_pspec/utils.py
+++ b/hera_pspec/utils.py
@@ -1455,7 +1455,6 @@ def uvp_noise_error(uvp, auto_Tsys=None, err_type='P_N', precomp_P_N=None, P_SN_
                         else:
                             Tsys = Tsys[0]
 
-                            
                     # calculate P_N
                     P_N = uvp.generate_noise_spectra(spw, polpair, Tsys, blpairs=[blp], form='Pk', component='real', scalar=scalar[(spw, polpair)])[blp_int]
 

--- a/hera_pspec/uvpspec.py
+++ b/hera_pspec/uvpspec.py
@@ -1409,13 +1409,11 @@ class UVPSpec(object):
         # Clear deprecated attributes.
         for dattr in self._meta_deprecated:
             if hasattr(self, dattr):
-                to_delete = getattr(self, dattr)
-                del to_delete
+                delattr(self, dattr)
 
         for dattr in self._meta_dsets_deprecated:
             if hasattr(self, dattr):
-                to_delete = getattr(self, dattr)
-                del to_delete     
+                delattr(self, dattr)
             
         self.check(just_meta=just_meta)
 

--- a/hera_pspec/uvpspec.py
+++ b/hera_pspec/uvpspec.py
@@ -23,8 +23,9 @@ class UVPSpec(object):
         """
         # Summary attributes
         self._Ntimes = PSpecParam("Ntimes", description="Number of unique times.", expected_type=int)
-        self._Nblpairts = PSpecParam("Nblpairts", description="Total number of baseline-pair times.", expected_type=int)
-        self._Nblpairs = PSpecParam("Nblpairs", description='Total number of baseline-pairs.', expected_type=int)
+        self._Ntpairs = PSpecParam("Ntpairs", description="Number of unique time-pairs.", expected_type=int)
+        self._Nbltpairs = PSpecParam("Nbltpairs", description="Total number of baseline-time-pairs.", expected_type=int)
+        self._Nblpairs = PSpecParam("Nblpairs", description="Total number of baseline-pairs.", expected_type=int)
         self._Nspwdlys = PSpecParam("Nspwdlys", description="Total number of delay bins across all spectral windows.", expected_type=int)
         self._Nspwfreqs = PSpecParam("Nspwfreqs", description="Total number of frequency bins across all spectral windows.", expected_type=int)
         self._Nspws = PSpecParam("Nspws", description="Number of unique spectral windows.", expected_type=int)
@@ -42,28 +43,28 @@ class UVPSpec(object):
         desc = "A boolean indicating if the window functions stored in window_function_array are exact or not."
         self._exact_windows = PSpecParam("exact_windows", description=desc, expected_type=bool)
         desc = "Power spectrum data dictionary with spw integer as keys and values as complex ndarrays."
-        self._data_array = PSpecParam("data_array", description=desc, expected_type=np.complex128, form="(Nblpairts, spw_Ndlys, Npols)")
+        self._data_array = PSpecParam("data_array", description=desc, expected_type=np.complex128, form="(Nbltpairs, spw_Ndlys, Npols)")
         desc = "Power spectrum covariance dictionary with spw integer as keys and values as float ndarrays, stored separately for real and imaginary parts."
-        self._cov_array_real = PSpecParam("cov_array_real", description=desc, expected_type=np.float64, form="(Nblpairts, spw_Ndlys, spw_Ndlys, Npols)")
-        self._cov_array_imag = PSpecParam("cov_array_imag", description=desc, expected_type=np.float64, form="(Nblpairts, spw_Ndlys, spw_Ndlys, Npols)")
+        self._cov_array_real = PSpecParam("cov_array_real", description=desc, expected_type=np.float64, form="(Nbltpairs, spw_Ndlys, spw_Ndlys, Npols)")
+        self._cov_array_imag = PSpecParam("cov_array_imag", description=desc, expected_type=np.float64, form="(Nbltpairs, spw_Ndlys, spw_Ndlys, Npols)")
         desc = "Window function dictionary of bandpowers."
-        self._window_function_array = PSpecParam("window_function_array", description=desc, expected_type=np.float64, form="(Nblpairts, spw_Ndlys, spw_Ndlys, Npols)")
+        self._window_function_array = PSpecParam("window_function_array", description=desc, expected_type=np.float64, form="(Nbltpairs, spw_Ndlys, spw_Ndlys, Npols)")
         desc = "Dictionary of bandpowers given the kperp grid used to compute the window functions."
-        self._window_function_kperp = PSpecParam("window_function_kperp", description=desc, expected_type=np.float64, form="(Nblpairts, spw_Ndlys, spw_Ndlys, Npols)")
+        self._window_function_kperp = PSpecParam("window_function_kperp", description=desc, expected_type=np.float64, form="(Nbltpairs, spw_Ndlys, spw_Ndlys, Npols)")
         desc = "Dictionary of bandpowers given the kparallel grid used to compute the window functions."
-        self._window_function_kpara = PSpecParam("window_function_kpara", description=desc, expected_type=np.float64, form="(Nblpairts, spw_Ndlys, spw_Ndlys, Npols)")
+        self._window_function_kpara = PSpecParam("window_function_kpara", description=desc, expected_type=np.float64, form="(Nbltpairs, spw_Ndlys, spw_Ndlys, Npols)")
         desc = "Weight dictionary for original two datasets. The second axis holds [dset1_wgts, dset2_wgts] in that order."
-        self._wgt_array = PSpecParam("wgt_array", description=desc, expected_type=np.float64, form="(Nblpairts, spw_Nfreqs, 2, Npols)")
+        self._wgt_array = PSpecParam("wgt_array", description=desc, expected_type=np.float64, form="(Nbltpairs, spw_Nfreqs, 2, Npols)")
         desc = "Integration time dictionary. This holds the average integration time [seconds] of each delay spectrum in the data. " \
                "This is not necessarily equal to the integration time of the visibility data: If data have been coherently averaged " \
                "(i.e. averaged before squaring), than this is the sum of each spectrum's integration time."
-        self._integration_array = PSpecParam("integration_array", description=desc, expected_type=np.float64, form="(Nblpairts, Npols)")
+        self._integration_array = PSpecParam("integration_array", description=desc, expected_type=np.float64, form="(Nbltpairs, Npols)")
         desc = "Nsample dictionary, if the pspectra have been incoherently averaged (i.e. averaged after squaring), this is " \
                "the effective number of samples in that average (float type). This is not the same as the pyuvdata.UVData nsample_array."
-        self._nsample_array = PSpecParam("nsample_array", description=desc, expected_type=np.float64, form="(Nblpairts, Npols)")
+        self._nsample_array = PSpecParam("nsample_array", description=desc, expected_type=np.float64, form="(Nbltpairs, Npols)")
         desc = ("Power spectrum stats array with stats type and spw integer as keys and values as complex ndarrays with same shape"
                 " as data_array")
-        self._stats_array = PSpecParam("stats_array", description=desc, expected_type=np.complex128, form="(Nblpairts, Ndlys, Npols)")
+        self._stats_array = PSpecParam("stats_array", description=desc, expected_type=np.complex128, form="(Nbltpairs, Ndlys, Npols)")
         self._spw_array = PSpecParam("spw_array", description="Integer array holding unique spectral windows.", form="(Nspws,)", expected_type=np.uint16)
         self._spw_dly_array = PSpecParam("spw_dly_array", description="Spw integer array for the dly_array.", form="(Nspwdlys,)", expected_type=np.uint16)
         self._spw_freq_array = PSpecParam("spw_freq_array", description="Spw integer array for the freq_array.", form="(Nspwfreqs,)", expected_type=np.uint16)
@@ -71,13 +72,13 @@ class UVPSpec(object):
         self._dly_array = PSpecParam("dly_array", description="Delay array in seconds.", form="(Nspwdlys,)", expected_type=np.float64)
         desc = "Polarization pair integer, made up of two polarization integers concatenated in a standardized way."
         self._polpair_array = PSpecParam("polpair_array", description=desc, form="(Npols,)", expected_type=np.int32)
-        self._lst_1_array = PSpecParam("lst_1_array", description="LST array of the first bl in the bl-pair [radians].", form="(Nblpairts,)", expected_type=np.float64)
-        self._lst_2_array = PSpecParam("lst_2_array", description="LST array of the second bl in the bl-pair [radians].", form="(Nblpairts,)", expected_type=np.float64)
-        self._lst_avg_array = PSpecParam("lst_avg_array", description="Average of the lst_1_array and lst_2_array [radians].", form="(Nblpairts,)", expected_type=np.float64)
-        self._time_1_array = PSpecParam("time_1_array", description="Time array of the first bl in the bl-pair [Julian Date].", form="(Nblpairts,)", expected_type=np.float64)
-        self._time_1_array = PSpecParam("time_2_array", description="Time array of the second bl in the bl-pair [Julian Date].", form="(Nblpairts,)", expected_type=np.float64)
-        self._time_avg_array = PSpecParam("time_avg_array", description="Average of the time_1_array and time_2_array [Julian Date].", form='(Nblpairts,)', expected_type=np.float64)
-        self._blpair_array = PSpecParam("blpair_array", description="Baseline-pair integer for all baseline-pair times.", form="(Nblpairts,)", expected_type=np.int64)
+        self._lst_1_array = PSpecParam("lst_1_array", description="LST array of the first bl in the bl-pair [radians].", form="(Nbltpairs,)", expected_type=np.float64)
+        self._lst_2_array = PSpecParam("lst_2_array", description="LST array of the second bl in the bl-pair [radians].", form="(Nbltpairs,)", expected_type=np.float64)
+        self._lst_avg_array = PSpecParam("lst_avg_array", description="Average of the lst_1_array and lst_2_array [radians].", form="(Nbltpairs,)", expected_type=np.float64)
+        self._time_1_array = PSpecParam("time_1_array", description="Time array of the first bl in the bl-pair [Julian Date].", form="(Nbltpairs,)", expected_type=np.float64)
+        self._time_1_array = PSpecParam("time_2_array", description="Time array of the second bl in the bl-pair [Julian Date].", form="(Nbltpairs,)", expected_type=np.float64)
+        self._time_avg_array = PSpecParam("time_avg_array", description="Average of the time_1_array and time_2_array [Julian Date].", form='(Nbltpairs,)', expected_type=np.float64)
+        self._blpair_array = PSpecParam("blpair_array", description="Baseline-pair integer for all baseline-pair times.", form="(Nbltpairs,)", expected_type=np.int64)
         self._scalar_array = PSpecParam("scalar_array", description="Power spectrum normalization scalar from pspecbeam module.", expected_type=np.float64, form="(Nspws, Npols)")
 
         # Baseline attributes
@@ -95,8 +96,8 @@ class UVPSpec(object):
         self._vis_units = PSpecParam("vis_units", description="Units of the original visibility data used to form the power spectra.", expected_type=str)
         self._norm_units = PSpecParam("norm_units", description="Power spectra normalization units, i.e. telescope units [Hz str] or cosmological [(h^-3) Mpc^3].", expected_type=str)
         self._labels = PSpecParam("labels", description="Array of dataset string labels.", expected_type=str)
-        self._label_1_array = PSpecParam("label_1_array", description="Integer array w/ shape of data that indexes labels and gives label of dset1.", form="(Nspws, Nblpairts, Npols)", expected_type=np.int32)
-        self._label_2_array = PSpecParam("label_2_array", description="Integer array w/ shape of data that indexes labels and gives label of dset2.", form="(Nspws, Nblpairts, Npols)", expected_type=np.int32)
+        self._label_1_array = PSpecParam("label_1_array", description="Integer array w/ shape of data that indexes labels and gives label of dset1.", form="(Nspws, Nbltpairs, Npols)", expected_type=np.int32)
+        self._label_2_array = PSpecParam("label_2_array", description="Integer array w/ shape of data that indexes labels and gives label of dset2.", form="(Nspws, Nbltpairs, Npols)", expected_type=np.int32)
         self._folded = PSpecParam("folded", description="if power spectra are folded (i.e. averaged) onto purely positive delay axis. Default is False", expected_type=bool)
         self._beamfile = PSpecParam("beamfile", description="filename of beam-model used to normalized pspectra.", expected_type=str)
         self._OmegaP = PSpecParam("OmegaP", description="Integral of unitless beam power over the sky [steradians].", form="(Nbeam_freqs, Npols)", expected_type=np.float64)
@@ -110,7 +111,7 @@ class UVPSpec(object):
 
         # Specify required params: these are required for read / write and
         # self.check()
-        self._req_params = ["Ntimes", "Nblpairts", "Nblpairs",
+        self._req_params = ["Ntimes", "Ntpairs", "Nbltpairs", "Nblpairs",
                             "Nspws", "Ndlys", "Npols", "Nfreqs", "history",
                             "Nspwdlys", "Nspwfreqs", "r_params",
                             "data_array", "wgt_array", "integration_array",
@@ -128,7 +129,7 @@ class UVPSpec(object):
 
         # All parameters must fall into one and only one of the following
         # groups, which are used in __eq__
-        self._immutables = ["Ntimes", "Nblpairts", "Nblpairs", "Nspwdlys",
+        self._immutables = ["Ntimes", "Ntpairs", "Nbltpairs", "Nblpairs", "Nspwdlys",
                             "Nspwfreqs", "Nspws", "Ndlys", "Npols", "Nfreqs",
                             "history", "r_params", "cov_model",
                             "Nbls", "channel_width", "weighting", "vis_units",
@@ -447,7 +448,7 @@ class UVPSpec(object):
         Returns
         -------
         blp_avg_sep : float ndarray
-            shape=(Nblpairts,)
+            shape=(Nbltpairs,)
         """
         # get list of bl separations
         bl_vecs = self.get_ENU_bl_vecs()
@@ -456,7 +457,7 @@ class UVPSpec(object):
                            for bl in self.bl_array])
 
         # construct empty blp_avg_sep array
-        blp_avg_sep = np.empty(self.Nblpairts, float)
+        blp_avg_sep = np.empty(self.Nbltpairs, float)
 
         # construct blpair_bls
         blpairs = _ordered_unique(self.blpair_array)
@@ -787,7 +788,7 @@ class UVPSpec(object):
             k_perp = uvp.get_kperps(spw, little_h=little_h)
             k_para = uvp.get_kparas(spw, little_h=little_h)
             k_mag = np.sqrt(k_perp[:, None, None]**2 + k_para[None, :, None]**2)
-            # shape of (Nblpairts, spw_Ndlys, Npols)
+            # shape of (Nbltpairs, spw_Ndlys, Npols)
             coeff = k_mag**3 / (2 * np.pi**2)
 
             # multiply into data
@@ -907,7 +908,7 @@ class UVPSpec(object):
         # assert exists in data
         assert np.array([b in self.blpair_array for b in blpair]).all(), \
             "blpairs {} not all found in data".format(blpair)
-        return np.arange(self.Nblpairts)[
+        return np.arange(self.Nbltpairs)[
                 np.logical_or.reduce([self.blpair_array == b for b in blpair])]
 
 
@@ -1092,15 +1093,15 @@ class UVPSpec(object):
         """
         time_select = np.isclose(self.time_avg_array, time, rtol=1e-10)
         if blpairs is None:
-            return np.arange(self.Nblpairts)[time_select]
+            return np.arange(self.Nbltpairs)[time_select]
         else:
-            blp_select = np.zeros(self.Nblpairts, bool)
+            blp_select = np.zeros(self.Nbltpairs, bool)
             if isinstance(blpairs, (tuple, int, np.integer)):
                 blpairs = [blpairs]
             for blp in blpairs:
                 blp_select[self.blpair_to_indices(blp)] = True
             time_select *= blp_select
-            return np.arange(self.Nblpairts)[time_select]
+            return np.arange(self.Nbltpairs)[time_select]
 
     def key_to_indices(self, key, omit_flags=False):
         """
@@ -1724,7 +1725,7 @@ class UVPSpec(object):
                 # lengths given as input
                 kperp_bins = uvw.get_kperp_bins(blpair_lens)
                 kpara_bins = uvw.get_kpara_bins(uvw.freq_array)
-                pol_window_function = np.zeros((self.Nblpairts, self.get_dlys(spw).size, kperp_bins.size, kpara_bins.size))
+                pol_window_function = np.zeros((self.Nbltpairs, self.get_dlys(spw).size, kperp_bins.size, kpara_bins.size))
                 # Iterate over baseline-pair groups
                 for j, blpg in enumerate(blpair_groups):
                     if verbose: 
@@ -2040,8 +2041,8 @@ class UVPSpec(object):
             # get indices
             inds = self.blpair_to_indices(blp)
             assert isinstance(Tsys[blp], (float, int)) \
-                or Tsys[blp].shape[0] == self.Ntimes, \
-                "Tsys must be a float or an ndarray with shape[0] == Ntimes"
+                or Tsys[blp].shape[0] == self.Ntpairs, \
+                "Tsys must be a float or an ndarray with shape[0] == Ntpairs"
             P_blp = []
 
             # iterate over time axis
@@ -2152,7 +2153,7 @@ class UVPSpec(object):
         Notes
         -----
         Currently, every baseline-pair in a blpair group must have the same
-        Ntimes, unless time_avg=True. Future versions may support
+        Ntpairs, unless time_avg=True. Future versions may support
         baseline-pair averaging of heterogeneous time arrays. This includes
         the scenario of repeated blpairs (e.g. in bootstrapping), which will
         return multiple copies of their time_array.
@@ -2318,7 +2319,7 @@ def combine_uvpspec(uvps, merge_history=True, verbose=True):
     new_blpts = sorted(new_blpts)
     new_polpairs = [new_polpairs[i] for i in np.argsort(np.abs(new_polpairs))]
     Nspws = len(new_spws)
-    Nblpairts = len(new_blpts)
+    Nbltpairs = len(new_blpts)
     Npols = len(new_polpairs)
 
     # Store optional attrs only if all uvps have them
@@ -2363,25 +2364,25 @@ def combine_uvpspec(uvps, merge_history=True, verbose=True):
     # Loop over new spectral windows and setup arrays
     for i, spw in enumerate(new_spws):
         # Initialize new arrays
-        u.data_array[i] = np.empty((Nblpairts, spw[3], Npols), np.complex128)
-        u.integration_array[i] = np.empty((Nblpairts, Npols), np.float64)
-        u.wgt_array[i] = np.empty((Nblpairts, spw[2], 2, Npols), np.float64)
+        u.data_array[i] = np.empty((Nbltpairs, spw[3], Npols), np.complex128)
+        u.integration_array[i] = np.empty((Nbltpairs, Npols), np.float64)
+        u.wgt_array[i] = np.empty((Nbltpairs, spw[2], 2, Npols), np.float64)
         # spw[2] == Nfreqs (wgt_array is not resampled if Ndlys != Nfreqs,
         # so needs to keep this shape)
-        u.nsample_array[i] = np.empty((Nblpairts, Npols), np.float64)
+        u.nsample_array[i] = np.empty((Nbltpairs, Npols), np.float64)
         if store_window:
             if exact_windows:
                 Nkperp = uvps[0].window_function_kperp[i][:, 0].size
                 Nkpara = uvps[0].window_function_kpara[i][:, 0].size
-                u.window_function_array[i] = np.empty((Nblpairts, spw[3], Nkperp, Nkpara, Npols), np.float64)
+                u.window_function_array[i] = np.empty((Nbltpairs, spw[3], Nkperp, Nkpara, Npols), np.float64)
             else:
-                u.window_function_array[i] = np.empty((Nblpairts, spw[3], spw[3], Npols), np.float64)
+                u.window_function_array[i] = np.empty((Nbltpairs, spw[3], spw[3], Npols), np.float64)
         if store_cov:
-            u.cov_array_real[i] = np.empty((Nblpairts, spw[3], spw[3], Npols), np.float64)
-            u.cov_array_imag[i] = np.empty((Nblpairts, spw[3], spw[3], Npols), np.float64)
+            u.cov_array_real[i] = np.empty((Nbltpairs, spw[3], spw[3], Npols), np.float64)
+            u.cov_array_imag[i] = np.empty((Nbltpairs, spw[3], spw[3], Npols), np.float64)
         if store_stats:
             for stat in stored_stats:
-                u.stats_array[stat][i] = np.empty((Nblpairts, spw[3], Npols), np.complex128)
+                u.stats_array[stat][i] = np.empty((Nbltpairs, spw[3], Npols), np.complex128)
 
     # Set frequencies and delays: if concat_ax == 'spw' this is changed below
     # assumes spw metadata are the same for all uvps
@@ -2400,24 +2401,24 @@ def combine_uvpspec(uvps, merge_history=True, verbose=True):
 
     # Number of spectral windows, delays etc.
     u.Nspws = Nspws
-    u.Nblpairts = Nblpairts
+    u.Nbltpairs = Nbltpairs
     u.Npols = Npols
 
     # Prepare time and label arrays
-    u.time_1_array, u.time_2_array = np.empty(Nblpairts, np.float64), \
-                                     np.empty(Nblpairts, np.float64)
-    u.time_avg_array, u.lst_avg_array = np.empty(Nblpairts, np.float64), \
-                                        np.empty(Nblpairts, np.float64)
-    u.lst_1_array, u.lst_2_array = np.empty(Nblpairts, np.float64), \
-                                   np.empty(Nblpairts, np.float64)
-    u.blpair_array = np.empty(Nblpairts, np.int64)
+    u.time_1_array, u.time_2_array = np.empty(Nbltpairs, np.float64), \
+                                     np.empty(Nbltpairs, np.float64)
+    u.time_avg_array, u.lst_avg_array = np.empty(Nbltpairs, np.float64), \
+                                        np.empty(Nbltpairs, np.float64)
+    u.lst_1_array, u.lst_2_array = np.empty(Nbltpairs, np.float64), \
+                                   np.empty(Nbltpairs, np.float64)
+    u.blpair_array = np.empty(Nbltpairs, np.int64)
     u.labels = sorted(set(np.concatenate([uvp.labels for uvp in uvps])))
-    u.label_1_array = np.empty((Nspws, Nblpairts, Npols), np.int32)
-    u.label_2_array = np.empty((Nspws, Nblpairts, Npols), np.int32)
+    u.label_1_array = np.empty((Nspws, Nbltpairs, Npols), np.int32)
+    u.label_2_array = np.empty((Nspws, Nbltpairs, Npols), np.int32)
 
     # get each uvp's data axes
     uvp_spws = [_uvp.get_spw_ranges() for _uvp in uvps]
-    uvp_blpts = [list(zip(_uvp.blpair_array, _uvp.time_avg_array))
+    uvp_blpts = [list(zip(_uvp.blpair_array, _uvp.time_1_array, _uvp.time_2_array))
                  for _uvp in uvps]
     uvp_polpairs = [_uvp.polpair_array.tolist() for _uvp in uvps]
 
@@ -2645,7 +2646,7 @@ def combine_uvpspec(uvps, merge_history=True, verbose=True):
         h = [bl == _bl for _bl in uvp_bls[l]].index(True)
         u.bl_vecs.append(uvps[l].bl_vecs[h])
     u.bl_vecs = np.array(u.bl_vecs)
-    u.Ntimes = len(np.unique(u.time_avg_array))
+    u.Ntimes = len(np.unique(np.hstack([u.time_1_array, u.time_2_array])))
     if merge_history:
         u.history = "".join([uvp.history for uvp in uvps])
     else:
@@ -2706,7 +2707,7 @@ def get_uvp_overlap(uvps, just_meta=True, verbose=True):
 
     unique_blpts : list
         List of unique baseline-pair-time tuples (blpair_integer,
-        time_avg_array JD float) across all input uvps
+        time_1_array JD float, time_2_array JD float) across all input uvps
 
     unique_polpairs : list
         List of unique polarization-pair integers across all input uvps
@@ -2758,12 +2759,12 @@ def get_uvp_overlap(uvps, just_meta=True, verbose=True):
         for p in uvp1.polpair_array:
             if p not in unique_polpairs: unique_polpairs.append(p)
 
-        uvp1_blpts = zip(uvp1.blpair_array, uvp1.time_1_array, uvp1.time_2_array)
-        uvp1_blpts_comb = [bl[0] + 1.j*bl[1] for bl in uvp1_blpts]
+        uvp1_blpts_comb = [(blp, t1, t2) for blp, t1, t2 in zip(uvp1.blpair_array, uvp1.time_1_array, uvp1.time_2_array)]
         blpts_comb.extend(uvp1_blpts_comb)
 
-    unique_blpts_comb = np.unique(blpts_comb)
-    unique_blpts = [(int(blt.real), blt.imag) for blt in unique_blpts_comb]
+    # Old way uwing np.unique and complex coding did not support
+    # two times.
+    unique_blpts = list(set(blpts_comb))
 
     # iterate over uvps
     for i, uvp1 in enumerate(uvps):

--- a/hera_pspec/uvpspec.py
+++ b/hera_pspec/uvpspec.py
@@ -1964,7 +1964,7 @@ class UVPSpec(object):
 
         Tsys : dictionary, float or array
             System temperature in Kelvin for each blpair. Key is blpair-integer,
-            value is Tsys float or ndarray. If fed as an ndarray, shape=(Ntimes,)
+            value is Tsys float or ndarray. If fed as an ndarray, shape=(Ntpairs,)
 
         blpairs : list
             List of unique blair tuples or i12 integers to calculate noise
@@ -2032,7 +2032,7 @@ class UVPSpec(object):
         # handle Tsys
         if not isinstance(Tsys, (dict, odict)):
             if not isinstance(Tsys, np.ndarray):
-                Tsys = np.ones(self.Ntimes) * Tsys
+                Tsys = np.ones(self.Ntpairs) * Tsys
             Tsys = dict([(blp, Tsys) for blp in blpairs])
 
         # Iterate over blpairs to get P_N
@@ -2320,6 +2320,7 @@ def combine_uvpspec(uvps, merge_history=True, verbose=True):
     new_polpairs = [new_polpairs[i] for i in np.argsort(np.abs(new_polpairs))]
     Nspws = len(new_spws)
     Nbltpairs = len(new_blpts)
+    Ntpairs = len(set([(t1, t2) for blp, t1, t2 in new_blpts]))
     Npols = len(new_polpairs)
 
     # Store optional attrs only if all uvps have them
@@ -2641,6 +2642,8 @@ def combine_uvpspec(uvps, merge_history=True, verbose=True):
     u.bl_array = np.array(new_bls)
     u.Nbls = len(u.bl_array)
     u.bl_vecs = []
+    u.Ntpairs = Ntpairs
+    u.Nbltpairs = Nbltpairs
     for b, bl in enumerate(new_bls):
         l = [bl in _bls for _bls in uvp_bls].index(True)
         h = [bl == _bl for _bl in uvp_bls[l]].index(True)
@@ -2758,7 +2761,6 @@ def get_uvp_overlap(uvps, just_meta=True, verbose=True):
             if s not in unique_spws: unique_spws.append(s)
         for p in uvp1.polpair_array:
             if p not in unique_polpairs: unique_polpairs.append(p)
-
         uvp1_blpts_comb = [(blp, t1, t2) for blp, t1, t2 in zip(uvp1.blpair_array, uvp1.time_1_array, uvp1.time_2_array)]
         blpts_comb.extend(uvp1_blpts_comb)
 

--- a/hera_pspec/uvpspec.py
+++ b/hera_pspec/uvpspec.py
@@ -2758,7 +2758,7 @@ def get_uvp_overlap(uvps, just_meta=True, verbose=True):
         for p in uvp1.polpair_array:
             if p not in unique_polpairs: unique_polpairs.append(p)
 
-        uvp1_blpts = zip(uvp1.blpair_array, uvp1.time_avg_array)
+        uvp1_blpts = zip(uvp1.blpair_array, uvp1.time_1_array, uvp1.time_2_array)
         uvp1_blpts_comb = [bl[0] + 1.j*bl[1] for bl in uvp1_blpts]
         blpts_comb.extend(uvp1_blpts_comb)
 
@@ -2769,7 +2769,7 @@ def get_uvp_overlap(uvps, just_meta=True, verbose=True):
     for i, uvp1 in enumerate(uvps):
         # get uvp1 sets and append to unique lists
         uvp1_spws = uvp1.get_spw_ranges()
-        uvp1_blpts = list(zip(uvp1.blpair_array, uvp1.time_avg_array))
+        uvp1_blpts = list(zip(uvp1.blpair_array, uvp1.time_1_array, uvp1.time_2_array))
         uvp1_polpairs = uvp1.polpair_array
 
         # iterate over uvps
@@ -2777,7 +2777,7 @@ def get_uvp_overlap(uvps, just_meta=True, verbose=True):
             if j <= i: continue
             # get uvp2 sets
             uvp2_spws = uvp2.get_spw_ranges()
-            uvp2_blpts = list(zip(uvp2.blpair_array, uvp2.time_avg_array))
+            uvp2_blpts = list(zip(uvp2.blpair_array, uvp2.time_1_array, uvp2.time_2_array))
             uvp2_polpairs = uvp2.polpair_array
 
             # determine if uvp1 and uvp2 are an identical match

--- a/hera_pspec/uvpspec.py
+++ b/hera_pspec/uvpspec.py
@@ -2563,7 +2563,7 @@ def combine_uvpspec(uvps, merge_history=True, verbose=True):
 
     elif concat_ax == 'blpairts':
 
-        is_in = [uvputils._fast_is_in(_blpts, new_blpts)
+        is_in = [uvputils._is_in(_blpts, new_blpts)
                  for _blpts in uvp_blpts]
 
         # Concatenate blpair-times
@@ -2798,7 +2798,7 @@ def get_uvp_overlap(uvps, just_meta=True, verbose=True):
         uvp1_blpts_comb = [(blp, t1, t2) for blp, t1, t2 in zip(uvp1.blpair_array, uvp1.time_1_array, uvp1.time_2_array)]
         blpts_comb.extend(uvp1_blpts_comb)
 
-    # Old way uwing np.unique and complex coding did not support
+    # Old way using np.unique and complex coding did not support
     # two times.
     unique_blpts = list(set(blpts_comb))
 

--- a/hera_pspec/uvpspec_utils.py
+++ b/hera_pspec/uvpspec_utils.py
@@ -485,6 +485,8 @@ def _select(uvp, spws=None, bls=None, only_pairs_in_bls=False, blpairs=None,
     Select function for selecting out certain slices of the data, as well
     as loading in data from HDF5 file.
 
+    TODO: Add time1, time2 selection options.
+
     Parameters
     ----------
     uvp : UVPSpec object
@@ -565,7 +567,7 @@ def _select(uvp, spws=None, bls=None, only_pairs_in_bls=False, blpairs=None,
 
     if blpairs is not None:
         if bls is None:
-            blp_select = np.zeros(uvp.Nblpairts, bool)
+            blp_select = np.zeros(uvp.Nbltpairs, bool)
 
         # assert form
         assert isinstance(blpairs[0], (tuple, int, np.integer)), \
@@ -580,7 +582,7 @@ def _select(uvp, spws=None, bls=None, only_pairs_in_bls=False, blpairs=None,
 
     if times is not None:
         if bls is None and blpairs is None:
-            blp_select = np.ones(uvp.Nblpairts, bool)
+            blp_select = np.ones(uvp.Nbltpairs, bool)
         time_select = np.logical_or.reduce(
                                [np.isclose(uvp.time_avg_array, t, rtol=1e-16)
                                 for t in times])
@@ -589,7 +591,7 @@ def _select(uvp, spws=None, bls=None, only_pairs_in_bls=False, blpairs=None,
     if lsts is not None:
         assert times is None, "Cannot select on lsts and times simultaneously."
         if bls is None and blpairs is None:
-            blp_select = np.ones(uvp.Nblpairts, bool)
+            blp_select = np.ones(uvp.Nbltpairs, bool)
         lst_select = np.logical_or.reduce(
                             [ np.isclose(uvp.lst_avg_array, t, rtol=1e-16)
                               for t in lsts] )
@@ -621,7 +623,7 @@ def _select(uvp, spws=None, bls=None, only_pairs_in_bls=False, blpairs=None,
         uvp.lst_avg_array = uvp.lst_avg_array[blp_select]
         uvp.Ntimes = len(np.unique(uvp.time_avg_array))
         uvp.Nblpairs = len(np.unique(uvp.blpair_array))
-        uvp.Nblpairts = len(uvp.blpair_array)
+        uvp.Nbltpairs = len(uvp.blpair_array)
 
         # Calculate unique baselines from new blpair_array
         new_blpairs = np.unique(uvp.blpair_array)

--- a/hera_pspec/uvpspec_utils.py
+++ b/hera_pspec/uvpspec_utils.py
@@ -1049,41 +1049,26 @@ def _conj_blpair(blpair, which='both'):
     return conj_blpair
 
 
-def _fast_is_in(src_blpts, query_blpts, time_prec=8):
+def _is_in(src_blpts, query_blpts):
     """
-    Helper function to rapidly check if a given blpair-time couplet is in an
+    Helper function to check if a given bltime-pari is in an
     array.
 
     Parameters
     ----------
     src_blpts : list of tuples or array_like
         List of tuples or array of shape (N, 2), containing a list of (blpair,
-        time) couplets.
+        time1, time2) triplets.
 
     query_blpts : list of tuples or array_like
         List of tuples or array of shape (M, 2), containing a list of (blpair,
-        time) which will be looked up in src_blpts
-
-    time_prec : int, optional
-        Number of decimals to round time array to when performing float
-        comparision. Default: 8.
+        time1, time2) which will be looked up in src_blpts
 
     Returns
     -------
     is_in_arr: list of bools
         A list of booleans, which indicate which query_blpts are in src_blpts.
     """
-    # This function converts baseline-pair-times, a tuple (blp, time)
-    # to a complex number blp + 1j * time, so that "in" function is much
-    # faster.
-    src_blpts = np.asarray(src_blpts)
-    query_blpts = np.asarray(query_blpts)
-
-    # Slice to create complex array
-    src_blpts = src_blpts[:,0] + 1.j*np.around(src_blpts[:,1], time_prec)
-    query_blpts = query_blpts[:,0] + 1.j*np.around(query_blpts[:,1], time_prec)
-
-    # see if q complex number is in src_blpts
     return [q in src_blpts for q in query_blpts]
 
 

--- a/hera_pspec/uvwindow.py
+++ b/hera_pspec/uvwindow.py
@@ -344,8 +344,11 @@ class UVWindow:
         assert hasattr(self.ftbeam_obj_pol[0], 'mapsize') and hasattr(self.ftbeam_obj_pol[1], 'mapsize'), \
             "Wrong input given in ftbeam_obj: must be (a list of) FTBeam object(s)"
         # check if elements in list have same properties
-        assert np.all(self.ftbeam_obj_pol[0].freq_array == self.ftbeam_obj_pol[1].freq_array), \
+        assert len(self.ftbeam_obj_pol[0].freq_array) == len(self.ftbeam_obj_pol[1].freq_array), \
             'Spectral ranges of the two FTBeam objects do not match'
+        if len(self.ftbeam_obj_pol[0].freq_array) == len(self.ftbeam_obj_pol[1].freq_array):
+            assert np.all(self.ftbeam_obj_pol[0].freq_array == self.ftbeam_obj_pol[1].freq_array), \
+                'Spectral ranges of the two FTBeam objects do not match'
         assert self.ftbeam_obj_pol[0].mapsize == self.ftbeam_obj_pol[1].mapsize, \
             'Physical properties of the two FTBeam objects do not match'
 


### PR DESCRIPTION
This PR addresses a current limitation in UVPspec class in that it addresses unique data samples with baseline pair and the average time of the two samples being crossed for a power spectrum sample. A common use case that comes up is when we cross two different times for the same baseline pair. For a concrete example, consider the baseline pair `(bl_0, bl_1)` where each baseline is sampled at two close-together times `t1, t2`. It is common practice to form interleaves between the times so that we form the baseline-time pairs, `(bl_0, t1) x conj((bl_1, t2))` and `(bl_0, t2) x conj((bl_1, t1))` Both of these power spectra have the same average-time (`t1/2 + t2/2`) and as a result, they cannot actually be stored in the same `UVPSpec` object. Currently `pspec_run` is forced to compute these interleaves from separate files and store them as different `UVPSpec` objects in a `PSPecContainer`. Unfortunately, none of the data-averaging tools in `hera_pspec` that rigorously track error statistics, etc, can operate on multiple `UVPSpec` objects.

I saw two potential solutions to this problem.  


(1) Change the definition of `UVPSpec` to allow for  time-permuted blt-pairs to be stored in the same object.
(2) Change the averaging functions to operate on multiple UVPSpec objects. 


This PR addresses the problem through the first option. I decided to take the first approach because 

1) **Option(1) will result in a simpler interfaces than option (2).** interleaving in time is done routinely in power spectrum estimation and I think that supporting it at the level of the `UVPSPec` class will simplify our interfaces for this common task by allowing us to calculate arbitrary time-interleaves on arbitrary numbers of input data files, avoiding additional up-stream pipeline tailoring. This PR does not add such functionality to the `pspecdata.pspec_run` routines changing the `UVPSPec` definition is necessary to support this. 

2) **Option (1) requires less additional code then option (2).** My initial hunch is that option 2 would result in more _additional_ code since it would mean writing entire new versions of all of our averaging functions to operate over multiple objects (rather then axes in the data arrays of one of these objects). Option 1 (chosen here) focuses more on making point changes to _existing_ code which in most cases involve swapping variable names. 

* We want to key our datapoints with baseline and time pairs instead of baseline pairs and a single average time. Thus, this PR changes the parameter `Nblpairts` to `Nbltpairs`.
* We introduce a new variable, `Ntpairs` to represent the total number of unique time_1, time_2 pairs.
* We change the meaning of `Ntimes` in UVPspec objects to reference the total number of unique times in `time_1_array` union `time_2_array`. Before, it only referenced the total number of unique times in `lst_average_array`.  

With these changes, we can apply all of the averaging infrastructure and error bar propagation that exists for individual UVPspec objects to arbitrary time interleaves.

This PR also manages backwards compatibility with `UVPSPec` files created with previous versions of `UVPSpec` by detecting the deprecated `Nblpairts` variable when reading files and computing the new required variables, even if they are not present in these files from outdated versions. 
