### PR TITLE
Change python version in tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: [3.8, 3.9, "3.10"]
+        python-version: [3.9, "3.10", "3.11", "3.12"]
       fail-fast: false
 
     steps:

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,8 @@ classifiers =
     Development Status :: 5 - Production/Stable
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     Intended Audience :: Science/Research
     License :: OSI Approved
     Natural Language :: English

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,8 +18,8 @@ platforms = OSX,Linux
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers
 classifiers =
     Development Status :: 5 - Production/Stable
-    Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Intended Audience :: Science/Research
     License :: OSI Approved
     Natural Language :: English


### PR DESCRIPTION
This PR removes `python=3.8` from tests as there was a compatibility problem with `hera_cal` and `optax1` and added 3.11 and 3.12.