### PR TITLE
Use only other nsamples from the same basetime/time/spw to fill in zeros in variance_from_auto_correlations()

### DIFF
--- a/hera_pspec/utils.py
+++ b/hera_pspec/utils.py
@@ -84,6 +84,8 @@ def variance_from_auto_correlations(uvd, bl, spw_range, time_index):
     $C_{ii}(b, LST) = | V(b_alpha, LST, nu_i) V(b_beta, LST, nu_i) | / {B Delta_t},
     where $b_alpha = (alpha,alpha)$ and $b_beta = (beta,beta)$.
     With LST binned over days, we have $C_{ii}(b, LST) = |V(b_alpha,nu_i,t) V(b_beta, nu_i,t)| / {N_{samples} B Delta_t}$.
+    Wherever nsamples is zero, we assign the median nsamples within the spectral window for that time index and that baseline.
+    If all nsamples are zero, we set the variance to be np.inf.
 
     Parameters
     ----------

--- a/hera_pspec/utils.py
+++ b/hera_pspec/utils.py
@@ -116,10 +116,10 @@ def variance_from_auto_correlations(uvd, bl, spw_range, time_index):
     x_bl1 = uvd.get_data(bl1)[time_index, spw]
     x_bl2 = uvd.get_data(bl2)[time_index, spw]
     nsample_bl = uvd.get_nsamples(bl)[time_index, spw]
-    nsample_bl = np.where(nsample_bl > 0, nsample_bl, np.median(nsample_bl[nsample_bl > 0]))
+    nsample_bl = np.where(nsample_bl > 0, nsample_bl, (np.median(nsample_bl[nsample_bl > 0]) if np.any(nsample_bl > 0) else 0))
     df = np.array(uvd.channel_width)[spw]
     # some impainted data have zero nsample while is not flagged, and they will be assigned the median nsample within the spectral window.
-    var = np.abs(x_bl1*x_bl2.conj()) / dt / df / nsample_bl
+    var = np.where(nsample_bl == 0, np.inf, np.abs(x_bl1*x_bl2.conj()) / dt / df / nsample_bl)
 
     return var
 

--- a/hera_pspec/utils.py
+++ b/hera_pspec/utils.py
@@ -116,7 +116,7 @@ def variance_from_auto_correlations(uvd, bl, spw_range, time_index):
     x_bl1 = uvd.get_data(bl1)[time_index, spw]
     x_bl2 = uvd.get_data(bl2)[time_index, spw]
     nsample_bl = uvd.get_nsamples(bl)[time_index, spw]
-    nsample_bl = np.where(nsample_bl>0, nsample_bl, np.median(uvd.nsample_array[:, spw, :]))
+    nsample_bl = np.where(nsample_bl > 0, nsample_bl, np.median(nsample_bl[nsample_bl > 0]))
     df = np.array(uvd.channel_width)[spw]
     # some impainted data have zero nsample while is not flagged, and they will be assigned the median nsample within the spectral window.
     var = np.abs(x_bl1*x_bl2.conj()) / dt / df / nsample_bl


### PR DESCRIPTION
This PR was made in response to @RajorshiSChandra's question in the May 28 pspec telecon.