### PR TITLE
Fix test errors: codecov secret and missing package for docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,12 +41,13 @@ jobs:
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v4
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       with:
         files: ./coverage.xml
         directory: ./coverage/reports/
         flags: unittests
         env_vars: OS,PYTHON
         name: codecov-umbrella
-        token: ${{ secrets.CODECOV_TOKEN }}
         fail_ci_if_error: true
         verbose: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3
       env:
-        CODECOV_TOKEN = ${{ secrets.CODECOV_TOKEN }}
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       with:
         files: ./coverage.xml
         directory: ./coverage/reports/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
                --cov-report xml:"./coverage.xml" --junitxml="./test-reports/xunit.xml"
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
                --cov-report xml:"./coverage.xml" --junitxml="./test-reports/xunit.xml"
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v3
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       with:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,9 +9,10 @@ version: 2
 # Set the version of Python and other tools you might need
 build:
   os: ubuntu-22.04
+  tools:
+    python: "3.11"
 
 python:
-  version: 3.11
   install:
     - method: pip
       path: .

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,8 +9,14 @@ version: 2
 # Set the version of Python and other tools you might need
 build:
   os: ubuntu-22.04
-  tools:
-    python: "3.11"
+
+python:
+  version: 3.11
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
@@ -28,6 +34,6 @@ sphinx:
 # Optional but recommended, declare the Python requirements required
 # to build your documentation
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
-python:
-   install:
-   - requirements: docs/requirements.txt
+# python:
+#    install:
+#    - requirements: docs/requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
 sphinx==5.3.0
 sphinx_rtd_theme==1.1.1
 readthedocs-sphinx-search==0.1.1
+mock==1.0.1

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,0 @@
-sphinx==5.3.0
-sphinx_rtd_theme==1.1.1
-readthedocs-sphinx-search==0.1.1
-mock==1.0.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -60,6 +60,7 @@ docs =
     sphinx_autorun
     numpydoc>=0.8
     nbsphinx
+    mock
 tests =
     coverage>=4.5.1
     pytest>=3.5.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,13 +54,15 @@ exclude =
 
 [options.extras_require]
 docs =
-    sphinx>=1.8
+    sphinx==5.3.0
+    sphinx_rtd_theme==1.1.1
+    readthedocs-sphinx-search==0.1.1
     nbsphinx
     ipython
     sphinx_autorun
     numpydoc>=0.8
     nbsphinx
-    mock
+    mock==1.0.1
 tests =
     coverage>=4.5.1
     pytest>=3.5.1


### PR DESCRIPTION
This PR adds two elements that were missing for the tests to pass:
- Adds a secret for `codecov`. Although it is not required for public repos, uploads often fail when you don't have one. If you don't set one, it uses like a backup public token which has a rate limit (@steven-murray)
- Adds the `mock` package as a requirement for the documentation: building `readthedocs` is failing without (called in `conf.py`)