### PR TITLE
Fix uvp_noise_error() for interleaved LSTs

### DIFF
--- a/hera_pspec/utils.py
+++ b/hera_pspec/utils.py
@@ -1420,6 +1420,7 @@ def uvp_noise_error(uvp, auto_Tsys=None, err_type='P_N', precomp_P_N=None, P_SN_
             # I don't anticipate this being a problem with HERA's 10 second interleave time.
             tinds1 = [np.where(np.isclose(times_blp_1, t, atol=1e-5, rtol=0))[0][0] for t in time_1_selection]
             tinds2 = [np.where(np.isclose(times_blp_2, t, atol=1e-5, rtol=0))[0][0] for t in time_2_selection]
+            auto_lst_avg = np.mean([np.unwrap(lsts[tinds1]), np.unwrap(lsts[tinds2])], axis=0) % (2 * np.pi)
             
             # iterate over polarization
             for polpair in uvp.polpair_array:
@@ -1451,7 +1452,7 @@ def uvp_noise_error(uvp, auto_Tsys=None, err_type='P_N', precomp_P_N=None, P_SN_
                         Tflag = np.all(Tflag, axis=-1)
                         # interpolate to appropriate LST grid
                         if np.count_nonzero(~Tflag) > 1:
-                            Tsys = interp1d(lsts[~Tflag], Tsys[~Tflag], kind='nearest', bounds_error=False, fill_value='extrapolate')(lst_avg)
+                            Tsys = interp1d(auto_lst_avg[~Tflag], Tsys[~Tflag], kind='nearest', bounds_error=False, fill_value='extrapolate')(lst_avg)
                         else:
                             Tsys = Tsys[0]
 

--- a/hera_pspec/utils.py
+++ b/hera_pspec/utils.py
@@ -1446,8 +1446,8 @@ def uvp_noise_error(uvp, auto_Tsys=None, err_type='P_N', precomp_P_N=None, P_SN_
                         Tsys = np.inf
                     else:
                         # get weights
-                        Tsys1 = np.sum(Tsys1**.5 * ~Tflag1 * taper, axis=-1) / np.sum(~Tflag1 * taper, axis=-1).clip(1e-20, np.inf)
-                        Tsys2 = np.sum(Tsys2**.5 * ~Tflag2 * taper, axis=-1) / np.sum(~Tflag2 * taper, axis=-1).clip(1e-20, np.inf)
+                        Tsys1 = np.sum(Tsys1 * ~Tflag1 * taper, axis=-1) / np.sum(~Tflag1 * taper, axis=-1).clip(1e-20, np.inf)
+                        Tsys2 = np.sum(Tsys2 * ~Tflag2 * taper, axis=-1) / np.sum(~Tflag2 * taper, axis=-1).clip(1e-20, np.inf)
                         Tflag1 = np.all(Tflag1, axis=-1)
                         Tflag2 = np.all(Tflag2, axis=-1)
                         # interpolate to appropriate LST grid
@@ -1457,8 +1457,6 @@ def uvp_noise_error(uvp, auto_Tsys=None, err_type='P_N', precomp_P_N=None, P_SN_
                             Tsys = (Tsys1 * Tsys2)**.5
                         else:
                             Tsys = (Tsys1[0] * Tsys2[0])**.5
-
-                    assert False, Tsys
 
                     # calculate P_N
                     P_N = uvp.generate_noise_spectra(spw, polpair, Tsys, blpairs=[blp], form='Pk', component='real', scalar=scalar[(spw, polpair)])[blp_int]


### PR DESCRIPTION
The documentation of `utils.uvp_noise_error()` suggest that if "power spectra were computed from interleaved times then the supplied `auto_Tsys` should include all of the times that are present in all of the pairs." For interleaved power spectra, that the number of times in `auto_Tsys` (a `UVData` object) might be double (or more, for more interleaves) the number of times in `uvp.lst_avg_array`.

This creates a problem in the line 

```
Tsys = interp1d(lsts[~Tflag], Tsys[~Tflag], kind='nearest', bounds_error=False, fill_value='extrapolate')(lst_avg)
``` 

because `lsts` is calculated as

```
lst_indices = np.unique(auto_Tsys.lst_array, return_index=True)[1]
lsts = auto_Tsys.lst_array[sorted(lst_indices)]
```

while `Tflag` has a shape determined by the number of times in `uvp.time_1_array` and `uvp.time_2_array`. When that number of times don't match, this causes an error in `lsts[~Tflag]` because `Tflag` is half the length of `lsts` (for example). 

This PR fixes that bug by ensuring that the range of lsts indexed into by `~Tflag` is the precise right shape.

@Kai-FengChen can you review this PR? Also, @aewallwi just wanted to give you a heads up since this might impinge on your work.
