### PR TITLE
Fixing pspec_run to allow the use of non-future-array-shape uvdata

### DIFF
--- a/hera_pspec/pspecdata.py
+++ b/hera_pspec/pspecdata.py
@@ -4179,7 +4179,7 @@ def pspec_run(dsets, filename, dsets_std=None, cals=None, cal_flag=True,
             assert 0 <= spw[0] < spw[1], f"spw_ranges must be a list of tuples of length 2, with both elements being non-negative integers of increasing value. Got {spw}"
             for dset in dsets:
                 assert spw[1] <= dset.Nfreqs, f"spw_range of {spw} out of range for dset {dset.filename[0]} with the second element being less than the number of frequencies in the data"
-            utils.log(f"Using spw_range: {dsets[0].freq_array[spw[0]] /1e6} - {dsets[0].freq_array[spw[1] - 1]/1e6} MHz", verbose=verbose)
+            utils.log(f"Using spw_range: {np.squeeze(dsets[0].freq_array)[spw[0]] /1e6} - {np.squeeze(dsets[0].freq_array)[spw[1] - 1]/1e6} MHz", verbose=verbose)
 
     # read calibration if provided (calfits partial IO not yet supported)
     if cals is not None:

--- a/hera_pspec/tests/test_pspecdata.py
+++ b/hera_pspec/tests/test_pspecdata.py
@@ -2038,6 +2038,22 @@ def test_pspec_run():
     phserr_after = np.mean(np.abs(np.angle(ds.dsets[0].data_array / ds.dsets[1].data_array)))
     assert phserr_after < phserr_before
 
+    # test without using future array shape
+    uvd_non_future = UVData()
+    uvd_non_future.read_miriad(fnames[0])
+    if os.path.exists("./out2.h5"):
+        os.remove("./out2.h5")
+    ds = pspecdata.pspec_run([copy.deepcopy(uvd_non_future)], "./out2.h5", dsets_std=[copy.deepcopy(uvd_non_future)],
+                             blpairs=[((37, 38), (37, 38)), ((37, 38), (52, 53))], interleave_times=True,
+                             verbose=False, overwrite=True, spw_ranges=[(0, 25)], rephase_to_dset=0,
+                             broadcast_dset_flags=True, time_thresh=0.3)
+    # assert ds passes validation
+    psc =  container.PSpecContainer('./out2.h5')
+    assert ds.dsets_std[0] is not None
+    ds.validate_datasets()
+    assert os.path.exists("./out2.h5")
+    os.remove("./out2.h5")
+
     # repeat feeding dsets_std and wgts
     if os.path.exists("./out2.h5"):
         os.remove("./out2.h5")


### PR DESCRIPTION
Currently the `pspec_run` command accepts `dsets` as a parameter, which is a list of UVData objects or string filepaths to UVData-compatible files. However, the acceptable UVData objects are implicitly using future_array_shape, which is not specified in the code. This PR aims to fix this issue. 