### PR TITLE
Fix residual issues with future_array_shapes affecting noise calculation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ ex.hdf5
 out.h5
 .coverage
 coverage.xml
+.DS_Store

--- a/hera_pspec/tests/test_noise.py
+++ b/hera_pspec/tests/test_noise.py
@@ -148,46 +148,46 @@ def test_analytic_noise():
     bls1, bls2, blps = utils.construct_blpairs(reds[0], exclude_auto_bls=True,
                                                exclude_permutations=True)
     taper = 'bh'
-    Nchan = 20
-    uvp = ds.pspec(bls1, bls2, (0, 1), [('xx', 'xx')], input_data_weight='identity', norm='I',
-                   taper=taper, sampling=False, little_h=True, spw_ranges=[(0, Nchan)], verbose=False,
-                   cov_model='autos', store_cov=True)
-    uvp_fg = ds.pspec(bls1, bls2, (0, 1), [('xx', 'xx')], input_data_weight='identity', norm='I',
-                   taper=taper, sampling=False, little_h=True, spw_ranges=[(0, Nchan)], verbose=False,
-                   cov_model='foreground_dependent', store_cov=True)
+    for spw_ranges in ([(0, 20)], [(119, 140)]):
+        uvp = ds.pspec(bls1, bls2, (0, 1), [('xx', 'xx')], input_data_weight='identity', norm='I',
+                    taper=taper, sampling=False, little_h=True, spw_ranges=spw_ranges, verbose=False,
+                    cov_model='autos', store_cov=True)
+        uvp_fg = ds.pspec(bls1, bls2, (0, 1), [('xx', 'xx')], input_data_weight='identity', norm='I',
+                    taper=taper, sampling=False, little_h=True, spw_ranges=spw_ranges, verbose=False,
+                    cov_model='foreground_dependent', store_cov=True)
 
-    # get P_N estimate
-    auto_Tsys = utils.uvd_to_Tsys(uvd, beam, os.path.join(DATA_PATH, "test_uvd.uvh5"))
-    assert os.path.exists(os.path.join(DATA_PATH, "test_uvd.uvh5"))
-    utils.uvp_noise_error(uvp, auto_Tsys, err_type=['P_N','P_SN'], P_SN_correction=False)
+        # get P_N estimate
+        auto_Tsys = utils.uvd_to_Tsys(uvd, beam, os.path.join(DATA_PATH, "test_uvd.uvh5"))
+        assert os.path.exists(os.path.join(DATA_PATH, "test_uvd.uvh5"))
+        utils.uvp_noise_error(uvp, auto_Tsys, err_type=['P_N','P_SN'], P_SN_correction=False)
 
-    # check consistency of 1-sigma standard dev. to 1%
-    cov_diag = uvp.cov_array_real[0][:, range(Nchan), range(Nchan)]
-    stats_diag = uvp.stats_array['P_N'][0]
-    frac_ratio = (cov_diag**0.5 - stats_diag) / stats_diag
-    assert np.abs(frac_ratio).mean() < 0.01
+        # check consistency of 1-sigma standard dev. to 1%
+        cov_diag = np.array([np.diag(uvp.cov_array_real[0][i][:, :, 0])[:, None] for i in range(uvp.cov_array_real[0].shape[0])])
+        stats_diag = uvp.stats_array['P_N'][0]
+        frac_ratio = (cov_diag**0.5 - stats_diag) / stats_diag
+        assert np.abs(frac_ratio).mean() < 0.01
 
-    ## check P_SN consistency of 1-sigma standard dev. to 1%
-    cov_diag = uvp_fg.cov_array_real[0][:, range(Nchan), range(Nchan)]
-    stats_diag = uvp.stats_array['P_SN'][0]
-    frac_ratio = (cov_diag**0.5 - stats_diag) / stats_diag
-    assert np.abs(frac_ratio).mean() < 0.01
+        ## check P_SN consistency of 1-sigma standard dev. to 1%
+        cov_diag = np.array([np.diag(uvp_fg.cov_array_real[0][i][:, :, 0])[:, None] for i in range(uvp_fg.cov_array_real[0].shape[0])])
+        stats_diag = uvp.stats_array['P_SN'][0]
+        frac_ratio = (cov_diag**0.5 - stats_diag) / stats_diag
+        assert np.abs(frac_ratio).mean() < 0.01
 
-    # now compute unbiased P_SN and check that it matches P_N at high-k
-    utils.uvp_noise_error(uvp, auto_Tsys, err_type=['P_N','P_SN'], P_SN_correction=True)
-    frac_ratio = (uvp.stats_array["P_SN"][0] - uvp.stats_array["P_N"][0]) / uvp.stats_array["P_N"][0]
-    dlys = uvp.get_dlys(0) * 1e9
-    select = np.abs(dlys) > 3000
-    assert np.abs(frac_ratio[:, select].mean()) < 1 / np.sqrt(uvp.Nbltpairs)
+        # now compute unbiased P_SN and check that it matches P_N at high-k
+        utils.uvp_noise_error(uvp, auto_Tsys, err_type=['P_N','P_SN'], P_SN_correction=True)
+        frac_ratio = (uvp.stats_array["P_SN"][0] - uvp.stats_array["P_N"][0]) / uvp.stats_array["P_N"][0]
+        dlys = uvp.get_dlys(0) * 1e9
+        select = np.abs(dlys) > 3000
+        assert np.abs(frac_ratio[:, select].mean()) < 1 / np.sqrt(uvp.Nbltpairs)
 
-    # test single time
-    uvp.select(times=uvp.time_avg_array[:1], inplace=True)
-    auto_Tsys.select(times=auto_Tsys.time_array[:1], inplace=True)
-    utils.uvp_noise_error(uvp, auto_Tsys, err_type=['P_N','P_SN'], P_SN_correction=True)
-    frac_ratio = (uvp.stats_array["P_SN"][0] - uvp.stats_array["P_N"][0]) / uvp.stats_array["P_N"][0]
-    dlys = uvp.get_dlys(0) * 1e9
-    select = np.abs(dlys) > 3000
-    assert np.abs(frac_ratio[:, select].mean()) < 1 / np.sqrt(uvp.Nbltpairs)
+        # test single time
+        uvp.select(times=uvp.time_avg_array[:1], inplace=True)
+        auto_Tsys.select(times=auto_Tsys.time_array[:1], inplace=True)
+        utils.uvp_noise_error(uvp, auto_Tsys, err_type=['P_N','P_SN'], P_SN_correction=True)
+        frac_ratio = (uvp.stats_array["P_SN"][0] - uvp.stats_array["P_N"][0]) / uvp.stats_array["P_N"][0]
+        dlys = uvp.get_dlys(0) * 1e9
+        select = np.abs(dlys) > 3000
+        assert np.abs(frac_ratio[:, select].mean()) < 1 / np.sqrt(uvp.Nbltpairs)
 
-    # clean up
-    os.remove(os.path.join(DATA_PATH, "test_uvd.uvh5"))
+        # clean up
+        os.remove(os.path.join(DATA_PATH, "test_uvd.uvh5"))

--- a/hera_pspec/tests/test_uvwindow.py
+++ b/hera_pspec/tests/test_uvwindow.py
@@ -379,7 +379,7 @@ class Test_UVWindow(unittest.TestCase):
         ft_beam = np.copy(test.ftbeam_obj_pol[0].ft_beam)
         interp_ft_beam, kperp_norm = test._interpolate_ft_beam(bl_len, ft_beam)
         # frequency resolution
-        delta_nu = abs(test.freq_array[-1]-test.freq_array[0])/test.Nfreqs
+        delta_nu = np.median(np.diff(test.freq_array))
         fnu = test._take_freq_FT(interp_ft_beam, delta_nu)
         # test for ft_beam of wrong dimensions
         pytest.raises(AssertionError, test._take_freq_FT,

--- a/hera_pspec/utils.py
+++ b/hera_pspec/utils.py
@@ -1388,7 +1388,7 @@ def uvp_noise_error(uvp, auto_Tsys=None, err_type='P_N', precomp_P_N=None, P_SN_
     if precomp_P_N is None:
         lst_indices = np.unique(auto_Tsys.lst_array, return_index=True)[1]
         lsts = auto_Tsys.lst_array[sorted(lst_indices)]
-        freqs = auto_Tsys.freq_array[0]
+        freqs = np.squeeze(auto_Tsys.freq_array)
     # calculate scalars for spws and polpairs.
     scalar = {}
     for spw in uvp.spw_array:
@@ -1399,7 +1399,7 @@ def uvp_noise_error(uvp, auto_Tsys=None, err_type='P_N', precomp_P_N=None, P_SN_
     for spw in uvp.spw_array:
         # get spw properties
         spw_range = uvp.get_spw_ranges(spw)[0]
-        spw_start = np.argmin(np.abs(auto_Tsys.freq_array[0] - spw_range[0]))
+        spw_start = np.argmin(np.abs(np.squeeze(auto_Tsys.freq_array) - spw_range[0]))
         spw_stop = spw_start + spw_range[2]
         taper = uvt.dspec.gen_window(uvp.taper, spw_range[2])
         # iterate over blpairs

--- a/hera_pspec/uvwindow.py
+++ b/hera_pspec/uvwindow.py
@@ -664,7 +664,7 @@ class UVWindow:
         alpha = self.cosmo.dRpara_df(self.avg_z, little_h=self.little_h,
                                      ghz=False)
         # frequency resolution
-        delta_nu = abs(self.freq_array[-1]-self.freq_array[0])/self.Nfreqs
+        delta_nu = np.median(np.diff(self.freq_array))
         # Fourier dual of frequency (unit 1: FT along theta)
         eta = np.fft.fftshift(np.fft.fftfreq(self.Nfreqs), axes=-1)/delta_nu
         # construct array of |kpara| values for given delay tau


### PR DESCRIPTION
This PR replaces a couple of lingering `freq_array[0]` with np.squeeze() which works for both past and future array shapes.

I've added a unit test that fails on the current main branch and passes (I hope!) on this branch. 

Finally, while searching the repo for `freq_array[0]` I found a couple of calculations of delta nu that aren't quite right (they take the middle freq of the first and last bin and divide by the number of bins, when really want you want to do is a diff... that calculation will be wrong by a factor of 2 in the limit where there are only 2 frequency channels). So I fixed those too.