### PR TITLE
Implement `pol_convention` in `pstokes` module

### DIFF
--- a/hera_pspec/pstokes.py
+++ b/hera_pspec/pstokes.py
@@ -5,6 +5,7 @@ import numpy as np, os
 import pyuvdata
 import copy
 from collections import OrderedDict as odict
+from collections.abc import Iterable
 import argparse
 import warnings
 
@@ -173,20 +174,20 @@ def _combine_pol_arrays(
         (the ``sum`` convention).
 
     data_list : any length 2 iterable of numpy arrays
-        List of data arrays to be combined to form their pseudo-Stokes equivalent.
+        Iterable of data arrays to be combined to form their pseudo-Stokes equivalent.
         If only one is given, it is duplicated. For the ``avg`` convention, the
         data arrays are combined as ``(data1 + data2)/2``, in the the ``sum`` 
         convention, the output is ``data1 + data2``.
         Default is None.
 
     flags_list :  any length 2 iterable of numpy arrays
-        List of flag arrays to be combined to form their pseudo-Stokes equivalent.
+        Iterable of flag arrays to be combined to form their pseudo-Stokes equivalent.
         If only one is given, it is duplicated.
         Flags are combined with a logical OR.
         Default is None.
 
     nsamples_list :  any length 2 iterable of numpy arrays
-        List of nsamples arrays to be combined to form their pseudo-Stokes equivalent.
+        Iterable of nsamples arrays to be combined to form their pseudo-Stokes equivalent.
         nsamples are combined to preserve proper variance, see hera_pspec issue #391.
         If only one is given, it is duplicated.
         Default is None.
@@ -237,14 +238,11 @@ def _combine_pol_arrays(
     # checks on input lists
     for a_list in [data_list, flags_list, nsamples_list]:
         if a_list is None:
-            a_list = None
             continue
-        if not isinstance(a_list, list) and isinstance(a_list, np.ndarray):
-            a_list = [a_list]
-        if len(a_list) == 1:
-            a_list.append(a_list[0])
-        elif len(a_list) > 2:
-            raise ValueError("Cannot combine more than two arrays.")
+        if not isinstance(a_list, Iterable):
+            raise ValueError('Data, flags and nsamples inputs must be iterables')
+        elif len(a_list) != 2:
+            raise ValueError("Can only combine two arrays.")
         assert np.shape(a_list[0]) == np.shape(a_list[1]), \
             "Arrays in list must have identical shape."
 

--- a/hera_pspec/pstokes.py
+++ b/hera_pspec/pstokes.py
@@ -107,9 +107,8 @@ def _combine_pol(uvd1, uvd2, pol1, pol2, pstokes='pI', x_orientation=None):
         "uvd2 must be a pyuvdata.UVData instance"
 
     for i, uvd in enumerate([uvd1, uvd2]):
-        try:
-            uvd.pol_convention
-        except AttributeError:
+        pol_convention = getattr(uvd, 'pol_convention', None)
+        if pol_convention is None: 
             warnings.warn(
                 f'No polarization convention in uvd{i+1}. '
                 'Considering it to be "avg".')

--- a/hera_pspec/tests/test_pstokes.py
+++ b/hera_pspec/tests/test_pstokes.py
@@ -45,6 +45,7 @@ class Test_pstokes(unittest.TestCase):
         setattr(uvd2, 'pol_convention', 'sum')
         out3 = pstokes._combine_pol(uvd1, uvd2, 'XX', 'YY')
         assert np.allclose(out3.data_array, out1.data_array * 2.)
+        assert np.allclose(out3.nsample_array, out1.nsample_array / 4.)
 
         # check exceptions
         pytest.raises(AssertionError, pstokes._combine_pol, dset1, dset2, 'XX', 'YY' )
@@ -94,23 +95,29 @@ class Test_pstokes(unittest.TestCase):
         assert np.allclose(f1, f3)
         assert np.allclose(ns1, ns3)
 
+        # if a_list is length one, repeat to auto-combine
+        _, _, _ = pstokes._combine_pol_arrays(
+            pol1='XX',
+            pol2='YY',
+            pstokes='pI',
+            data_list=[uvd1.data_array]
+        )
+        _, _, _ = pstokes._combine_pol_arrays(
+            pol1='XX',
+            pol2='YY',
+            pstokes='pI',
+            data_list=uvd1.data_array
+        )
+
         # check exceptions
         pytest.raises(AssertionError, pstokes._combine_pol_arrays, 'XX', 'pI', 'pI')
         pytest.raises(AssertionError, pstokes._combine_pol_arrays, 'pI', 'YY', 'pI')
         pytest.raises(ValueError, pstokes._combine_pol_arrays, 'XX', 'YY', 'pI',
             pol_convention='blah')
-        pytest.raises(AssertionError, pstokes._combine_pol_arrays, 'XX', 'YY', 'pI',
-            data_list=[uvd1.data_array])
-        pytest.raises(AssertionError, pstokes._combine_pol_arrays, 'XX', 'YY', 'pI',
-            flags_list=[uvd1.flag_array])
-        pytest.raises(AssertionError, pstokes._combine_pol_arrays, 'XX', 'YY', 'pI',
-            nsamples_list=[uvd1.nsample_array])
+        pytest.raises(ValueError, pstokes._combine_pol_arrays, 'XX', 'YY', 'pI',
+            data_list=[uvd1.data_array, uvd1.data_array, uvd1.data_array])
         pytest.raises(AssertionError, pstokes._combine_pol_arrays, 'XX', 'YY', 'pI',
             data_list=[uvd1.data_array, uvd1.data_array[0]])
-        pytest.raises(AssertionError, pstokes._combine_pol_arrays, 'XX', 'YY', 'pI',
-            flags_list=[uvd1.flag_array, uvd1.flag_array[0]])
-        pytest.raises(AssertionError, pstokes._combine_pol_arrays, 'XX', 'YY', 'pI',
-            nsamples_list=[uvd1.nsample_array, uvd1.nsample_array[0]])
 
     def test_construct_pstokes(self):
         uvd1 = self.uvd1

--- a/hera_pspec/tests/test_pstokes.py
+++ b/hera_pspec/tests/test_pstokes.py
@@ -51,7 +51,66 @@ class Test_pstokes(unittest.TestCase):
         pytest.raises(AssertionError, pstokes._combine_pol, uvd1, uvd2, 'XX', 1)
         # if different polarization conventions
         setattr(uvd1, 'pol_convention', 'avg')
-        pytest.raises(ValueError, pstokes._combine_pol, uvd1, uvd2, 'XX', 1)
+        pytest.raises(ValueError, pstokes._combine_pol, uvd1, uvd2, 'XX', 'YY')
+
+    def test_combine_pol_arrays(self):
+        uvd1 = copy.deepcopy(self.uvd1)
+        uvd2 = copy.deepcopy(self.uvd2)
+
+        # proper usage
+        d1, f1, ns1 = pstokes._combine_pol_arrays(
+            pol1=-5,
+            pol2=-6,
+            pstokes='pI',
+            pol_convention='avg',
+            data_list=[uvd1.data_array, uvd2.data_array],
+            flags_list=[uvd1.flag_array, uvd2.flag_array],
+            nsamples_list=[uvd1.nsample_array, uvd2.nsample_array]
+        )
+        # inputs can be None
+        d2, f2, ns2 = pstokes._combine_pol_arrays(
+            pol1=-5,
+            pol2=-6,
+            pstokes='pI',
+            pol_convention='avg',
+            data_list=None,
+            flags_list=None,
+            nsamples_list=None
+        )
+        assert d2 is None
+        assert f2 is None
+        assert ns2 is None
+        # polarizations can be strings     
+        d3, f3, ns3 = pstokes._combine_pol_arrays(
+            pol1='XX',
+            pol2='YY',
+            pstokes='pI',
+            pol_convention='avg',
+            data_list=[uvd1.data_array, uvd2.data_array],
+            flags_list=[uvd1.flag_array, uvd2.flag_array],
+            nsamples_list=[uvd1.nsample_array, uvd2.nsample_array]
+        )
+        assert np.allclose(d1, d3)
+        assert np.allclose(f1, f3)
+        assert np.allclose(ns1, ns3)
+
+        # check exceptions
+        pytest.raises(AssertionError, pstokes._combine_pol_arrays, 'XX', 'pI', 'pI')
+        pytest.raises(AssertionError, pstokes._combine_pol_arrays, 'pI', 'YY', 'pI')
+        pytest.raises(ValueError, pstokes._combine_pol_arrays, 'XX', 'YY', 'pI',
+            pol_convention='blah')
+        pytest.raises(AssertionError, pstokes._combine_pol_arrays, 'XX', 'YY', 'pI',
+            data_list=[uvd1.data_array])
+        pytest.raises(AssertionError, pstokes._combine_pol_arrays, 'XX', 'YY', 'pI',
+            flags_list=[uvd1.flag_array])
+        pytest.raises(AssertionError, pstokes._combine_pol_arrays, 'XX', 'YY', 'pI',
+            nsamples_list=[uvd1.nsample_array])
+        pytest.raises(AssertionError, pstokes._combine_pol_arrays, 'XX', 'YY', 'pI',
+            data_list=[uvd1.data_array, uvd1.data_array[0]])
+        pytest.raises(AssertionError, pstokes._combine_pol_arrays, 'XX', 'YY', 'pI',
+            flags_list=[uvd1.flag_array, uvd1.flag_array[0]])
+        pytest.raises(AssertionError, pstokes._combine_pol_arrays, 'XX', 'YY', 'pI',
+            nsamples_list=[uvd1.nsample_array, uvd1.nsample_array[0]])
 
     def test_construct_pstokes(self):
         uvd1 = self.uvd1

--- a/hera_pspec/tests/test_pstokes.py
+++ b/hera_pspec/tests/test_pstokes.py
@@ -95,25 +95,13 @@ class Test_pstokes(unittest.TestCase):
         assert np.allclose(f1, f3)
         assert np.allclose(ns1, ns3)
 
-        # if a_list is length one, repeat to auto-combine
-        _, _, _ = pstokes._combine_pol_arrays(
-            pol1='XX',
-            pol2='YY',
-            pstokes='pI',
-            data_list=[uvd1.data_array]
-        )
-        _, _, _ = pstokes._combine_pol_arrays(
-            pol1='XX',
-            pol2='YY',
-            pstokes='pI',
-            data_list=uvd1.data_array
-        )
-
         # check exceptions
         pytest.raises(AssertionError, pstokes._combine_pol_arrays, 'XX', 'pI', 'pI')
         pytest.raises(AssertionError, pstokes._combine_pol_arrays, 'pI', 'YY', 'pI')
         pytest.raises(ValueError, pstokes._combine_pol_arrays, 'XX', 'YY', 'pI',
             pol_convention='blah')
+        pytest.raises(ValueError, pstokes._combine_pol_arrays, 'XX', 'YY', 'pI',
+            data_list=uvd1.data_array)
         pytest.raises(ValueError, pstokes._combine_pol_arrays, 'XX', 'YY', 'pI',
             data_list=[uvd1.data_array, uvd1.data_array, uvd1.data_array])
         pytest.raises(AssertionError, pstokes._combine_pol_arrays, 'XX', 'YY', 'pI',

--- a/hera_pspec/tests/test_pstokes.py
+++ b/hera_pspec/tests/test_pstokes.py
@@ -30,8 +30,8 @@ class Test_pstokes(unittest.TestCase):
         pass
 
     def test_combine_pol(self):
-        uvd1 = self.uvd1
-        uvd2 = self.uvd2
+        uvd1 = copy.deepcopy(self.uvd1)
+        uvd2 = copy.deepcopy(self.uvd2)
 
         # basic execution on pol strings
         out1 = pstokes._combine_pol(uvd1, uvd2, 'XX', 'YY')
@@ -39,10 +39,19 @@ class Test_pstokes(unittest.TestCase):
         out2 = pstokes._combine_pol(uvd1, uvd2, -5, -6)
         # assert equivalence
         assert out1 == out2
+        # basic execution with different polarization conventions
+        # out1 assumed avg by default
+        setattr(uvd1, 'pol_convention', 'sum')
+        setattr(uvd2, 'pol_convention', 'sum')
+        out3 = pstokes._combine_pol(uvd1, uvd2, 'XX', 'YY')
+        assert np.allclose(out3.data_array, out1.data_array * 2.)
 
         # check exceptions
         pytest.raises(AssertionError, pstokes._combine_pol, dset1, dset2, 'XX', 'YY' )
         pytest.raises(AssertionError, pstokes._combine_pol, uvd1, uvd2, 'XX', 1)
+        # if different polarization conventions
+        setattr(uvd1, 'pol_convention', 'avg')
+        pytest.raises(ValueError, pstokes._combine_pol, uvd1, uvd2, 'XX', 1)
 
     def test_construct_pstokes(self):
         uvd1 = self.uvd1


### PR DESCRIPTION
This PR introduces some changes to the `pstokes` module for two purposes
1. Take into account the new `pol_convention` attribute of `UVData` objects (see this [PR](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/pull/1455)) when constructing pseudo-Stokes polarizations whilst ensuring backwards compatibility (if there is no `pol_convention`, then there is a warning and `avg` is assumed). This is commit [6ffd0dc](https://github.com/HERA-Team/hera_pspec/pull/404/commits/6ffd0dcc6143fe9ac12021dab97556aa5c284c05).
2. As per @jsdillon's request, create a new method called `_combine_pol_arrays` (final name still open to debate) which takes lists of data, flags, and nsamples arrays and combines them into pseudo-Stokes following the appropriate `pol_convention` (i.e. `avg` and `sum`). Although I see how useful this method can be, it does make the code slightly heavy so, reviewers, please let me know if you have any suggestions on how to make things cleaner. This is commit [2601670](https://github.com/HERA-Team/hera_pspec/pull/404/commits/2601670b3d8f17ea2d5c3e73408a683c16d69327).
I added new tests and modified existing ones accordingly.