### PR TITLE
fix: Ntimes is now the same as Ntpairs

### DIFF
--- a/hera_pspec/grouping.py
+++ b/hera_pspec/grouping.py
@@ -179,6 +179,11 @@ def average_spectra(uvp_in, blpair_groups=None, time_avg=False,
     add_to_history : str, optional
         Added text to add to file history.
 
+    time_tol : float, optional
+        The tolerance for checking if times are equivalent, in order to count
+        "unique" time-pairs in the average. The units are (julian) days. Setting too
+        low can result in numerical noise creating more time-pairs than expected.
+
     Notes
     -----
     Currently, every baseline-pair in a blpair group must have the same
@@ -591,7 +596,7 @@ def average_spectra(uvp_in, blpair_groups=None, time_avg=False,
 
 
 def spherical_average(uvp_in, kbins, bin_widths, blpair_groups=None, time_avg=False, blpair_weights=None,
-                      weight_by_cov=False, error_weights=None,
+                      weight_by_cov=False, error_weights=None, time_tol: float = 1e-6,
                       add_to_history='', little_h=True, A={}, run_check=True):
     """
     Perform a spherical average of a UVPSpec, mapping k_perp & k_para onto a |k| grid.
@@ -641,6 +646,11 @@ def spherical_average(uvp_in, kbins, bin_widths, blpair_groups=None, time_avg=Fa
     run_check : bool, optional
         If True, run UVPSpec.check() on resultant object
 
+    time_tol : float, optional
+        The tolerance for checking if times are equivalent, in order to count
+        "unique" time-pairs in the average. The units are (julian) days. Setting too
+        low can result in numerical noise creating more time-pairs than expected.
+        
     Returns
     --------
     UVPSpec object
@@ -683,6 +693,7 @@ def spherical_average(uvp_in, kbins, bin_widths, blpair_groups=None, time_avg=Fa
     # perform time and cylindrical averaging upfront if requested
     if not uvp.exact_windows and (blpair_groups is not None or time_avg):
         uvp.average_spectra(blpair_groups=blpair_groups, time_avg=time_avg,
+                            time_tol=time_tol,
                             blpair_weights=blpair_weights, error_weights=error_weights,
                             inplace=True)
 
@@ -948,7 +959,7 @@ def spherical_average(uvp_in, kbins, bin_widths, blpair_groups=None, time_avg=Fa
 def spherical_wf_from_uvp(uvp_in, kbins, bin_widths,
                           blpair_groups=None, blpair_lens=None, blpair_weights=None,
                           error_weights=None, time_avg=False, spw_array=None,
-                          little_h=True, verbose=False):
+                          little_h=True, verbose=False, time_tol: float=1e-6):
     
     """
     Obtains exact spherical window functions from an UVPspec object,
@@ -995,6 +1006,11 @@ def spherical_wf_from_uvp(uvp_in, kbins, bin_widths,
         If True, print progress, warnings and debugging info to stdout.
         If None, value used is the class attribute.
 
+    time_tol : float, optional
+        The tolerance for checking if times are equivalent, in order to count
+        "unique" time-pairs in the average. The units are (julian) days. Setting too
+        low can result in numerical noise creating more time-pairs than expected.
+        
     Returns
     --------
     wf_spherical : array
@@ -1079,6 +1095,7 @@ def spherical_wf_from_uvp(uvp_in, kbins, bin_widths,
                         blpair_weights=blpair_weights,
                         error_weights=error_weights,
                         time_avg=time_avg,
+                        time_tol=time_tol,
                         inplace=True)
 
     # initialize blank arrays and dicts

--- a/hera_pspec/grouping.py
+++ b/hera_pspec/grouping.py
@@ -103,7 +103,8 @@ def sample_baselines(bls, seed=None):
 def average_spectra(uvp_in, blpair_groups=None, time_avg=False,
                     blpair_weights=None, error_field=None,
                     error_weights=None, normalize_weights=True,
-                    inplace=True, add_to_history=''):
+                    inplace=True, add_to_history='',
+                    time_tol: float = 1e-6):
     """
     Average power spectra across the baseline-pair-time axis, weighted by
     each spectrum's integration time or a specified kind of error bars.
@@ -540,12 +541,12 @@ def average_spectra(uvp_in, blpair_groups=None, time_avg=False,
                         for bl in bl_arr])
 
     # Assign arrays and metadata to UVPSpec object
-    uvp.Ntimes = len(np.unique(np.hstack([time_1, time_2])))
     uvp.Nbltpairs = len(time_avg_arr)
     uvp.Nblpairs = len(np.unique(blpair_arr))
     uvp.Nbls = len(bl_arr)
-    uvp.Ntpairs = len(set((t1, t2) for t1, t2 in zip(time_1, time_2)))
-
+    uvp.Ntpairs = len(set((np.round(t1/time_tol,0), np.round(t2/time_tol, 0)) for t1, t2 in zip(time_1, time_2)))
+    uvp.Ntimes = uvp.Ntpairs
+    
     # Baselines
     uvp.bl_array = bl_arr
     uvp.bl_vecs = bl_vecs

--- a/hera_pspec/pspecbeam.py
+++ b/hera_pspec/pspecbeam.py
@@ -5,7 +5,7 @@ from scipy.interpolate import interp1d
 from pyuvdata import UVBeam, utils as uvutils
 import uvtools.dspec as dspec
 from collections import OrderedDict as odict
-
+from pathlib import Path
 
 from . import conversions as conversions, uvpspec_utils as uvputils
 
@@ -413,7 +413,7 @@ class PSpecBeamUV(PSpecBeamBase):
             specified. Default: None.
         """
         # setup uvbeam object
-        if isinstance(uvbeam, str):
+        if isinstance(uvbeam, str | Path):
             uvb = UVBeam()
             uvb.read_beamfits(uvbeam)
         else:

--- a/hera_pspec/uvpspec.py
+++ b/hera_pspec/uvpspec.py
@@ -2133,7 +2133,7 @@ class UVPSpec(object):
 
     def average_spectra(self, blpair_groups=None, time_avg=False,
                         blpair_weights=None, error_field=None, error_weights=None,
-                        inplace=True, add_to_history=''):
+                        inplace=True, add_to_history='', time_tol: float=1e-6):
         """
         Average power spectra across the baseline-pair-time axis, weighted by
         each spectrum's integration time.
@@ -2207,6 +2207,11 @@ class UVPSpec(object):
         add_to_history : str, optional
             Added text to add to file history.
 
+        time_tol : float, optional
+            The tolerance for checking if times are equivalent, in order to count
+            "unique" time-pairs in the average. The units are (julian) days. Setting too
+            low can result in numerical noise creating more time-pairs than expected.
+
         Notes
         -----
         Currently, every baseline-pair in a blpair group must have the same
@@ -2215,25 +2220,21 @@ class UVPSpec(object):
         the scenario of repeated blpairs (e.g. in bootstrapping), which will
         return multiple copies of their time_array.
         """
-        if inplace:
-            grouping.average_spectra(self,
-                                     blpair_groups=blpair_groups,
-                                     time_avg=time_avg,
-                                     error_field=error_field,
-                                     error_weights=error_weights,
-                                     blpair_weights=blpair_weights,
-                                     inplace=True,
-                                     add_to_history=add_to_history)
-        else:
-            return grouping.average_spectra(self,
-                                            blpair_groups=blpair_groups,
-                                            time_avg=time_avg,
-                                            error_field=error_field,
-                                            error_weights=error_weights,
-                                            blpair_weights=blpair_weights,
-                                            inplace=False,
-                                            add_to_history=add_to_history)
+        result = grouping.average_spectra(
+            self,
+            blpair_groups=blpair_groups,
+            time_avg=time_avg,
+            error_field=error_field,
+            error_weights=error_weights,
+            blpair_weights=blpair_weights,
+            inplace=inplace,
+            add_to_history=add_to_history,
+            time_tol=time_tol,
+        )
 
+        if not inplace:
+            return result
+        
     def fold_spectra(self):
         """
         Average bandpowers from matching positive and negative delay bins onto a

--- a/hera_pspec/uvpspec.py
+++ b/hera_pspec/uvpspec.py
@@ -27,7 +27,7 @@ class UVPSpec(object):
         """
         # Summary attributes
         # Note that in the past (pre-v0.5) Ntimes was the number of unique times in 
-        # either of the underlying visibilitydatasets (i.e. time_1_array and time_2_array),
+        # the union of the underlying visibility datasets (i.e. time_1_array and time_2_array),
         # however throughout the code it was often assumed to mean the number of unique
         # time-pairs (i.e. how many distinct average times there are in the data), which
         # is really Ntpairs. In fact, there's never a situation in which you would need

--- a/hera_pspec/uvpspec_utils.py
+++ b/hera_pspec/uvpspec_utils.py
@@ -472,6 +472,7 @@ def _get_blpairs_from_bls(uvp, bls, only_pairs_in_bls=False):
     if only_pairs_in_bls:
         blp_select = np.array( [bool((blp[0] in bls) * (blp[1] in bls))
                                 for blp in blpair_bls] )
+        
     else:
         blp_select = np.array( [bool((blp[0] in bls) + (blp[1] in bls))
                                 for blp in blpair_bls] )
@@ -576,6 +577,8 @@ def _select(uvp, spws=None, bls=None, only_pairs_in_bls=False, blpairs=None,
         # if fed as list of tuples, convert to integers
         if isinstance(blpairs[0], tuple):
             blpairs = [uvp.antnums_to_blpair(blp) for blp in blpairs]
+        print("blps:", blpairs)
+        print("blpair_array:", uvp.blpair_array)
         blpair_select = np.logical_or.reduce(
                                    [uvp.blpair_array == blp for blp in blpairs])
         blp_select += blpair_select
@@ -621,10 +624,11 @@ def _select(uvp, spws=None, bls=None, only_pairs_in_bls=False, blpairs=None,
         uvp.lst_1_array = uvp.lst_1_array[blp_select]
         uvp.lst_2_array = uvp.lst_2_array[blp_select]
         uvp.lst_avg_array = uvp.lst_avg_array[blp_select]
-        uvp.Ntimes = len(np.unique(uvp.time_avg_array))
+        uvp.Ntpairs = len(np.unique(uvp.time_avg_array))
         uvp.Nblpairs = len(np.unique(uvp.blpair_array))
         uvp.Nbltpairs = len(uvp.blpair_array)
-
+        uvp.Ntimes = uvp.Ntpairs
+        
         # Calculate unique baselines from new blpair_array
         new_blpairs = np.unique(uvp.blpair_array)
         bl1 = np.floor(new_blpairs / 1e6)

--- a/hera_pspec/uvwindow.py
+++ b/hera_pspec/uvwindow.py
@@ -425,7 +425,7 @@ class UVWindow:
                     ftbeam_obj_pol.append(FTBeam.from_beam(beamfile='tbd',
                                                            verbose=verbose,
                                                            x_orientation=x_orientation))
-                elif isinstance(ftbeam, str):
+                elif isinstance(ftbeam, str | Path):
                     ftbeam_obj_pol.append(FTBeam.from_file(f'{ftbeam}_{pol}.hdf5',
                                                            spw_range=None,
                                                            verbose=verbose,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ tests = [
     "coverage>=4.5.1",
     "pytest>=3.5.1",
     "pytest-cov>=2.5.1",
+    "pytest-cases",
 ]
 dev = [
     "hera_pspec[doc,tests]",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,62 @@
+import pytest
+from hera_pspec.testing import build_vanilla_uvpspec
+from hera_pspec import UVPSpec, PSpecData, utils
+from hera_pspec import PSpecBeamUV
+from pathlib import Path
+from hera_pspec.data import DATA_PATH
+from pyuvdata import UVData
+import copy
+
+DATA_PATH = Path(DATA_PATH)
+
+@pytest.fixture(scope="session")
+def beam_nf_dipole() -> PSpecBeamUV:
+    beamfile = DATA_PATH / 'HERA_NF_dipole_power.beamfits'
+    return PSpecBeamUV(beamfile)
+        
+@pytest.fixture(scope="session")
+def vanilla_uvp() -> UVPSpec:
+    return build_vanilla_uvpspec(equal_time_arrays=True)[0]
+
+@pytest.fixture(scope="session")
+def vanilla_uvp_with_beam(beam_nf_dipole: PSpecBeamUV) -> UVPSpec:
+    return build_vanilla_uvpspec(beam=beam_nf_dipole)[0]
+
+@pytest.fixture(scope="session")
+def vanilla_uvp_alternating_times(beam_nf_dipole: PSpecBeamUV) -> UVPSpec:
+    """A UVPSpec with alternating times."""
+    return build_vanilla_uvpspec(equal_time_arrays=False, beam=beam_nf_dipole)[0]
+    
+@pytest.fixture(scope="session")
+def uvp_example_data() -> UVPSpec:
+    # obtain uvp object
+    datafile = DATA_PATH / 'zen.2458116.31939.HH.uvh5'
+
+    # read datafile
+    uvd = UVData.from_file(datafile)
+    # Create a new PSpecData objec
+    ds = PSpecData(dsets=[uvd, uvd], wgts=[None, None])
+
+    # choose baselines
+    baselines1, baselines2, blpairs = utils.construct_blpairs(
+        uvd.get_antpairs()[1:],
+        exclude_permutations=False,
+        exclude_auto_bls=True
+    )
+    # compute ps
+    return ds.pspec(
+        baselines1, baselines2, dsets=(0, 1), pols=[('xx','xx')], 
+        spw_ranges=(175, 195), taper='bh',verbose=False
+    )
+    
+@pytest.fixture(scope="session")
+def uvp_exact_wfs(uvp_example_data) -> UVPSpec:
+    uvp = copy.deepcopy(uvp_example_data)
+    ft_file = DATA_PATH / 'FT_beam_HERA_dipole_test'
+    
+    uvp.get_exact_window_functions(ftbeam=ft_file, inplace=True)
+    uvp.check()
+    return uvp
+
+
+    

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,8 @@
+"""Pytest configuration and fixtures for tests.
+
+This adds several mock UVPSpec objects that can be used throughout the tests.
+"""
+
 import pytest
 from hera_pspec.testing import build_vanilla_uvpspec
 from hera_pspec import UVPSpec, PSpecData, utils

--- a/tests/test_grouping.py
+++ b/tests/test_grouping.py
@@ -1,4 +1,3 @@
-import unittest
 import pytest
 import numpy as np
 import os


### PR DESCRIPTION
I updated the code so that `uvp.Ntimes` is no longer the number of unique times within both the `time_1_array` and `time_2_array`, but instead reflects what most people expect of it -- the number of unique *time-pairs* (i.e. the same as `Ntpairs`). 

I updated the docstring to reflect this, as well as updating a few of the existing functions that set `Ntimes` to be the set of unique times in the underlying visibilities:

* `combine_uvpspec`
* `read_hd5f_group`
* `average_spectra`

Note that in the code, several places already assumed that `Ntimes` referred to the number of time-pairs, not the number of unique times of the underlying visibilities, for example:

* `uvpspec_utils._select`
* Several of the tutorial notebooks
* Window functions

This standardizes the usage across the repo.

I also added a number of new test cases, especially within `test_uvpspec`, including test cases that would have failed before I made these updates (since the `build_vanilla_uvp` function always output pspec objects where `time_1_array` and `time_2_array` were equal, now I have made cases where they are not). 