### PR TITLE
Handling non-square window functions

### DIFF
--- a/hera_pspec/grouping.py
+++ b/hera_pspec/grouping.py
@@ -411,7 +411,7 @@ def average_spectra(uvp_in, blpair_groups=None, time_avg=False,
                             if uvp.exact_windows:
                                 window_function = (np.sum(window_function * w[:, :, None, None], axis=0)\
                                                     / (wsum)[:, None, None])[None]
-                            if not uvp.exact_windows:
+                            else:
                                 window_function = (np.sum(window_function * w[:, :, None], axis=0) \
                                                    / (wsum)[:, None])[None]
                         if store_cov:
@@ -677,7 +677,7 @@ def spherical_average(uvp_in, kbins, bin_widths, blpair_groups=None, time_avg=Fa
         bin_widths = np.ones_like(kbins) * bin_widths
 
     # copy input
-    uvp = copy.deepcopy(uvp_in) 
+    uvp = copy.deepcopy(uvp_in)
 
     # transform kgrid to little_h units
     if not little_h:
@@ -724,6 +724,8 @@ def spherical_average(uvp_in, kbins, bin_widths, blpair_groups=None, time_avg=Fa
 
         # setup arrays with delays in them
         Ndlys = spw_range[3]
+        Nfreqs = spw_range[2]
+        # check if object has been delay-averaged
         Ndlyblps = Ndlys * uvp.Nblpairs
         data_array[spw] = np.zeros((uvp.Ntimes, Ndlyblps, uvp.Npols), dtype=np.complex128)
         if store_cov:
@@ -736,21 +738,25 @@ def spherical_average(uvp_in, kbins, bin_widths, blpair_groups=None, time_avg=Fa
             if uvp.exact_windows:
                 window_function_array[spw] = np.zeros((uvp.Ntimes, Nk, Nk, uvp.Npols), dtype=np.float64)
             else:
-                window_function_array[spw] = np.zeros((uvp.Ntimes, Ndlyblps, Ndlyblps, uvp.Npols), dtype=np.float64)
+                window_function_array[spw] = np.zeros((uvp.Ntimes, Ndlys * uvp.Nblpairs, Nfreqs * uvp.Nblpairs, uvp.Npols), dtype=np.float64)
 
         # setup the design matrix: P_cyl = A P_sph
         A[spw] = np.zeros((uvp.Ntimes, Ndlyblps, Nk, uvp.Npols), dtype=np.float64)
-
+        if uvp.delay_avg:
+            # need a design matrix per frequency
+            A2 = np.zeros((uvp.Ntimes, Nfreqs*uvp.Nblpairs, Nk, uvp.Npols), dtype=np.float64)
         # setup weighting matrix: block diagonal for each Ndly x Ndly
         # we can represent the Ndlyblps x Ndlyblps block diagonal matrix as Ndlyblps x Ndlys
         E = np.zeros((uvp.Ntimes, Ndlyblps, Ndlys, uvp.Npols), dtype=np.float64)
-
 
         # get kperps for this spw: shape (Nbltpairs,)
         kperps = uvp.get_kperps(spw, little_h=True)
 
         # get kparas for this spw: shape (Ndlys,)
         kparas = uvp.get_kparas(spw, little_h=True)
+        if uvp.delay_avg:
+            all_dlys = utils.get_delays(uvp.freq_array[uvp.spw_to_freq_indices(spw)])
+            kparas_per_freq = uvp.get_kparas(spw, little_h=True, dlys=all_dlys)
 
         # get k to tau mapping for this spw
         avgz = uvp.cosmo.f2z(np.mean(uvp.freq_array[uvp.spw_to_freq_indices(spw)]))
@@ -781,12 +787,16 @@ def spherical_average(uvp_in, kbins, bin_widths, blpair_groups=None, time_avg=Fa
             # get Ndlyblps slice
             dstart, dstop = Ndlys * b, Ndlys * (b + 1)
             dslice = slice(dstart, dstop)
+            if uvp.delay_avg:
+                dslice_freq = slice(Nfreqs * b, Nfreqs * (b + 1))
+            else:
+                dslice_freq = dslice
 
             # store data
             data_array[spw][:, dslice] = uvp.data_array[spw][blpt_inds]
 
             if store_window and not uvp.exact_windows:
-                window_function_array[spw][:, dslice, dslice] = uvp.window_function_array[spw][blpt_inds]
+                window_function_array[spw][:, dslice, dslice_freq] = uvp.window_function_array[spw][blpt_inds]
 
             if store_stats:
                 for stat in stats_array:
@@ -833,6 +843,22 @@ def spherical_average(uvp_in, kbins, bin_widths, blpair_groups=None, time_avg=Fa
                 # populate A matrix
                 A[spw][:, i + Ndlys * b, kind, :] = 1.0
 
+            if uvp.delay_avg:
+                # get k magnitude of data: (Ndlys,)
+                kmags_per_freq = np.sqrt(kperps[blpt_inds][0]**2 + kparas_per_freq**2)
+                for i, kmag in enumerate(kmags_per_freq):
+                    kind = (kbin_left < kmag) & (kbin_right >= kmag)
+
+                    if not np.any(kind):
+                        # skip if not in any kbins
+                        continue
+                    else:
+                        # convert kind into an integer for indexing
+                        kind = np.where(kind)[0][0]
+
+                    # populate A matrix
+                    A2[:, i + Nfreqs * b, kind, :] = 1.0
+
         # normalize metadata sums
         wgt_array[spw] /= np.max(wgt_array[spw], axis=(2, 3), keepdims=True).clip(1e-40, np.inf)
         integration_array[spw] /= np.trace(E.real, axis1=1, axis2=2).clip(1e-40, np.inf)
@@ -869,7 +895,11 @@ def spherical_average(uvp_in, kbins, bin_widths, blpair_groups=None, time_avg=Fa
             # bin window function: W_sph = H.T W_cyl A
             # wm shape (Npols, Ntimes, Ndlyblps, Ndlyblps)
             wm = np.moveaxis(window_function_array[spw], -1, 0)
-            wm = Ht @ wm @ Am
+            if uvp.delay_avg:
+                Am2 = np.moveaxis(A2, -1, 0)
+                wm = Ht @ wm @ Am2
+            else:
+                wm = Ht @ wm @ Am
             window_function_array[spw] = np.moveaxis(wm, 0, -1)
 
         if store_stats:
@@ -1049,7 +1079,7 @@ def spherical_wf_from_uvp(uvp_in, kbin_edges, kbin_edges_in=None,
     # ensure bins don't overlap
     assert np.all(np.diff(kbin_edges) > 0), "kbins must not overlap"
     assert np.all(np.diff(kbin_edges_in) > 0), "kbins_in must not overlap"
-    
+
     # copy input
     uvp = copy.deepcopy(uvp_in) 
 
@@ -1071,7 +1101,7 @@ def spherical_wf_from_uvp(uvp_in, kbin_edges, kbin_edges_in=None,
             # get baseline length for each group of baseline pairs
             # assuming only redundant baselines are paired together
             blpair_lens, _ = utils.get_bl_lens_angs(blvecs_groups, bl_error_tol=1.)
-        else:     
+        else:
             # ensure consistency between inputs
             assert len(blpair_groups)==len(blpair_lens), "Baseline-pair groups" \
                         " are inconsistent with baseline lengths"
@@ -1171,13 +1201,13 @@ def fold_spectra(uvp):
         UVPSpec object to be folded.
     """
     # assert folded is False
-    assert uvp.folded == False, "cannot fold power spectra if uvp.folded == True"
+    assert uvp.folded is False, "cannot fold power spectra if uvp.folded is True"
     store_cov = hasattr(uvp, "cov_array_real")
     # Iterate over spw
     for spw in range(uvp.Nspws):
 
         # get number of dly bins
-        Ndlys = len(uvp.get_dlys(spw))
+        Ndlys = uvp.data_array[spw].shape[1]
 
         # This section could be streamlined considerably since there is a lot of
         # code overlap between the even and odd Ndlys cases.
@@ -1190,7 +1220,7 @@ def fold_spectra(uvp):
             uvp.data_array[spw][:, :Ndlys//2, :] = 0.0
             uvp.nsample_array[spw] *= 2.0
             if hasattr(uvp, 'window_function_array'):
-                if uvp.exact_windows:
+                if uvp.exact_windows or uvp.delay_avg:
                     left = uvp.window_function_array[spw][:, 1:Ndlys//2, ...][:, ::-1, ...]
                     right = uvp.window_function_array[spw][:, Ndlys//2+1: , ...]
                     uvp.window_function_array[spw][:, Ndlys//2+1:, ...] = .50*(left+right)
@@ -1206,7 +1236,7 @@ def fold_spectra(uvp):
                     uvp.window_function_array[spw][:, :, :Ndlys//2, :] = 0.0
                 uvp.window_function_array[spw][:, :Ndlys//2, ...] = 0.0
             # fold covariance array if it exists.
-            if hasattr(uvp,'cov_array_real'):
+            if hasattr(uvp, 'cov_array_real'):
                 leftleft = uvp.cov_array_real[spw][:, 1:Ndlys//2, 1:Ndlys//2, :][:, ::-1, ::-1, :]
                 leftright = uvp.cov_array_real[spw][:, 1:Ndlys//2, Ndlys//2+1:, :][:, ::-1, :, :]
                 rightleft = uvp.cov_array_real[spw][:, Ndlys//2+1: , 1:Ndlys//2, :][:, :, ::-1, :]
@@ -1245,7 +1275,7 @@ def fold_spectra(uvp):
             uvp.data_array[spw][:, :Ndlys//2, :] = 0.0
             uvp.nsample_array[spw] *= 2.0
             if hasattr(uvp, 'window_function_array'):
-                if uvp.exact_windows:
+                if uvp.exact_windows or uvp.delay_avg:
                     left = uvp.window_function_array[spw][:, :Ndlys//2, ...][:, ::-1, ...]
                     right = uvp.window_function_array[spw][:, Ndlys//2+1: , ...]
                     uvp.window_function_array[spw][:, Ndlys//2+1:, ...] = .50*(left+right)
@@ -1842,8 +1872,8 @@ def _get_delay_slices(
     )
 
 def average_in_delay_bins(
-    uvp, 
-    kernel: np.ndarray, 
+    uvp,
+    kernel: np.ndarray,
     cov_weighted_stats: tuple[str] = ("P_N", "P_SN"),
     zero_bin_kernel: np.ndarray = np.ones(1),
 ):
@@ -1942,8 +1972,8 @@ def average_in_delay_bins(
 
     dly_array = []
     spw_dly_array = []
-    for spw in uvp.spw_array:   
-        
+    for spw in uvp.spw_array:
+
         p = uvp.data_array[spw]
         dly = uvp.get_dlys(spw)
         slices, kernels = _get_delay_slices(dly, kernel=kernel, zero_kernel=zero_bin_kernel)
@@ -1999,5 +2029,6 @@ def average_in_delay_bins(
     new_uvp.dly_array = np.concatenate(dly_array)
     new_uvp.spw_dly_array = np.concatenate(spw_dly_array)
     new_uvp.Nspwdlys = len(new_uvp.dly_array)
+    new_uvp.delay_avg = True
 
     return new_uvp

--- a/hera_pspec/grouping.py
+++ b/hera_pspec/grouping.py
@@ -998,6 +998,7 @@ def spherical_average(uvp_in, kbins, bin_widths, kbins_theory=None, blpair_group
 
     return uvp
 
+
 def spherical_wf_from_uvp(uvp_in, kbin_edges, kbin_edges_theory=None,
                           blpair_groups=None, blpair_lens=None, blpair_weights=None,
                           error_weights=None, time_avg=False, spw_array=None,
@@ -1221,7 +1222,6 @@ def fold_spectra(uvp):
 
         # get number of dly bins
         Ndlys = uvp.data_array[spw].shape[1]
-
         # This section could be streamlined considerably since there is a lot of
         # code overlap between the even and odd Ndlys cases.
 
@@ -1233,20 +1233,20 @@ def fold_spectra(uvp):
             uvp.data_array[spw][:, :Ndlys//2, :] = 0.0
             uvp.nsample_array[spw] *= 2.0
             if hasattr(uvp, 'window_function_array'):
-                if uvp.exact_windows or uvp.delays_are_binned:
+                Nkpar = uvp.window_function_array[spw].shape[2]
+                first_kpar = 1 if Nkpar % 2 == 0 else 0
+                if uvp.exact_windows:
                     left = uvp.window_function_array[spw][:, 1:Ndlys//2, ...][:, ::-1, ...]
-                    right = uvp.window_function_array[spw][:, Ndlys//2+1: , ...]
+                    right = uvp.window_function_array[spw][:, Ndlys//2+1:, ...]
                     uvp.window_function_array[spw][:, Ndlys//2+1:, ...] = .50*(left+right)
                 else:
-                    leftleft = uvp.window_function_array[spw][:, 1:Ndlys//2, 1:Ndlys//2, :][:, ::-1, ::-1, :]
-                    leftright = uvp.window_function_array[spw][:, 1:Ndlys//2, Ndlys//2+1:, :][:, ::-1, :, :]
-                    rightleft = uvp.window_function_array[spw][:, Ndlys//2+1: , 1:Ndlys//2, :][:, :, ::-1, :]
-                    rightright = uvp.window_function_array[spw][:, Ndlys//2+1:, Ndlys//2+1:, :]
-                    uvp.window_function_array[spw][:, Ndlys//2+1:, Ndlys//2+1:, :] = .25*(leftleft\
-                                                                                     +leftright\
-                                                                                     +rightleft\
-                                                                                     +rightright)
-                    uvp.window_function_array[spw][:, :, :Ndlys//2, :] = 0.0
+                    leftleft = uvp.window_function_array[spw][:, 1:Ndlys//2, first_kpar:Nkpar//2, :][:, ::-1, ::-1, :]
+                    leftright = uvp.window_function_array[spw][:, 1:Ndlys//2, Nkpar//2+1:, :][:, ::-1, :, :]
+                    rightleft = uvp.window_function_array[spw][:, Ndlys//2+1:, first_kpar:Nkpar//2, :][:, :, ::-1, :]
+                    rightright = uvp.window_function_array[spw][:, Ndlys//2+1:, Nkpar//2+1:, :]
+                    uvp.window_function_array[spw][:, Ndlys//2+1:, Nkpar//2+1:, :] = .25 *\
+                        (leftleft + leftright + rightleft + rightright)
+                    uvp.window_function_array[spw][:, :, :Nkpar//2, :] = 0.0
                 uvp.window_function_array[spw][:, :Ndlys//2, ...] = 0.0
             # fold covariance array if it exists.
             if hasattr(uvp, 'cov_array_real'):
@@ -1254,21 +1254,17 @@ def fold_spectra(uvp):
                 leftright = uvp.cov_array_real[spw][:, 1:Ndlys//2, Ndlys//2+1:, :][:, ::-1, :, :]
                 rightleft = uvp.cov_array_real[spw][:, Ndlys//2+1: , 1:Ndlys//2, :][:, :, ::-1, :]
                 rightright = uvp.cov_array_real[spw][:, Ndlys//2+1:, Ndlys//2+1:, :]
-                uvp.cov_array_real[spw][:, Ndlys//2+1:, Ndlys//2+1:, :] = .25*(leftleft\
-                                                                         +leftright\
-                                                                         +rightleft\
-                                                                         +rightright)
+                uvp.cov_array_real[spw][:, Ndlys//2+1:, Ndlys//2+1:, :] = .25 * \
+                    (leftleft + leftright + rightleft + rightright)
                 uvp.cov_array_real[spw][:, :Ndlys//2, :, :] = 0.0
-                uvp.cov_array_real[spw][:, :, :Ndlys//2, : :] = 0.0
+                uvp.cov_array_real[spw][:, :, :Ndlys//2, :] = 0.0
 
                 leftleft = uvp.cov_array_imag[spw][:, 1:Ndlys//2, 1:Ndlys//2, :][:, ::-1, ::-1, :]
                 leftright = uvp.cov_array_imag[spw][:, 1:Ndlys//2, Ndlys//2+1:, :][:, ::-1, :, :]
-                rightleft = uvp.cov_array_imag[spw][:, Ndlys//2+1: , 1:Ndlys//2, :][:, :, ::-1, :]
+                rightleft = uvp.cov_array_imag[spw][:, Ndlys//2+1:, 1:Ndlys//2, :][:, :, ::-1, :]
                 rightright = uvp.cov_array_imag[spw][:, Ndlys//2+1:, Ndlys//2+1:, :]
-                uvp.cov_array_imag[spw][:, Ndlys//2+1:, Ndlys//2+1:, :] = .25*(leftleft\
-                                                                         +leftright\
-                                                                         +rightleft\
-                                                                         +rightright)
+                uvp.cov_array_imag[spw][:, Ndlys//2+1:, Ndlys//2+1:, :] = .25 * \
+                    (leftleft + leftright + rightleft + rightright)
                 uvp.cov_array_imag[spw][:, :Ndlys//2, :, :] = 0.0
                 uvp.cov_array_imag[spw][:, :, :Ndlys//2, : :] = 0.0
 
@@ -1288,45 +1284,41 @@ def fold_spectra(uvp):
             uvp.data_array[spw][:, :Ndlys//2, :] = 0.0
             uvp.nsample_array[spw] *= 2.0
             if hasattr(uvp, 'window_function_array'):
-                if uvp.exact_windows or uvp.delays_are_binned:
+                Nkpar = uvp.window_function_array[spw].shape[2]
+                first_kpar = 1 if Nkpar % 2 == 0 else 0
+                if uvp.exact_windows:
                     left = uvp.window_function_array[spw][:, :Ndlys//2, ...][:, ::-1, ...]
-                    right = uvp.window_function_array[spw][:, Ndlys//2+1: , ...]
+                    right = uvp.window_function_array[spw][:, Ndlys//2+1:, ...]
                     uvp.window_function_array[spw][:, Ndlys//2+1:, ...] = .50*(left+right)
                 else:
-                    leftleft = uvp.window_function_array[spw][:, :Ndlys//2, :Ndlys//2, :][:, ::-1, ::-1, :]
-                    leftright = uvp.window_function_array[spw][:, :Ndlys//2, Ndlys//2+1:, :][:, ::-1, :, :]
-                    rightleft = uvp.window_function_array[spw][:, Ndlys//2+1: , :Ndlys//2, :][:, :, ::-1, :]
-                    rightright = uvp.window_function_array[spw][:, Ndlys//2+1:, Ndlys//2+1:, :]
-                    uvp.window_function_array[spw][:, Ndlys//2+1:, Ndlys//2+1:, :] = .25*(leftleft\
-                                                                                 +leftright\
-                                                                                 +rightleft\
-                                                                                 +rightright)
-                    uvp.window_function_array[spw][:, :, :Ndlys//2, :] = 0.0
+                    leftleft = uvp.window_function_array[spw][:, :Ndlys//2, first_kpar:Nkpar//2, :][:, ::-1, ::-1, :]
+                    leftright = uvp.window_function_array[spw][:, :Ndlys//2, Nkpar//2+1:, :][:, ::-1, :, :]
+                    rightleft = uvp.window_function_array[spw][:, Ndlys//2+1:, first_kpar:Nkpar//2, :][:, :, ::-1, :]
+                    rightright = uvp.window_function_array[spw][:, Ndlys//2+1:, Nkpar//2+1:, :]
+                    uvp.window_function_array[spw][:, Ndlys//2+1:, Nkpar//2+1:, :] = .25 * \
+                        (leftleft + leftright + rightleft + rightright)
+                    uvp.window_function_array[spw][:, :, :Nkpar//2, :] = 0.0
                 uvp.window_function_array[spw][:, :Ndlys//2, ...] = 0.0
 
             # fold covariance array if it exists.
             if hasattr(uvp,'cov_array_real'):
                 leftleft = uvp.cov_array_real[spw][:, :Ndlys//2, :Ndlys//2, :][:, ::-1, ::-1, :]
                 leftright = uvp.cov_array_real[spw][:, :Ndlys//2, Ndlys//2+1:, :][:, ::-1, :, :]
-                rightleft = uvp.cov_array_real[spw][:, Ndlys//2+1: , :Ndlys//2, :][:, :, ::-1, :]
+                rightleft = uvp.cov_array_real[spw][:, Ndlys//2+1:, :Ndlys//2, :][:, :, ::-1, :]
                 rightright = uvp.cov_array_real[spw][:, Ndlys//2+1:, Ndlys//2+1:, :]
-                uvp.cov_array_real[spw][:, Ndlys//2+1:, Ndlys//2+1:, :] = .25*(leftleft\
-                                                                         +leftright\
-                                                                         +rightleft\
-                                                                         +rightright)
+                uvp.cov_array_real[spw][:, Ndlys//2+1:, Ndlys//2+1:, :] = .25 * \
+                    (leftleft + leftright + rightleft + rightright)
                 uvp.cov_array_real[spw][:, :Ndlys//2, :, :] = 0.0
-                uvp.cov_array_real[spw][:, :, :Ndlys//2, : :] = 0.0
+                uvp.cov_array_real[spw][:, :, :Ndlys//2, :] = 0.0
 
                 leftleft = uvp.cov_array_imag[spw][:, :Ndlys//2, :Ndlys//2, :][:, ::-1, ::-1, :]
                 leftright = uvp.cov_array_imag[spw][:, :Ndlys//2, Ndlys//2+1:, :][:, ::-1, :, :]
-                rightleft = uvp.cov_array_imag[spw][:, Ndlys//2+1: , :Ndlys//2, :][:, :, ::-1, :]
+                rightleft = uvp.cov_array_imag[spw][:, Ndlys//2+1:, :Ndlys//2, :][:, :, ::-1, :]
                 rightright = uvp.cov_array_imag[spw][:, Ndlys//2+1:, Ndlys//2+1:, :]
-                uvp.cov_array_imag[spw][:, Ndlys//2+1:, Ndlys//2+1:, :] = .25*(leftleft\
-                                                                         +leftright\
-                                                                         +rightleft\
-                                                                         +rightright)
+                uvp.cov_array_imag[spw][:, Ndlys//2+1:, Ndlys//2+1:, :] = .25 * \
+                    (leftleft + leftright + rightleft + rightright)
                 uvp.cov_array_imag[spw][:, :Ndlys//2, :, :] = 0.0
-                uvp.cov_array_imag[spw][:, :, :Ndlys//2, : :] = 0.0
+                uvp.cov_array_imag[spw][:, :, :Ndlys//2, :] = 0.0
 
             # fold stats array if it exists: sum in inverse quadrature
             if hasattr(uvp, 'stats_array'):
@@ -2042,6 +2034,5 @@ def average_in_delay_bins(
     new_uvp.dly_array = np.concatenate(dly_array)
     new_uvp.spw_dly_array = np.concatenate(spw_dly_array)
     new_uvp.Nspwdlys = len(new_uvp.dly_array)
-    new_uvp.delays_are_binned = True
 
     return new_uvp

--- a/hera_pspec/grouping.py
+++ b/hera_pspec/grouping.py
@@ -936,7 +936,7 @@ def spherical_average(uvp_in, kbins, bin_widths, kbins_theory=None, blpair_group
     if uvp.exact_windows and store_window:
         window_function_array = spherical_wf_from_uvp(
             uvp, np.r_[kbin_left, kbin_right[-1]],
-            kbin_edges_in=np.r_[kbin_left_theory, kbin_right_theory[-1]],
+            kbin_edges_theory=np.r_[kbin_left_theory, kbin_right_theory[-1]],
             blpair_groups=blpair_groups,
             blpair_weights=blpair_weights,
             time_avg=time_avg,
@@ -998,7 +998,7 @@ def spherical_average(uvp_in, kbins, bin_widths, kbins_theory=None, blpair_group
 
     return uvp
 
-def spherical_wf_from_uvp(uvp_in, kbin_edges, kbin_edges_in=None,
+def spherical_wf_from_uvp(uvp_in, kbin_edges, kbin_edges_theory=None,
                           blpair_groups=None, blpair_lens=None, blpair_weights=None,
                           error_weights=None, time_avg=False, spw_array=None,
                           little_h=True, verbose=False, time_tol: float=1e-6):
@@ -1017,7 +1017,7 @@ def spherical_wf_from_uvp(uvp_in, kbin_edges, kbin_edges_in=None,
         1D float array of ascending |k| bin edges in [h] Mpc^-1 units
         (h included if little_h is True)
 
-    kbin_edges_in : array-like
+    kbin_edges_theory : array-like
         1D float array of ascending |k| bin edges in [h] Mpc^-1 units
         (h included if little_h is True)
         Default is None, that is kbins_in = kbins.
@@ -1066,10 +1066,10 @@ def spherical_wf_from_uvp(uvp_in, kbin_edges, kbin_edges_in=None,
 
     # input checks
 
-    if kbin_edges_in is None:
-        kbin_edges_in = np.copy(kbin_edges)
+    if kbin_edges_theory is None:
+        kbin_edges_theory = np.copy(kbin_edges)
     Nk = np.size(kbin_edges) - 1
-    Nk_in = np.size(kbin_edges_in) - 1
+    Nk_in = np.size(kbin_edges_theory) - 1
 
     # if window functions have been computed without little h
     # it is not possible to re adjust so kbins need to be in Mpc-1
@@ -1078,17 +1078,20 @@ def spherical_wf_from_uvp(uvp_in, kbin_edges, kbin_edges_in=None,
         warnings.warn('Changed little_h units to make kbins consistent ' \
                       'with uvp.window_function_array. Might be inconsistent ' \
                       'with the power spectrum units.')
+        # we modify the units of the input kbins to be consistent with uvp_in
+        # and, likely, the units of the pre-computed window functions.
         if little_h:
-            kbin_edges *= uvp_in.cosmo.h 
-            kbin_edges_in *= uvp_in.cosmo.h 
+            kbin_edges *= uvp_in.cosmo.h
+            kbin_edges_theory *= uvp_in.cosmo.h
         else:
             kbin_edges /= uvp_in.cosmo.h
-            kbin_edges_in /= uvp_in.cosmo.h
+            kbin_edges_theory /= uvp_in.cosmo.h
+        # final little_h matches the units of uvp_in
         little_h = 'h^-3' in uvp_in.norm_units
 
     # ensure bins don't overlap
     assert np.all(np.diff(kbin_edges) > 0), "kbins must not overlap"
-    assert np.all(np.diff(kbin_edges_in) > 0), "kbins_in must not overlap"
+    assert np.all(np.diff(kbin_edges_theory) > 0), "kbins_in must not overlap"
 
     # copy input
     uvp = copy.deepcopy(uvp_in) 
@@ -1178,9 +1181,9 @@ def spherical_wf_from_uvp(uvp_in, kbin_edges, kbin_edges_in=None,
                     mask1 = (kbin_edges[m1] <= kmags) & (kmags < kbin_edges[m1+1])
                     if np.any(mask1):
                         wf_temp = np.sum(cyl_wf[it, ...]*mask1[:, :, None, None].astype(int), axis=(0, 1))/np.sum(mask1)
-                        if np.sum(wf_temp) > 0.: 
+                        if np.sum(wf_temp) > 0.:
                             for m2 in range(Nk_in):
-                                mask2 = (kbin_edges_in[m2] <= ktot) & (ktot < kbin_edges_in[m2+1])
+                                mask2 = (kbin_edges_theory[m2] <= ktot) & (ktot < kbin_edges_theory[m2+1])
                                 if np.any(mask2): #cannot compute mean if zero elements
                                     wf_spherical[m1, m2] = np.mean(wf_temp[mask2])
                             # normalisation

--- a/hera_pspec/grouping.py
+++ b/hera_pspec/grouping.py
@@ -1233,7 +1233,7 @@ def fold_spectra(uvp):
             uvp.data_array[spw][:, :Ndlys//2, :] = 0.0
             uvp.nsample_array[spw] *= 2.0
             if hasattr(uvp, 'window_function_array'):
-                if uvp.exact_windows or uvp.delay_avg:
+                if uvp.exact_windows or uvp.delays_are_binned:
                     left = uvp.window_function_array[spw][:, 1:Ndlys//2, ...][:, ::-1, ...]
                     right = uvp.window_function_array[spw][:, Ndlys//2+1: , ...]
                     uvp.window_function_array[spw][:, Ndlys//2+1:, ...] = .50*(left+right)
@@ -1288,7 +1288,7 @@ def fold_spectra(uvp):
             uvp.data_array[spw][:, :Ndlys//2, :] = 0.0
             uvp.nsample_array[spw] *= 2.0
             if hasattr(uvp, 'window_function_array'):
-                if uvp.exact_windows or uvp.delay_avg:
+                if uvp.exact_windows or uvp.delays_are_binned:
                     left = uvp.window_function_array[spw][:, :Ndlys//2, ...][:, ::-1, ...]
                     right = uvp.window_function_array[spw][:, Ndlys//2+1: , ...]
                     uvp.window_function_array[spw][:, Ndlys//2+1:, ...] = .50*(left+right)
@@ -2042,6 +2042,6 @@ def average_in_delay_bins(
     new_uvp.dly_array = np.concatenate(dly_array)
     new_uvp.spw_dly_array = np.concatenate(spw_dly_array)
     new_uvp.Nspwdlys = len(new_uvp.dly_array)
-    new_uvp.delay_avg = True
+    new_uvp.delays_are_binned = True
 
     return new_uvp

--- a/hera_pspec/grouping.py
+++ b/hera_pspec/grouping.py
@@ -595,7 +595,7 @@ def average_spectra(uvp_in, blpair_groups=None, time_avg=False,
         return uvp
 
 
-def spherical_average(uvp_in, kbins, bin_widths, blpair_groups=None, time_avg=False, blpair_weights=None,
+def spherical_average(uvp_in, kbins, bin_widths, kbins_theory=None, blpair_groups=None, time_avg=False, blpair_weights=None,
                       weight_by_cov=False, error_weights=None, time_tol: float = 1e-6,
                       add_to_history='', little_h=True, A={}, run_check=True):
     """
@@ -613,6 +613,13 @@ def spherical_average(uvp_in, kbins, bin_widths, blpair_groups=None, time_avg=Fa
 
     bin_widths : array-like
         1D float array of kbin widths for each element in kbins
+
+    kbins_theory : array-like, optional
+        1D float array of ascending |k| bin centers in [h] Mpc^-1 units
+        used in the theory (used for averaging the window functions).
+        For now, it is assumed the bins are linearly equally spaced.
+        Default is identical to data spherical binning.
+        (h included if little_h is True)
 
     blpair_groups : list of tuples, optional
         blpair_groups to average if fed (cylindrical binning)
@@ -712,6 +719,24 @@ def spherical_average(uvp_in, kbins, bin_widths, blpair_groups=None, time_avg=Fa
         stats_array = odict([[stat, odict()] for stat in uvp.stats_array.keys()])
     if store_window:
         window_function_array = odict()
+        # define arrays for theory spherical bins
+        if kbins_theory is None:
+            kbins_theory = kbins
+            bin_widths_theory = bin_widths
+            kbin_left_theory = kbin_left
+            kbin_right_theory = kbin_right
+            Nk_theory = Nk
+        else:
+            kbins_theory = np.atleast_1d(kbins_theory)
+            bin_widths_theory = np.ones_like(kbins_theory) * np.diff(kbins_theory).mean()
+            # transform kgrid to little_h units
+            if not little_h:
+                kbins_theory = kbins_theory / uvp.cosmo.h
+                bin_widths_theory = bin_widths_theory / uvp.cosmo.h
+            kbin_left_theory = kbins_theory - bin_widths_theory / 2
+            kbin_right_theory = kbins_theory + bin_widths_theory / 2
+            assert np.all(kbin_left_theory[1:] >= kbin_right_theory[:-1] - 1e-6), "kbins_theory must not overlap"
+            Nk_theory = len(kbins_theory)
 
     # iterate over spectral windows
     spw_ranges = uvp.get_spw_ranges()
@@ -736,15 +761,15 @@ def spherical_average(uvp_in, kbins, bin_widths, blpair_groups=None, time_avg=Fa
                 stats_array[stat][spw] = np.zeros((uvp.Ntimes, Ndlyblps, uvp.Npols), dtype=np.complex128)
         if store_window:
             if uvp.exact_windows:
-                window_function_array[spw] = np.zeros((uvp.Ntimes, Nk, Nk, uvp.Npols), dtype=np.float64)
+                window_function_array[spw] = np.zeros((uvp.Ntimes, Nk, Nk_theory, uvp.Npols), dtype=np.float64)
             else:
-                window_function_array[spw] = np.zeros((uvp.Ntimes, Ndlys * uvp.Nblpairs, Nfreqs * uvp.Nblpairs, uvp.Npols), dtype=np.float64)
+                Nkpar = uvp.window_function_array[spw].shape[2]
+                window_function_array[spw] = np.zeros((uvp.Ntimes, Ndlyblps, Nkpar, uvp.Npols), dtype=np.float64)
 
         # setup the design matrix: P_cyl = A P_sph
         A[spw] = np.zeros((uvp.Ntimes, Ndlyblps, Nk, uvp.Npols), dtype=np.float64)
-        if uvp.delay_avg:
-            # need a design matrix per frequency
-            A2 = np.zeros((uvp.Ntimes, Nfreqs*uvp.Nblpairs, Nk, uvp.Npols), dtype=np.float64)
+        # design matrix for window functions
+        Aw = np.zeros((uvp.Ntimes, Nfreqs, Nk_theory, uvp.Npols), dtype=np.float64)
         # setup weighting matrix: block diagonal for each Ndly x Ndly
         # we can represent the Ndlyblps x Ndlyblps block diagonal matrix as Ndlyblps x Ndlys
         E = np.zeros((uvp.Ntimes, Ndlyblps, Ndlys, uvp.Npols), dtype=np.float64)
@@ -754,9 +779,9 @@ def spherical_average(uvp_in, kbins, bin_widths, blpair_groups=None, time_avg=Fa
 
         # get kparas for this spw: shape (Ndlys,)
         kparas = uvp.get_kparas(spw, little_h=True)
-        if uvp.delay_avg:
-            all_dlys = utils.get_delays(uvp.freq_array[uvp.spw_to_freq_indices(spw)])
-            kparas_per_freq = uvp.get_kparas(spw, little_h=True, dlys=all_dlys)
+        # get kparas for this spw: shape (Nfreqs,) - used for window function averaging
+        all_dlys = utils.get_delays(uvp.freq_array[uvp.spw_to_freq_indices(spw)])
+        kparas_per_freq = uvp.get_kparas(spw, little_h=True, dlys=all_dlys)
 
         # get k to tau mapping for this spw
         avgz = uvp.cosmo.f2z(np.mean(uvp.freq_array[uvp.spw_to_freq_indices(spw)]))
@@ -787,16 +812,12 @@ def spherical_average(uvp_in, kbins, bin_widths, blpair_groups=None, time_avg=Fa
             # get Ndlyblps slice
             dstart, dstop = Ndlys * b, Ndlys * (b + 1)
             dslice = slice(dstart, dstop)
-            if uvp.delay_avg:
-                dslice_freq = slice(Nfreqs * b, Nfreqs * (b + 1))
-            else:
-                dslice_freq = dslice
 
             # store data
             data_array[spw][:, dslice] = uvp.data_array[spw][blpt_inds]
 
             if store_window and not uvp.exact_windows:
-                window_function_array[spw][:, dslice, dslice_freq] = uvp.window_function_array[spw][blpt_inds]
+                window_function_array[spw][:, dslice, ...] = uvp.window_function_array[spw][blpt_inds]
 
             if store_stats:
                 for stat in stats_array:
@@ -822,7 +843,6 @@ def spherical_average(uvp_in, kbins, bin_widths, blpair_groups=None, time_avg=Fa
                 E[:, range(dstart, dstop), range(0, Ndlys)] = 1.0
                 f = np.isclose(uvp.integration_array[spw][blpt_inds] * uvp.nsample_array[spw][blpt_inds], 0)
                 E[:, range(dstart, dstop), range(0, Ndlys)] *= (~f[:, None, :])
-
             # append to non-dly arrays
             Emean = np.trace(E[:, dslice, :], axis1=1, axis2=2)  # use sum of E across delay as weight
             wgt_array[spw] += wgts * Emean[:, None, None, :]
@@ -832,32 +852,24 @@ def spherical_average(uvp_in, kbins, bin_widths, blpair_groups=None, time_avg=Fa
             # get k_sph -> k_cyl mapping
             for i, kmag in enumerate(kmags):
                 kind = (kbin_left < kmag) & (kbin_right >= kmag)
-
-                if not np.any(kind):
+                if np.any(kind):
                     # skip if not in any kbins
-                    continue
-                else:
                     # convert kind into an integer for indexing
                     kind = np.where(kind)[0][0]
-
                 # populate A matrix
                 A[spw][:, i + Ndlys * b, kind, :] = 1.0
 
-            if uvp.delay_avg:
-                # get k magnitude of data: (Ndlys,)
-                kmags_per_freq = np.sqrt(kperps[blpt_inds][0]**2 + kparas_per_freq**2)
-                for i, kmag in enumerate(kmags_per_freq):
-                    kind = (kbin_left < kmag) & (kbin_right >= kmag)
-
-                    if not np.any(kind):
-                        # skip if not in any kbins
-                        continue
-                    else:
-                        # convert kind into an integer for indexing
-                        kind = np.where(kind)[0][0]
-
-                    # populate A matrix
-                    A2[:, i + Nfreqs * b, kind, :] = 1.0
+            # get k_sph -> k_cyl mapping for window function
+            # get k magnitude of data: (Ndlys,)
+            kmags_per_freq = np.sqrt(kperps[blpt_inds][0]**2 + kparas_per_freq**2)
+            for i, kmag in enumerate(kmags_per_freq):
+                kind = (kbin_left_theory < kmag) & (kbin_right_theory >= kmag)
+                if np.any(kind):
+                    # skip if not in any kbins
+                    # convert kind into an integer for indexing
+                    kind = np.where(kind)[0][0]
+                # populate Aw matrix
+                Aw[:, i, kind, :] = 1.0
 
         # normalize metadata sums
         wgt_array[spw] /= np.max(wgt_array[spw], axis=(2, 3), keepdims=True).clip(1e-40, np.inf)
@@ -872,6 +884,7 @@ def spherical_average(uvp_in, kbins, bin_widths, blpair_groups=None, time_avg=Fa
         # Ht shape (Npols, Ntimes, Nk, Ndlyblps)
         Am = np.moveaxis(A[spw], -1, 0)
         Em = np.moveaxis(E, -1, 0)
+        # return Em[0, 0], Am[0, 0]
         # Multiply block diagoinal Em @ Am
         # by applying each baseline block in Em
         # to each Ndly x Nk baseline-horizontal block in Am
@@ -895,11 +908,8 @@ def spherical_average(uvp_in, kbins, bin_widths, blpair_groups=None, time_avg=Fa
             # bin window function: W_sph = H.T W_cyl A
             # wm shape (Npols, Ntimes, Ndlyblps, Ndlyblps)
             wm = np.moveaxis(window_function_array[spw], -1, 0)
-            if uvp.delay_avg:
-                Am2 = np.moveaxis(A2, -1, 0)
-                wm = Ht @ wm @ Am2
-            else:
-                wm = Ht @ wm @ Am
+            Aw2 = np.moveaxis(Aw, -1, 0)
+            wm = Ht @ wm @ Aw2
             window_function_array[spw] = np.moveaxis(wm, 0, -1)
 
         if store_stats:
@@ -927,6 +937,7 @@ def spherical_average(uvp_in, kbins, bin_widths, blpair_groups=None, time_avg=Fa
         if uvp.exact_windows:
             window_function_array[spw] = spherical_wf_from_uvp(
                 uvp, np.r_[kbin_left, kbin_right[-1]],
+                kbin_edges_in=np.r_[kbin_left_theory, kbin_right_theory[-1]],
                 blpair_groups=blpair_groups,
                 blpair_weights=blpair_weights,
                 time_avg=time_avg,
@@ -2001,12 +2012,14 @@ def average_in_delay_bins(
             new_uvp.cov_array_imag[spw] = newcov
         
         if hasattr(uvp, "window_function_array"):
-            wf = uvp.window_function_array[spw] # shape (Nblts, Ndly, Ndly, Npol)
+            oldwf = uvp.window_function_array[spw] # shape (Nblts, Ndly, Ndly, Npol)
             # We bin this like a data array (on axis=1) and end up with a non-square
             # window function. This works both for exact/non-exact window functions.
             # If we really need a square window function, then the second axis should 
             # be binned using a uniform kernel.
-            new_uvp.window_function_array[spw] = _bin_data_like_array(wf, kernels, slices, axis=1)
+            new_uvp.window_function_array[spw] = _bin_data_like_array(oldwf, kernels, slices, axis=1)
+            # new_uvp.window_function_array[spw] = _bin_data_like_array(new_uvp.window_function_array[spw], kernels, slices, axis=2)
+            # new_uvp.window_function_array[spw] = _bin_cov_like_array(oldwf, kernels, slices)
 
         for stat in cov_weighted_stats:
             # Problematically, there's only one covariance array, but there could be

--- a/hera_pspec/grouping.py
+++ b/hera_pspec/grouping.py
@@ -884,7 +884,6 @@ def spherical_average(uvp_in, kbins, bin_widths, kbins_theory=None, blpair_group
         # Ht shape (Npols, Ntimes, Nk, Ndlyblps)
         Am = np.moveaxis(A[spw], -1, 0)
         Em = np.moveaxis(E, -1, 0)
-        # return Em[0, 0], Am[0, 0]
         # Multiply block diagoinal Em @ Am
         # by applying each baseline block in Em
         # to each Ndly x Nk baseline-horizontal block in Am
@@ -2018,8 +2017,6 @@ def average_in_delay_bins(
             # If we really need a square window function, then the second axis should 
             # be binned using a uniform kernel.
             new_uvp.window_function_array[spw] = _bin_data_like_array(oldwf, kernels, slices, axis=1)
-            # new_uvp.window_function_array[spw] = _bin_data_like_array(new_uvp.window_function_array[spw], kernels, slices, axis=2)
-            # new_uvp.window_function_array[spw] = _bin_cov_like_array(oldwf, kernels, slices)
 
         for stat in cov_weighted_stats:
             # Problematically, there's only one covariance array, but there could be

--- a/hera_pspec/grouping.py
+++ b/hera_pspec/grouping.py
@@ -933,18 +933,18 @@ def spherical_average(uvp_in, kbins, bin_widths, kbins_theory=None, blpair_group
             cov_array_real[spw] = np.moveaxis(cm, 0, -1)
             cov_array_imag[spw] = np.zeros_like(cov_array_real[spw])
 
-        if uvp.exact_windows:
-            window_function_array[spw] = spherical_wf_from_uvp(
-                uvp, np.r_[kbin_left, kbin_right[-1]],
-                kbin_edges_in=np.r_[kbin_left_theory, kbin_right_theory[-1]],
-                blpair_groups=blpair_groups,
-                blpair_weights=blpair_weights,
-                time_avg=time_avg,
-                error_weights=error_weights,
-                spw_array=spw,
-                little_h=True,
-                verbose=True
-            )[spw]
+    if uvp.exact_windows and store_window:
+        window_function_array = spherical_wf_from_uvp(
+            uvp, np.r_[kbin_left, kbin_right[-1]],
+            kbin_edges_in=np.r_[kbin_left_theory, kbin_right_theory[-1]],
+            blpair_groups=blpair_groups,
+            blpair_weights=blpair_weights,
+            time_avg=time_avg,
+            error_weights=error_weights,
+            spw_array=uvp.spw_array,
+            little_h=True,
+            verbose=False
+        )
 
     # handle data arrays
     uvp.data_array = data_array

--- a/hera_pspec/pspecdata.py
+++ b/hera_pspec/pspecdata.py
@@ -1164,7 +1164,7 @@ class PSpecData:
 
         # Set the lru-cached get_Q_alt function, with a maxsize of Ndlys
         self._get_qalt_cached = lru_cache(maxsize=int(self.spw_Ndlys))(utils.get_Q_alt)
-        
+
 
     def cov_q_hat(self, key1, key2, model='empirical', exact_norm=False, pol=False,
                   time_indices=None):
@@ -3326,6 +3326,7 @@ class PSpecData:
                     else:
                         Mv, Wv = self.get_MW(Gv, Hv, mode=norm, exact_norm=exact_norm)
                     pv = self.p_hat(Mv, qv)
+                    # Gv.shape = Hv.shape = (nfreqs, nfreqs)
 
                     # Multiply by scalar
                     if self.primary_beam != None:
@@ -3380,7 +3381,12 @@ class PSpecData:
 
                     # store the window_function
                     if store_window:
+                        # Wv shape = (nfreqs, nfreqs) ie (64, 64)
+                        # qv shape = (nfreqs, ntimes) ie (64, 60)
                         pol_window_function.extend(np.repeat(Wv[np.newaxis,:,:], qv.shape[1], axis=0).astype(np.float64))
+                        # pol_wf shape = (ntimes, nfreqs, nfreqs) ie (60, 64, 64)
+                        # 4 blps so final wf_array shape for each spw is
+                        # (ntimes * nbls, nfreqs, nfreqs) = (4 * 60 = 240, 64, 64)
 
                     # Get baseline keys
                     if isinstance(blp, list):
@@ -3523,6 +3529,7 @@ class PSpecData:
         uvp.scalar_array = np.array(sclr_arr)
         uvp.channel_width = np.array(dset1.channel_width)  # all dsets validated to agree
         uvp.exact_windows = False
+        uvp.delay_avg = False
         uvp.weighting = input_data_weight
         uvp.vis_units, uvp.norm_units = self.units(little_h=little_h)
         # SGM: I've kept the same API in hera_pspec for now, but we should

--- a/hera_pspec/pspecdata.py
+++ b/hera_pspec/pspecdata.py
@@ -3528,7 +3528,6 @@ class PSpecData:
         uvp.scalar_array = np.array(sclr_arr)
         uvp.channel_width = np.array(dset1.channel_width)  # all dsets validated to agree
         uvp.exact_windows = False
-        uvp.delays_are_binned = False
         uvp.weighting = input_data_weight
         uvp.vis_units, uvp.norm_units = self.units(little_h=little_h)
         # SGM: I've kept the same API in hera_pspec for now, but we should

--- a/hera_pspec/pspecdata.py
+++ b/hera_pspec/pspecdata.py
@@ -3326,7 +3326,6 @@ class PSpecData:
                     else:
                         Mv, Wv = self.get_MW(Gv, Hv, mode=norm, exact_norm=exact_norm)
                     pv = self.p_hat(Mv, qv)
-                    # Gv.shape = Hv.shape = (nfreqs, nfreqs)
 
                     # Multiply by scalar
                     if self.primary_beam != None:

--- a/hera_pspec/pspecdata.py
+++ b/hera_pspec/pspecdata.py
@@ -3528,7 +3528,7 @@ class PSpecData:
         uvp.scalar_array = np.array(sclr_arr)
         uvp.channel_width = np.array(dset1.channel_width)  # all dsets validated to agree
         uvp.exact_windows = False
-        uvp.delay_avg = False
+        uvp.delays_are_binned = False
         uvp.weighting = input_data_weight
         uvp.vis_units, uvp.norm_units = self.units(little_h=little_h)
         # SGM: I've kept the same API in hera_pspec for now, but we should

--- a/hera_pspec/testing.py
+++ b/hera_pspec/testing.py
@@ -107,6 +107,7 @@ def build_vanilla_uvpspec(
     uvp.r_params = ""
     uvp.cov_model = "dsets"
     uvp.exact_windows = False
+    uvp.delay_avg = False
     
     label1 = "red"
     label2 = "blue"
@@ -140,9 +141,17 @@ def build_vanilla_uvpspec(
         # dimensions of the input visibilities, not the output delay spectra
         integration_array[s] = np.ones((uvp.Nbltpairs, uvp.Npols), dtype=float)
         nsample_array[s] = np.ones((uvp.Nbltpairs, uvp.Npols), dtype=float)
-        window_function_array[s] = np.ones(
-            (uvp.Nbltpairs, uvp.Ndlys, uvp.Ndlys, uvp.Npols), dtype=np.float64
+        # if uvp.Nfreqs == uvp.Ndlys:
+        Wv = np.diag(np.ones(uvp.Ndlys, dtype=np.float64))
+        window_function_array[s] = np.repeat(
+            # repeat along blpairtime axis
+            np.repeat(Wv[None, :], uvp.Nbltpairs, axis=0)[..., None],
+            uvp.Npols, axis=-1,  # repeat along polarization axis
         )
+        # else:
+        #     window_function_array[s] = np.ones(
+        #         (uvp.Nbltpairs, uvp.Ndlys, uvp.Ndlys, uvp.Npols), dtype=np.float64
+        #     )
         cov_array_real[s] = np.moveaxis(
             np.array(
                 [
@@ -172,10 +181,10 @@ def build_vanilla_uvpspec(
     uvp.nsample_array = nsample_array
     uvp.window_function_array = window_function_array
     uvp.cosmo = cosmo
-    
+
     # From v0.5, this must always be true.
     uvp.Ntimes = uvp.Ntpairs
-    
+
     uvp.check()
 
     return uvp, cosmo

--- a/hera_pspec/testing.py
+++ b/hera_pspec/testing.py
@@ -19,7 +19,7 @@ from . import (
 
 def build_vanilla_uvpspec(
     beam: pspecbeam.PSpecBeamBase | None=None,
-    Ndlys: int | None = 30,
+    Ndlys: int | None = None,
     equal_time_arrays: bool = True
 ) -> tuple[uvpspec.UVPSpec, conversions.Cosmo_Conversions]:
     """
@@ -32,9 +32,7 @@ def build_vanilla_uvpspec(
         A beam to use for the UVPSpec object. If None, no beam is used.
     Ndlys : int, optional
         Number of delay bins to use. If None, uses as many delay bins as
-        frequency channels. Default is 30, which was the original default, but
-        is *different* than the number of frequency channels, which can break 
-        window functions.
+        frequency channels. Default is None, which uses the number of frequency channels.
     equal_time_arrays
         If True, the time_1_array and time_2_array will be equal. If False,
         they will be different. Default is True.
@@ -107,7 +105,7 @@ def build_vanilla_uvpspec(
     uvp.r_params = ""
     uvp.cov_model = "dsets"
     uvp.exact_windows = False
-    uvp.delay_avg = False
+    uvp.delays_are_binned = False
     
     label1 = "red"
     label2 = "blue"

--- a/hera_pspec/testing.py
+++ b/hera_pspec/testing.py
@@ -105,7 +105,6 @@ def build_vanilla_uvpspec(
     uvp.r_params = ""
     uvp.cov_model = "dsets"
     uvp.exact_windows = False
-    uvp.delays_are_binned = False
     
     label1 = "red"
     label2 = "blue"

--- a/hera_pspec/testing.py
+++ b/hera_pspec/testing.py
@@ -148,10 +148,6 @@ def build_vanilla_uvpspec(
             np.repeat(Wv[None, :], uvp.Nbltpairs, axis=0)[..., None],
             uvp.Npols, axis=-1,  # repeat along polarization axis
         )
-        # else:
-        #     window_function_array[s] = np.ones(
-        #         (uvp.Nbltpairs, uvp.Ndlys, uvp.Ndlys, uvp.Npols), dtype=np.float64
-        #     )
         cov_array_real[s] = np.moveaxis(
             np.array(
                 [

--- a/hera_pspec/uvpspec.py
+++ b/hera_pspec/uvpspec.py
@@ -2472,7 +2472,7 @@ def combine_uvpspec(uvps, merge_history=True, verbose=True):
     store_window = np.all([hasattr(uvp, 'window_function_array') for uvp in uvps])
     exact_windows = np.all([uvp.exact_windows for uvp in uvps])
     store_stats = np.all([hasattr(uvp, 'stats_array') for uvp in uvps])
-    delays_are_binned = np.all([uvp.delays_are_binned for uvp in uvps])
+    delays_are_binned = np.any([uvp.delays_are_binned for uvp in uvps])
     # Create new empty data arrays and fill spw arrays
     u.data_array = odict()
     u.integration_array = odict()

--- a/hera_pspec/uvpspec.py
+++ b/hera_pspec/uvpspec.py
@@ -116,7 +116,7 @@ class UVPSpec(object):
         self._beam_freqs = PSpecParam("beam_freqs", description="Frequency bins of the OmegaP and OmegaPP beam-integral arrays [Hz].", form="(Nbeam_freqs,)", expected_type=np.float64)
         self._cosmo = PSpecParam("cosmo", description="Instance of conversion.Cosmo_Conversions class.", expected_type=conversions.Cosmo_Conversions)
         desc = "Whether the UVPSpec object have been averaged over delays. Then, Ndlys!=Nfreqs."
-        self._delay_avg = PSpecParam("delay_avg", description=desc, expected_type=bool)
+        self._delays_are_binned = PSpecParam("delays_are_binned", description=desc, expected_type=bool)
         # Collect all parameters: required and non-required
         self._all_params = sorted( [ p[1:] for p in
                                     fnmatch.filter(self.__dict__.keys(), '_*')])
@@ -146,7 +146,7 @@ class UVPSpec(object):
                             "history", "r_params", "cov_model",
                             "Nbls", "weighting", "vis_units",
                             "norm", "norm_units", "taper", "cosmo", "beamfile",
-                            'folded', 'exact_windows', 'delay_avg']
+                            'folded', 'exact_windows', 'delays_are_binned']
         self._ndarrays = ["spw_array", "freq_array", "dly_array",
                           "polpair_array", "lst_1_array", "lst_avg_array",
                           "time_avg_array", "channel_width", 
@@ -1398,8 +1398,8 @@ class UVPSpec(object):
         # Backwards compatibility: exact_windows
         if 'exact_windows' not in grp.attrs:
             setattr(self, 'exact_windows', False)
-        if 'delay_avg' not in grp.attrs:
-            setattr(self, 'delay_avg', False)
+        if 'delays_are_binned' not in grp.attrs:
+            setattr(self, 'delays_are_binned', False)
 
         # Use _select() to pick out only the requested baselines/spws
         if just_meta:
@@ -2472,7 +2472,7 @@ def combine_uvpspec(uvps, merge_history=True, verbose=True):
     store_window = np.all([hasattr(uvp, 'window_function_array') for uvp in uvps])
     exact_windows = np.all([uvp.exact_windows for uvp in uvps])
     store_stats = np.all([hasattr(uvp, 'stats_array') for uvp in uvps])
-    delay_avg = np.all([uvp.delay_avg for uvp in uvps])
+    delays_are_binned = np.all([uvp.delays_are_binned for uvp in uvps])
     # Create new empty data arrays and fill spw arrays
     u.data_array = odict()
     u.integration_array = odict()
@@ -2523,7 +2523,7 @@ def combine_uvpspec(uvps, merge_history=True, verbose=True):
                 Nkpara = uvps[0].window_function_kpara[i][:, 0].size
                 u.window_function_array[i] = np.empty((Nbltpairs, spw[3], Nkperp, Nkpara, Npols), np.float64)
             else:
-                if delay_avg:
+                if delays_are_binned:
                     u.window_function_array[i] = np.empty((Nbltpairs, spw[3], spw[2], Npols), np.float64)
                 else:
                     u.window_function_array[i] = np.empty((Nbltpairs, spw[3], spw[3], Npols), np.float64)
@@ -2545,7 +2545,7 @@ def combine_uvpspec(uvps, merge_history=True, verbose=True):
     u.Nspwfreqs = len(u.spw_freq_array)
     u.Ndlys = len(np.unique(u.dly_array))
     u.Nspwdlys = len(u.spw_dly_array)
-    u.delay_avg = delay_avg
+    u.delays_are_binned = delays_are_binned
 
     # other metadata
     u.polpair_array = np.array(new_polpairs)
@@ -2744,6 +2744,7 @@ def combine_uvpspec(uvps, merge_history=True, verbose=True):
                     n = blpts_idxs[j]
                     u.data_array[i][j, :, k] = uvps[l].data_array[m][n, :, q]
                     if store_window:
+                        print(u.window_function_array[i].shape, uvps[l].window_function_array[m].shape)
                         u.window_function_array[i][j, ..., k] = uvps[l].window_function_array[m][n, ..., q]
                     if store_cov:
                         u.cov_array_real[i][j, :, :, k] = uvps[l].cov_array_real[m][n, :, :, q]
@@ -2908,7 +2909,7 @@ def get_uvp_overlap(uvps, just_meta=True, verbose=True):
 
     # ensure static metadata agree between all objects
     static_meta = ['channel_width', 'telescope_location', 'weighting',
-                   'OmegaP', 'beam_freqs', 'OmegaPP', 'beamfile', 'norm', 'delay_avg',
+                   'OmegaP', 'beam_freqs', 'OmegaPP', 'beamfile', 'norm', 'delays_are_binned',
                    'taper', 'vis_units', 'norm_units', 'folded', 'cosmo', 'exact_windows']
     for m in static_meta:
         for u in uvps[1:]:

--- a/hera_pspec/uvpspec.py
+++ b/hera_pspec/uvpspec.py
@@ -116,7 +116,6 @@ class UVPSpec(object):
         self._beam_freqs = PSpecParam("beam_freqs", description="Frequency bins of the OmegaP and OmegaPP beam-integral arrays [Hz].", form="(Nbeam_freqs,)", expected_type=np.float64)
         self._cosmo = PSpecParam("cosmo", description="Instance of conversion.Cosmo_Conversions class.", expected_type=conversions.Cosmo_Conversions)
         desc = "Whether the UVPSpec object have been averaged over delays. Then, Ndlys!=Nfreqs."
-        self._delays_are_binned = PSpecParam("delays_are_binned", description=desc, expected_type=bool)
         # Collect all parameters: required and non-required
         self._all_params = sorted( [ p[1:] for p in
                                     fnmatch.filter(self.__dict__.keys(), '_*')])
@@ -146,7 +145,7 @@ class UVPSpec(object):
                             "history", "r_params", "cov_model",
                             "Nbls", "weighting", "vis_units",
                             "norm", "norm_units", "taper", "cosmo", "beamfile",
-                            'folded', 'exact_windows', 'delays_are_binned']
+                            'folded', 'exact_windows',]
         self._ndarrays = ["spw_array", "freq_array", "dly_array",
                           "polpair_array", "lst_1_array", "lst_avg_array",
                           "time_avg_array", "channel_width", 
@@ -1398,8 +1397,6 @@ class UVPSpec(object):
         # Backwards compatibility: exact_windows
         if 'exact_windows' not in grp.attrs:
             setattr(self, 'exact_windows', False)
-        if 'delays_are_binned' not in grp.attrs:
-            setattr(self, 'delays_are_binned', False)
 
         # Use _select() to pick out only the requested baselines/spws
         if just_meta:
@@ -2142,7 +2139,6 @@ class UVPSpec(object):
 
         return P_N
 
-
     def average_spectra(self, blpair_groups=None, time_avg=False,
                         blpair_weights=None, error_field=None, error_weights=None,
                         inplace=True, add_to_history='', time_tol: float=1e-6):
@@ -2261,7 +2257,6 @@ class UVPSpec(object):
         """
         grouping.fold_spectra(self)
 
-
     def get_blpair_groups_from_bl_groups(self, blgroups, only_pairs_in_bls=False):
         """
         Get baseline pair matches from a list of baseline groups.
@@ -2352,7 +2347,6 @@ class UVPSpec(object):
                                                  little_h=little_h,
                                                  noise_scalar=noise_scalar)
         return scalar
-
 
     def add_approximate_covariance(
         self, 
@@ -2467,12 +2461,17 @@ def combine_uvpspec(uvps, merge_history=True, verbose=True):
     Ntpairs = len(set([(t1, t2) for blp, t1, t2 in new_blpts]))
     Npols = len(new_polpairs)
 
+    # get each uvp's data axes
+    uvp_spws = [_uvp.get_spw_ranges() for _uvp in uvps]
+    uvp_blpts = [list(zip(_uvp.blpair_array, _uvp.time_1_array, _uvp.time_2_array))
+                 for _uvp in uvps]
+    uvp_polpairs = [_uvp.polpair_array.tolist() for _uvp in uvps]
+
     # Store optional attrs only if all uvps have them
     store_cov = np.all([hasattr(uvp, 'cov_array_real') for uvp in uvps])
     store_window = np.all([hasattr(uvp, 'window_function_array') for uvp in uvps])
     exact_windows = np.all([uvp.exact_windows for uvp in uvps])
     store_stats = np.all([hasattr(uvp, 'stats_array') for uvp in uvps])
-    delays_are_binned = np.any([uvp.delays_are_binned for uvp in uvps])
     # Create new empty data arrays and fill spw arrays
     u.data_array = odict()
     u.integration_array = odict()
@@ -2518,15 +2517,15 @@ def combine_uvpspec(uvps, merge_history=True, verbose=True):
         # so needs to keep this shape)
         u.nsample_array[i] = np.empty((Nbltpairs, Npols), np.float64)
         if store_window:
+            l = [spw in _u for _u in uvp_spws].index(True)
+            m = [spw == _spw for _spw in uvp_spws[l]].index(True)
             if exact_windows:
-                Nkperp = uvps[0].window_function_kperp[i][:, 0].size
-                Nkpara = uvps[0].window_function_kpara[i][:, 0].size
+                Nkperp = uvps[l].window_function_kperp[m][:, 0].size
+                Nkpara = uvps[l].window_function_kpara[m][:, 0].size
                 u.window_function_array[i] = np.empty((Nbltpairs, spw[3], Nkperp, Nkpara, Npols), np.float64)
             else:
-                if delays_are_binned:
-                    u.window_function_array[i] = np.empty((Nbltpairs, spw[3], spw[2], Npols), np.float64)
-                else:
-                    u.window_function_array[i] = np.empty((Nbltpairs, spw[3], spw[3], Npols), np.float64)
+                Nkpar = uvps[l].window_function_array[m].shape[2]
+                u.window_function_array[i] = np.empty((Nbltpairs, spw[3], Nkpar, Npols), np.float64)
         if store_cov:
             u.cov_array_real[i] = np.empty((Nbltpairs, spw[3], spw[3], Npols), np.float64)
             u.cov_array_imag[i] = np.empty((Nbltpairs, spw[3], spw[3], Npols), np.float64)
@@ -2545,7 +2544,6 @@ def combine_uvpspec(uvps, merge_history=True, verbose=True):
     u.Nspwfreqs = len(u.spw_freq_array)
     u.Ndlys = len(np.unique(u.dly_array))
     u.Nspwdlys = len(u.spw_dly_array)
-    u.delays_are_binned = delays_are_binned
 
     # other metadata
     u.polpair_array = np.array(new_polpairs)
@@ -2566,12 +2564,6 @@ def combine_uvpspec(uvps, merge_history=True, verbose=True):
     u.labels = sorted(set(np.concatenate([uvp.labels for uvp in uvps])))
     u.label_1_array = np.empty((Nspws, Nbltpairs, Npols), np.int32)
     u.label_2_array = np.empty((Nspws, Nbltpairs, Npols), np.int32)
-
-    # get each uvp's data axes
-    uvp_spws = [_uvp.get_spw_ranges() for _uvp in uvps]
-    uvp_blpts = [list(zip(_uvp.blpair_array, _uvp.time_1_array, _uvp.time_2_array))
-                 for _uvp in uvps]
-    uvp_polpairs = [_uvp.polpair_array.tolist() for _uvp in uvps]
 
     # Construct dict of label indices, to be used for re-ordering later
     u_lbls = {lbl: ll for ll, lbl in enumerate(u.labels)}
@@ -2744,7 +2736,6 @@ def combine_uvpspec(uvps, merge_history=True, verbose=True):
                     n = blpts_idxs[j]
                     u.data_array[i][j, :, k] = uvps[l].data_array[m][n, :, q]
                     if store_window:
-                        print(u.window_function_array[i].shape, uvps[l].window_function_array[m].shape)
                         u.window_function_array[i][j, ..., k] = uvps[l].window_function_array[m][n, ..., q]
                     if store_cov:
                         u.cov_array_real[i][j, :, :, k] = uvps[l].cov_array_real[m][n, :, :, q]
@@ -2909,7 +2900,7 @@ def get_uvp_overlap(uvps, just_meta=True, verbose=True):
 
     # ensure static metadata agree between all objects
     static_meta = ['channel_width', 'telescope_location', 'weighting',
-                   'OmegaP', 'beam_freqs', 'OmegaPP', 'beamfile', 'norm', 'delays_are_binned',
+                   'OmegaP', 'beam_freqs', 'OmegaPP', 'beamfile', 'norm',
                    'taper', 'vis_units', 'norm_units', 'folded', 'cosmo', 'exact_windows']
     for m in static_meta:
         for u in uvps[1:]:

--- a/hera_pspec/uvpspec_utils.py
+++ b/hera_pspec/uvpspec_utils.py
@@ -113,7 +113,7 @@ def subtract_uvp(uvp1, uvp2, run_check=True, verbose=False):
                     and hasattr(uvp2, 'window_function_array')):
                     window1 = uvp1.get_window_function(key1)
                     window2 = uvp2.get_window_function(key2)
-                    uvp1.window_function_array[i][blp1_inds, :, :, j] \
+                    uvp1.window_function_array[i][blp1_inds, ..., j] \
                         = np.sqrt(window1.real**2 + window2.real**2) \
                         + 1j*np.sqrt(window1.imag**2 + window2.imag**2)
 
@@ -577,8 +577,6 @@ def _select(uvp, spws=None, bls=None, only_pairs_in_bls=False, blpairs=None,
         # if fed as list of tuples, convert to integers
         if isinstance(blpairs[0], tuple):
             blpairs = [uvp.antnums_to_blpair(blp) for blp in blpairs]
-        print("blps:", blpairs)
-        print("blpair_array:", uvp.blpair_array)
         blpair_select = np.logical_or.reduce(
                                    [uvp.blpair_array == blp for blp in blpairs])
         blp_select += blpair_select

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,12 +5,13 @@ This adds several mock UVPSpec objects that can be used throughout the tests.
 
 import pytest
 from hera_pspec.testing import build_vanilla_uvpspec
-from hera_pspec import UVPSpec, PSpecData, utils
+from hera_pspec import UVPSpec, PSpecData, utils, grouping
 from hera_pspec import PSpecBeamUV
 from pathlib import Path
 from hera_pspec.data import DATA_PATH
 from pyuvdata import UVData
 import copy
+import numpy as np
 
 DATA_PATH = Path(DATA_PATH)
 
@@ -31,7 +32,17 @@ def vanilla_uvp_with_beam(beam_nf_dipole: PSpecBeamUV) -> UVPSpec:
 def vanilla_uvp_alternating_times(beam_nf_dipole: PSpecBeamUV) -> UVPSpec:
     """A UVPSpec with alternating times."""
     return build_vanilla_uvpspec(equal_time_arrays=False, beam=beam_nf_dipole)[0]
-    
+
+@pytest.fixture(scope="session")
+def vanilla_uvp_w_ndlys() -> UVPSpec:
+    """A UVPSpec with delay binning."""
+    return build_vanilla_uvpspec(Ndlys=30)[0]
+
+@pytest.fixture(scope="session")
+def vanilla_uvp_delay_binned() -> UVPSpec:
+    """A UVPSpec with delay binning."""
+    return grouping.average_in_delay_bins(build_vanilla_uvpspec()[0], kernel=np.array([1, 1, 1]))
+
 @pytest.fixture(scope="session")
 def uvp_example_data() -> UVPSpec:
     # obtain uvp object

--- a/tests/test_grouping.py
+++ b/tests/test_grouping.py
@@ -808,9 +808,11 @@ class TestAverageDelayBins:
             "Window functions wrongly propagated by grouping.average_spectra"
 
         # spherical average
-        kbins = np.arange(0, 2.9, 0.25)
-        sph_uvp = grouping.spherical_average(averaged_uvp, kbins, np.diff(kbins).mean())
-        sph_new = grouping.spherical_average(averaged_new, kbins, np.diff(kbins).mean())
+        dk = 0.08959223 * 3.
+        kmin = 0.004
+        kbins = np.arange(kmin, 2.3, dk)
+        sph_uvp = grouping.spherical_average(averaged_uvp, kbins, dk, time_avg=True)
+        sph_new = grouping.spherical_average(averaged_new, kbins, dk, time_avg=True)
         assert np.allclose(
             sph_uvp.window_function_array[0][0, ..., 0],
             sph_new.window_function_array[0][0, ..., 0]), \

--- a/tests/test_grouping.py
+++ b/tests/test_grouping.py
@@ -599,11 +599,19 @@ def test_spherical_average():
     # exceptions
     pytest.raises(AssertionError, grouping.spherical_average, uvp, kbins, 1.0)
 
+    # user input kbins theory
+    sph2 = grouping.spherical_average(
+        uvp, kbins, bin_widths, kbins_theory=kbins[:4]
+    )
+    assert np.allclose(
+        sph.window_function_array[0][:, :, :4, :],
+        sph2.window_function_array[0]
+    )
+
     # tests related to exact_windows
     uvd = UVData()
     uvd.read_uvh5(
         os.path.join(DATA_PATH, 'zen.2458116.31939.HH.uvh5'),
-        
     )
     ds = pspecdata.PSpecData(dsets=[uvd, uvd], wgts=[None, None], beam=beam)
     baselines1, baselines2, blpairs = utils.construct_blpairs(uvd.get_antpairs()[1:],
@@ -743,22 +751,22 @@ def test_spherical_wf_from_uvp():
 
 class TestAverageDelayBins:
     """Tests of the average_in_delay_bins function."""
-    
+
     def setup_class(self):
         beamfile = os.path.join(DATA_PATH, 'HERA_NF_dipole_power.beamfits')
         self.beam = pspecbeam.PSpecBeamUV(beamfile)
-        uvp, cosmo = testing.build_vanilla_uvpspec(beam=self.beam, Ndlys=None) # None means take Nfreqs
+        uvp, _ = testing.build_vanilla_uvpspec(beam=self.beam, Ndlys=None) # None means take Nfreqs
         self.uvp = uvp
-        
+
         self.uvp_nocov = copy.deepcopy(self.uvp)
         del self.uvp_nocov.cov_array_real
         del self.uvp_nocov.cov_array_imag
-        
-        self.uvp2 = copy.deepcopy(self.uvp) 
+
+        self.uvp2 = copy.deepcopy(self.uvp)
         gaussian_beam = uvwindow.FTBeam.gaussian(freq_array=self.uvp2.freq_array, widths=8., pol=1) 
         del self.uvp2.window_function_array
         self.uvp2.get_exact_window_functions(ftbeam=gaussian_beam, inplace=True)
-        
+
     def test_get_delay_slices_errors(self):
         with pytest.raises(ValueError, match="nzero must be odd!"):
             grouping._get_delay_slices(
@@ -766,7 +774,7 @@ class TestAverageDelayBins:
                 kernel=np.array([1, 1, 1]),
                 zero_kernel=np.array([1, 0, 1, 0]),
             )
-            
+
     def test_exceptions(self):
         """Test that proper exceptions are raised for bad inputs."""
         with pytest.raises(ValueError, match="The kernel must be 1D"):
@@ -785,6 +793,9 @@ class TestAverageDelayBins:
 
     def test_propagation(self):
 
+        """
+        Check if the delay average is properly propagated to UVPSpec properties.
+        """
         new = grouping.average_in_delay_bins(self.uvp, kernel=np.array([1, 1, 1]))
 
         # window functions propagation
@@ -812,13 +823,43 @@ class TestAverageDelayBins:
         kbin_left = np.arange(dk/3/2, 2.3, dk)
         kbin_right = kbin_left + dk
         kbins = (kbin_left + kbin_right) / 2.
-        sph_uvp = grouping.spherical_average(averaged_uvp, kbins, dk, time_avg=True)
-        sph_new = grouping.spherical_average(averaged_new, kbins, dk, time_avg=True)
+        sph_uvp = grouping.spherical_average(self.uvp, kbins, dk, time_avg=True)
+        sph_new = grouping.spherical_average(new, kbins, dk, time_avg=True)
         assert np.allclose(
             sph_uvp.window_function_array[0][0, :, :-1, 0],
             # given the bin edges, the final bin is empty in the delay averaged spectrum
             sph_new.window_function_array[0][0, :, :-1, 0]), \
             "Window functions wrongly propagated by grouping.spherical_average"
+        # if theory kbins are given by the user
+        sph_uvp2 = grouping.spherical_average(
+            self.uvp, kbins, bin_widths=dk,
+            kbins_theory=kbins[::2],
+            time_avg=True
+        )
+        sph_new2 = grouping.spherical_average(
+            new, kbins, bin_widths=dk,
+            kbins_theory=kbins[::2],
+            time_avg=True,
+        )
+        # window functions propagation
+        assert np.allclose(
+            sph_uvp2.window_function_array[0][0, :, :-1, 0],
+            # given the bin edges, the final bin is empty in the delay averaged spectrum
+            sph_new2.window_function_array[0][0, :, :-1, 0]), \
+            "Window functions wrongly propagated by grouping.spherical_average"
+        
+        # tests with exact window functions
+        new2 = grouping.average_in_delay_bins(self.uvp2, kernel=np.array([1, 1, 1]))
+        # delay array propagation
+        assert np.isclose(
+            new2.dly_array[0], np.mean(self.uvp2.dly_array[1:4])
+        ) 
+        # window functions propagation
+        assert np.allclose(
+            np.mean(self.uvp2.window_function_array[0][:, 1:4], axis=1),
+            new2.window_function_array[0][:, 0, ...]
+        ), "Window functions wrongly propagated by grouping.average_in_delay_bins with exact window functions"
+
 
     @pytest.mark.parametrize("with_cov", [True, False])
     @pytest.mark.parametrize("cov_weighted_stats", [(), ('P_N',)])

--- a/tests/test_grouping.py
+++ b/tests/test_grouping.py
@@ -636,8 +636,8 @@ def test_spherical_wf_from_uvp():
     dk = 0.25
     kbin_edges = np.arange(0.075, 2.9, dk)
     Nk = kbin_edges.size - 1
-    kbin_edges_in = np.arange(0.075, 2.9, dk/2.)
-    Nk_in = kbin_edges_in.size - 1
+    kbin_edges_theory = np.arange(0.075, 2.9, dk/2.)
+    Nk_in = kbin_edges_theory.size - 1
 
     basename = 'FT_beam_HERA_dipole_test'
     # obtain uvp object
@@ -672,9 +672,9 @@ def test_spherical_wf_from_uvp():
     wf_array2 = grouping.spherical_wf_from_uvp(
         uvp,
         kbin_edges=kbin_edges,
-        kbin_edges_in=kbin_edges_in,
+        kbin_edges_theory=kbin_edges_theory,
         little_h='h^-3' in uvp.norm_units
-    )    
+    )
     assert wf_array2[0].shape == (uvp.Ntimes, Nk, Nk_in, uvp.Npols)
     # little_h
     wf_array = grouping.spherical_wf_from_uvp(

--- a/tests/test_grouping.py
+++ b/tests/test_grouping.py
@@ -809,13 +809,15 @@ class TestAverageDelayBins:
 
         # spherical average
         dk = 0.08959223 * 3.
-        kmin = 0.004
-        kbins = np.arange(kmin, 2.3, dk)
+        kbin_left = np.arange(dk/3/2, 2.3, dk)
+        kbin_right = kbin_left + dk
+        kbins = (kbin_left + kbin_right) / 2.
         sph_uvp = grouping.spherical_average(averaged_uvp, kbins, dk, time_avg=True)
         sph_new = grouping.spherical_average(averaged_new, kbins, dk, time_avg=True)
         assert np.allclose(
-            sph_uvp.window_function_array[0][0, ..., 0],
-            sph_new.window_function_array[0][0, ..., 0]), \
+            sph_uvp.window_function_array[0][0, :, :-1, 0],
+            # given the bin edges, the final bin is empty in the delay averaged spectrum
+            sph_new.window_function_array[0][0, :, :-1, 0]), \
             "Window functions wrongly propagated by grouping.spherical_average"
 
     @pytest.mark.parametrize("with_cov", [True, False])

--- a/tests/test_uvpspec.py
+++ b/tests/test_uvpspec.py
@@ -50,7 +50,7 @@ class TestUVPSpec:
     def test_param(self):
         a = parameter.PSpecParam("example", description="example", expected_type=int)
 
-    
+
     @parametrize_with_cases('uvp', cases=".")
     def test_eq(self, uvp: uvpspec.UVPSpec):
         # test equivalence
@@ -631,10 +631,10 @@ class TestUVPSpec:
         assert(uvp1.folded)
         pytest.raises(AssertionError, uvp1.fold_spectra)
 
-        if uvp1.delays_are_binned:
-            assert len(uvp1.get_dlys(0)) == len(uvp.get_dlys(0)) // 2
-        else:
+        if uvp.get_dlys(0).size % 2 == 0:
             assert len(uvp1.get_dlys(0)) == len(uvp.get_dlys(0)) // 2 - 1
+        else:
+            assert len(uvp1.get_dlys(0)) == len(uvp.get_dlys(0)) // 2
         assert(np.isclose(uvp1.nsample_array[0], 2.0).all())
 
     def test_fold_spectra_odd_cases(self):

--- a/tests/test_uvpspec.py
+++ b/tests/test_uvpspec.py
@@ -631,7 +631,7 @@ class TestUVPSpec:
         assert(uvp1.folded)
         pytest.raises(AssertionError, uvp1.fold_spectra)
 
-        if uvp1._delays_are_binned:
+        if uvp1.delays_are_binned:
             assert len(uvp1.get_dlys(0)) == len(uvp.get_dlys(0)) // 2
         else:
             assert len(uvp1.get_dlys(0)) == len(uvp.get_dlys(0)) // 2 - 1

--- a/tests/test_uvpspec.py
+++ b/tests/test_uvpspec.py
@@ -19,12 +19,18 @@ def case_vanilla_uvp(vanilla_uvp: UVPSpec):
 def case_vanilla_uvp_with_beam(vanilla_uvp_with_beam: UVPSpec):
     return vanilla_uvp_with_beam
 
+def case_vanilla_uvp_w_ndlys(vanilla_uvp_w_ndlys: UVPSpec):
+    return vanilla_uvp_w_ndlys
+
+def case_vanilla_uvp_delay_binned(vanilla_uvp_delay_binned: UVPSpec):
+    return vanilla_uvp_delay_binned
+
 def case_vanilla_uvp_alternating_times(vanilla_uvp_alternating_times: UVPSpec):
     return vanilla_uvp_alternating_times
 
 def case_uvp_exact_wfs(uvp_exact_wfs: UVPSpec):
     return uvp_exact_wfs
-    
+
 class TestUVPSpec:
 
     def _add_optionals(self, uvp: uvpspec.UVPSpec) -> uvpspec.UVPSpec:
@@ -54,7 +60,7 @@ class TestUVPSpec:
     def test_get_funcs(self, uvp: uvpspec.UVPSpec):
         # get_data
         d = uvp.get_data((0, ((1, 2), (1, 2)), ('xx','xx')))
-        assert d.shape == (10, 30)
+        assert d.shape == (uvp.Ntimes, uvp.get_dlys(0).size)
         assert(d.dtype == complex)
         np.testing.assert_almost_equal(d[0,0], (101.1021011020000001+0j))
         d = uvp.get_data((0, ((1, 2), (1, 2)), 1515))
@@ -82,7 +88,7 @@ class TestUVPSpec:
 
         # get dly
         d = uvp.get_dlys(0)
-        assert len(d) == 30
+        assert len(d) == uvp.get_dlys(0).size
 
         # get blpair seps
         blp = uvp.get_blpair_seps()
@@ -92,17 +98,17 @@ class TestUVPSpec:
         # get kvecs
         k_perp, k_para = uvp.get_kperps(0), uvp.get_kparas(0)
         assert len(k_perp) == 30
-        assert len(k_para) == 30
+        assert len(k_para) == uvp.get_dlys(0).size
 
         # test key expansion
         key = (0, ((1, 2), (1, 2)), ('xx','xx'))
         d = uvp.get_data(key)
-        assert d.shape == (10, 30)
+        assert d.shape == (uvp.Ntimes, uvp.get_dlys(0).size)
 
         # test key as dictionary
         key = {'spw':0, 'blpair':((1, 2), (1, 2)), 'polpair': ('xx','xx')}
         d = uvp.get_data(key)
-        assert d.shape == (10, 30)
+        assert d.shape == (uvp.Ntimes, uvp.get_dlys(0).size)
 
         # test get_blpairs
         blps = uvp.get_blpairs()
@@ -168,7 +174,6 @@ class TestUVPSpec:
         cov_imag = uvp.get_cov(key, component='imag')
         assert cov_imag[0].shape == (24, 24)
 
-
     def test_stats_array(
         self, 
         vanilla_uvp_with_beam: uvpspec.UVPSpec,
@@ -179,7 +184,7 @@ class TestUVPSpec:
         keys = uvp.get_all_keys()
         pytest.raises(ValueError, uvp.set_stats, "errors", keys[0], np.linspace(0, 1, 2))
         pytest.raises(AttributeError, uvp.get_stats, "__", keys[0])
-        errs = np.ones((uvp.Ntimes, uvp.Ndlys))
+        errs = np.ones((uvp.Ntimes, uvp.get_dlys(0).size))
         for key in keys:
             uvp.set_stats("errors", key, errs)
         uvp.get_stats("errors", keys[0])
@@ -199,23 +204,24 @@ class TestUVPSpec:
         u3 = uvp.average_spectra([blpairs], time_avg=True, inplace=False)
         pytest.raises(KeyError, uvp.average_spectra, [blpairs], time_avg=True, inplace=False, error_field=["..............."])
         assert hasattr(u3, "stats_array") == False
-        
+
         u.write_hdf5(tmp_path / 'ex.hdf5')
         u.read_hdf5(tmp_path / 'ex.hdf5')
-        
+
         # test folding
         uvp = copy.deepcopy(vanilla_uvp_with_beam)
-        errs = np.repeat(np.arange(1, 31)[None], 10, axis=0)
+        Ndlys = uvp.get_dlys(0).size
+        errs = np.repeat(np.arange(1, Ndlys+1)[None], uvp.Ntimes, axis=0)
         uvp.set_stats("test", keys[0], errs)
         uvp.fold_spectra()
         # fold by summing in inverse quadrature
-        folded_errs = np.sum([1/errs[:, 1:15][:, ::-1]**2.0, 1/errs[:, 16:]**2.0], axis=0)**(-0.5)
+        folded_errs = np.sum([1/errs[:, 1:Ndlys//2][:, ::-1]**2.0, 1/errs[:, Ndlys//2+1:]**2.0], axis=0)**(-0.5)
         np.testing.assert_array_almost_equal(uvp.get_stats("test", keys[0]), folded_errs)
 
         # test set_stats_slice
         uvp = copy.deepcopy(vanilla_uvp_with_beam)
         key = (0, ((1, 2), (1, 2)), ('xx', 'xx'))
-        uvp.set_stats('err', key, np.ones((uvp.Ntimes, uvp.Ndlys)))
+        uvp.set_stats('err', key, np.ones((uvp.Ntimes, uvp.get_dlys(0).size)))
         uvp.set_stats_slice('err', 50, 0, above=True, val=10)
         # ensure all dlys above 50 * 15 ns are set to 10 and all others set to 1
         assert np.isclose(uvp.get_stats('err', key)[:, np.abs(uvp.get_dlys(0)*1e9) > 15 * 50], 10).all()
@@ -296,7 +302,7 @@ class TestUVPSpec:
 
         # spw to indices
         spw1 = uvp.spw_to_dly_indices(0)
-        assert len(spw1) == uvp.Ndlys
+        assert len(spw1) == uvp.get_dlys(0).size
         spw2 = uvp.spw_to_freq_indices(0)
         assert len(spw2) == uvp.Nfreqs
         spw3 = uvp.spw_indices(0)
@@ -340,18 +346,18 @@ class TestUVPSpec:
 
     @parametrize_with_cases('uvp', cases=".", glob="*vanilla*")
     def test_select(self, uvp: uvpspec.UVPSpec):
+        Ndlys = uvp.get_dlys(0).size
         # bl group select
         uvp1 = copy.deepcopy(uvp)
         uvp1.select(bls=[(1, 2)], inplace=True)
         assert uvp1.Nblpairs == 1
-        assert uvp1.data_array[0].shape == (10, 30, 1)
+        assert uvp1.data_array[0].shape == (uvp.Ntimes, uvp.get_dlys(0).size, 1)
         np.testing.assert_almost_equal(uvp.data_array[0][0,0,0], (101.1021011020000001+0j))
 
         # inplace vs not inplace, spw selection
         uvd = UVData()
         uvd.read_miriad(
             os.path.join(DATA_PATH, 'zen.even.xx.LST.1.28828.uvOCRSA'),
-            
         )
         beam = pspecbeam.PSpecBeamUV(os.path.join(DATA_PATH, "HERA_NF_dipole_power.beamfits"))
         bls = [(37, 38), (38, 39), (52, 53)]
@@ -390,21 +396,22 @@ class TestUVPSpec:
 
         # test pol and blpair select, and check dimensionality of output
         uvp1 = copy.deepcopy(uvp)
-        uvp1.set_stats('hi', uvp.get_all_keys()[0], np.ones(300).reshape(10, 30))
+        uvp1.set_stats('hi', uvp.get_all_keys()[0], np.ones(Ndlys*uvp1.Ntimes).reshape(uvp1.Ntimes, Ndlys))
         uvp2 = uvp1.select(blpairs=uvp1.get_blpairs(), polpairs=uvp1.polpair_array,
                           inplace=False)
-        assert uvp2.data_array[0].shape == (30, 30, 1)
-        assert uvp2.stats_array['hi'][0].shape == (30, 30, 1)
+        assert uvp2.data_array[0].shape == (uvp1.Nbltpairs, Ndlys, 1)
+        assert uvp2.stats_array['hi'][0].shape == (uvp1.Nbltpairs, Ndlys, 1)
 
         # test when both blp and pol array are non-sliceable
         uvp2, uvp3, uvp4 = copy.deepcopy(uvp), copy.deepcopy(uvp), copy.deepcopy(uvp)
+        print(uvp.window_function_array[0].shape, uvp2.window_function_array[0].shape)
         uvp2.polpair_array[0] = 1414
         uvp3.polpair_array[0] = 1313
         uvp4.polpair_array[0] = 1212
         uvp1 = uvp + uvp2 + uvp3 + uvp4
         uvp5 = uvp1.select(blpairs=[101102101102], polpairs=[1515, 1414, 1313],
                           inplace=False)
-        assert uvp5.data_array[0].shape == (10, 30, 3)
+        assert uvp5.data_array[0].shape == (uvp.Ntimes*1, Ndlys, 3)
 
         # select only on lst
         uvp1 = copy.deepcopy(uvp)
@@ -497,16 +504,17 @@ class TestUVPSpec:
         # test partial I/O
         uvp.read_hdf5(out, blpairs=uvp.blpair_array[:1])
         assert uvp.Nblpairs==1
-        assert uvp.data_array[0].shape == (uvp.Nbltpairs, uvp.Ndlys, uvp.Npols)
+        assert uvp.data_array[0].shape == (uvp.Nbltpairs, uvp.get_dlys(0).size, uvp.Npols)
 
 
     def test_sense(self, vanilla_uvp_with_beam):
         uvp = copy.deepcopy(vanilla_uvp_with_beam)
+        Ndlys = uvp.get_dlys(0).size
 
         # test generate noise spectra
         polpair = ('xx', 'xx')
         P_N = uvp.generate_noise_spectra(0, polpair, 500, form='Pk', component='real')
-        assert P_N[101102101102].shape == (10, 30)
+        assert P_N[101102101102].shape == (uvp.Ntimes, Ndlys)
 
         # test smaller system temp
         P_N2 = uvp.generate_noise_spectra(0, polpair, 400, form='Pk', component='real')
@@ -518,16 +526,16 @@ class TestUVPSpec:
 
         # test Dsq
         Dsq = uvp.generate_noise_spectra(0, polpair, 500, form='DelSq', component='real')
-        assert Dsq[101102101102].shape == (10, 30)
+        assert Dsq[101102101102].shape == (uvp.Ntimes, Ndlys)
         assert(Dsq[101102101102][0, 1] < P_N[101102101102][0, 1])
 
         # test a blpair selection and int polpair
         blpairs = uvp.get_blpairs()[:1]
         P_N = uvp.generate_noise_spectra(0, 1515, 500, form='Pk', blpairs=blpairs, component='real')
-        assert P_N[101102101102].shape == (10, 30)
+        assert P_N[101102101102].shape == (uvp.Ntimes, Ndlys)
 
         # test as a dictionary of arrays
-        Tsys = dict([(uvp.antnums_to_blpair(k), 500 * np.ones((uvp.Ntimes, uvp.Ndlys)) * np.linspace(1, 2, uvp.Ntimes)[:, None]) for k in uvp.get_blpairs()])
+        Tsys = dict([(uvp.antnums_to_blpair(k), 500 * np.ones((uvp.Ntimes, Ndlys)) * np.linspace(1, 2, uvp.Ntimes)[:, None]) for k in uvp.get_blpairs()])
         P_N = uvp.generate_noise_spectra(0, 1515, Tsys, form='Pk', blpairs=blpairs, component='real')
         # assert time gradient is captured: 2 * Tsys results in 4 * P_N
         assert(np.isclose(P_N[101102101102][0, 0] * 4, P_N[101102101102][-1, 0]))
@@ -535,7 +543,8 @@ class TestUVPSpec:
     @parametrize_with_cases('uvp', cases=".", glob="*vanilla*")
     def test_average_spectra(self, uvp: uvpspec.UVPSpec):
         uvp = copy.deepcopy(uvp)
-        
+        Ndlys = uvp.get_dlys(0).size
+
         # test blpair averaging
         blpairs = uvp.get_blpair_groups_from_bl_groups([[101102, 102103, 101103]],
                                                        only_pairs_in_bls=False)
@@ -543,7 +552,7 @@ class TestUVPSpec:
                                    inplace=False)
         assert uvp2.Nblpairs == 1
         assert(np.isclose(uvp2.get_nsamples((0, 101102101102, ('xx','xx'))), 3.0).all())
-        assert uvp2.get_data((0, 101102101102, ('xx','xx'))).shape == (10, 30)
+        assert uvp2.get_data((0, 101102101102, ('xx','xx'))).shape == (10, Ndlys)
 
         # Test blpair averaging (with baseline-pair weights)
         # Results should be identical with different weights here, as the data
@@ -560,14 +569,14 @@ class TestUVPSpec:
         assert(np.isclose(
                         uvp3a.get_data((0, 101102101102, ('xx','xx'))),
                         uvp3b.get_data((0, 101102101102, ('xx','xx')))).all())
-        #assert uvp2.get_data((0, 101102101102, 'xx')).shape == (10, 30)
+        #assert uvp2.get_data((0, 101102101102, 'xx')).shape == (10, Ndlys)
 
         # test time averaging
         uvp2 = uvp.average_spectra(time_avg=True, inplace=False)
         assert uvp2.Ntimes == 1
         assert(np.isclose(
                 uvp2.get_nsamples((0, 101102101102, ('xx','xx'))), 10.0).all())
-        assert uvp2.get_data((0, 101102101102, ('xx','xx'))).shape == (1, 30)
+        assert uvp2.get_data((0, 101102101102, ('xx','xx'))).shape == (1, Ndlys)
         # ensure averaging works when multiple repeated baselines are present, but only
         # if time_avg = True
         uvp.blpair_array[uvp.blpair_to_indices(102103102103)] = 101102101102
@@ -621,8 +630,11 @@ class TestUVPSpec:
         uvp1.fold_spectra()
         assert(uvp1.folded)
         pytest.raises(AssertionError, uvp1.fold_spectra)
-        
-        assert len(uvp1.get_dlys(0)) == len(uvp.get_dlys(0)) // 2 - 1
+
+        if uvp1._delays_are_binned:
+            assert len(uvp1.get_dlys(0)) == len(uvp.get_dlys(0)) // 2
+        else:
+            assert len(uvp1.get_dlys(0)) == len(uvp.get_dlys(0)) // 2 - 1
         assert(np.isclose(uvp1.nsample_array[0], 2.0).all())
 
     def test_fold_spectra_odd_cases(self):
@@ -804,6 +816,7 @@ class TestUVPSpec:
         uvp4 = testing.uvpspec_from_data(uvd, bls, beam=beam,
                                          spw_ranges=[(20, 30), (60, 90)],
                                          n_dlys=[5, 15])
+        print('test', uvp4.window_function_array[0].shape, uvp4.window_function_array[1].shape)
         uvp4b = copy.deepcopy(uvp4)
         uvp4b.polpair_array[0] = 1414
         out = uvpspec.combine_uvpspec([uvp4, uvp4b], verbose=False)
@@ -883,7 +896,6 @@ class TestUVPSpec:
         del uvp2.OmegaP
         del uvp2.OmegaPP
         pytest.raises(AssertionError, uvpspec.combine_uvpspec, [uvp1, uvp2])
-
 
     def test_combine_uvpspec_r_params(self):
         # setup uvp build

--- a/tests/test_uvpspec_utils.py
+++ b/tests/test_uvpspec_utils.py
@@ -2,7 +2,7 @@ import unittest
 import pytest
 import numpy as np
 from hera_pspec import uvpspec_utils as uvputils
-from hera_pspec import testing, pspecbeam, UVPSpec
+from hera_pspec import testing, grouping, pspecbeam, UVPSpec
 from pyuvdata import UVData
 from hera_pspec.data import DATA_PATH
 import os
@@ -209,6 +209,17 @@ def test_subtract_uvp():
     assert isinstance(uvs, UVPSpec)
     assert hasattr(uvs, "stats_array")
     assert hasattr(uvs, "cov_array_real")
+    assert hasattr(uvs, "window_function_array")
+
+    # test with delay-averaged spectra
+    averaged_uvp = grouping.average_in_delay_bins(uvp, kernel=np.array([1, 1, 1]))
+    uvs = uvputils.subtract_uvp(averaged_uvp, averaged_uvp, run_check=True)
+    assert isinstance(uvs, UVPSpec)
+    assert hasattr(uvs, "stats_array")
+    assert hasattr(uvs, "cov_array_real")
+    assert hasattr(uvs, "window_function_array")
+    # make sure you cannot combine spectra if only one have been delay averaged
+    pytest.raises(ValueError, uvputils.subtract_uvp, averaged_uvp, uvp)
 
     # we subtracted uvp from itself, so data_array should be zero
     assert np.isclose(uvs.data_array[0], 0.0).all()

--- a/tests/test_uvpspec_utils.py
+++ b/tests/test_uvpspec_utils.py
@@ -199,10 +199,9 @@ def test_subtract_uvp():
     beamfile = os.path.join(DATA_PATH, 'HERA_NF_dipole_power.beamfits')
     beam = pspecbeam.PSpecBeamUV(beamfile)
     uvp, cosmo = testing.build_vanilla_uvpspec(beam=beam)
-
     # add a dummy stats_array
     for k in uvp.get_all_keys():
-        uvp.set_stats('mystat', k, np.ones((10, 30), dtype=complex))
+        uvp.set_stats('mystat', k, np.ones_like(uvp.get_data(k), dtype=complex))
 
     # test execution
     uvs = uvputils.subtract_uvp(uvp, uvp, run_check=True)


### PR DESCRIPTION
This PR is to answer issue #426: I have modified `spherical_wf_from_uvp` to allow the output to be non-square, i.e. the spherical window functions have shape `(Nk, Nk_in)` where `Nk` is the number of "output" k-bins (average over the (kperp, kpar) corresponding to (bl_lens, delays) and `Nk_in` is the number of "input" k-bins (average over the (kperp, kpar) from the exact computation, derived from the beam simulation, etc.

To do this I have modified the input of `spherical_wf_from_uvp` such that:
- `kbin_widths` has been removed
- `kbins` has been replaced by `kbin_edges` to allow for non-uniform binning
- `kbin_edges_in` has been added, to describe the bin edges of the "input" k-bins
Some tests have been fixed, and others added, to account for this change.