### PR TITLE
Changed kpara binning to sample exact delays

### DIFF
--- a/hera_pspec/uvwindow.py
+++ b/hera_pspec/uvwindow.py
@@ -748,10 +748,10 @@ class UVWindow:
 
         # define default kperp bins,
         dk_para = self.cosmo.tau_to_kpara(avg_z, little_h=self.little_h)\
-            / (abs(freq_array[-1]-freq_array[0]))
+            * np.diff(dly_array)[0]
         kpara_max = self.cosmo.tau_to_kpara(avg_z, little_h=self.little_h)\
             * abs(dly_array).max()+10.*dk_para
-        kpara_bin_edges = np.arange(dk_para, kpara_max, step=dk_para)
+        kpara_bin_edges = np.arange(dk_para/2., kpara_max, step=dk_para)
         kpara_bins = (kpara_bin_edges[1:]+kpara_bin_edges[:-1])/2
         nbins_kpara = kpara_bins.size
 


### PR DESCRIPTION
@adeliegorce has made these changes so that the k_para binning for the exact window function aligns with the delay sampling. 

After this PR:
<img width="665" alt="Screenshot 2025-06-12 at 18 03 48" src="https://github.com/user-attachments/assets/4f924859-929d-4162-b690-e917025c1b7d" />

Before:
<img width="664" alt="Screenshot 2025-06-12 at 18 04 01" src="https://github.com/user-attachments/assets/595fb51a-565d-4cf7-b911-5cc0d8dd617f" />
