### PR TITLE
Get rid of future_array_shapes in PSpecBeam

### DIFF
--- a/hera_pspec/pspecbeam.py
+++ b/hera_pspec/pspecbeam.py
@@ -415,10 +415,9 @@ class PSpecBeamUV(PSpecBeamBase):
         # setup uvbeam object
         if isinstance(uvbeam, str):
             uvb = UVBeam()
-            uvb.read_beamfits(uvbeam, use_future_array_shapes=True)
+            uvb.read_beamfits(uvbeam)
         else:
             uvb = uvbeam
-            uvb.use_future_array_shapes()
 
         # get frequencies and set cosmology
         self.beam_freqs = uvb.freq_array


### PR DESCRIPTION
Just getting rid of reference to future_array_shapes in PSpecBeam since this is no longer a thing in pyuvdata and it holds up some of the analysis notebooks. I did not check anywhere else for where this might cause us problems.