### PR TITLE
chore: enable ruff I (isort) lint family

### DIFF
--- a/examples/Average_spectra_example.ipynb
+++ b/examples/Average_spectra_example.ipynb
@@ -21,11 +21,12 @@
    "outputs": [],
    "source": [
     "%matplotlib inline\n",
-    "import numpy as np\n",
-    "import matplotlib.pyplot as plt\n",
     "import os\n",
     "\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
     "from pyuvdata import UVData\n",
+    "\n",
     "import hera_pspec as hp\n",
     "from hera_pspec.data import DATA_PATH"
    ]

--- a/examples/Bootstrap_example.ipynb
+++ b/examples/Bootstrap_example.ipynb
@@ -15,11 +15,12 @@
    "outputs": [],
    "source": [
     "%matplotlib inline\n",
-    "from pyuvdata import UVData\n",
-    "import hera_pspec as hp\n",
-    "from hera_cal import redcal\n",
+    "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
-    "import matplotlib.pyplot as plt"
+    "from hera_cal import redcal\n",
+    "from pyuvdata import UVData\n",
+    "\n",
+    "import hera_pspec as hp"
    ]
   },
   {

--- a/examples/DesignReview_WarmUp.ipynb
+++ b/examples/DesignReview_WarmUp.ipynb
@@ -29,13 +29,15 @@
    "outputs": [],
    "source": [
     "%matplotlib inline\n",
-    "import hera_pspec as hp\n",
+    "import glob\n",
+    "import os\n",
+    "\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
-    "from hera_pspec.data import DATA_PATH\n",
     "from pyuvdata import UVData\n",
-    "import os\n",
-    "import glob"
+    "\n",
+    "import hera_pspec as hp\n",
+    "from hera_pspec.data import DATA_PATH"
    ]
   },
   {

--- a/examples/Error_estimation_example.ipynb
+++ b/examples/Error_estimation_example.ipynb
@@ -26,11 +26,12 @@
    "outputs": [],
    "source": [
     "%matplotlib inline\n",
-    "import numpy as np\n",
-    "import matplotlib.pyplot as plt\n",
     "import os\n",
     "\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
     "from pyuvdata import UVData\n",
+    "\n",
     "import hera_pspec as hp\n",
     "from hera_pspec.data import DATA_PATH"
    ]

--- a/examples/Forming_PseudoStokes_Vis.ipynb
+++ b/examples/Forming_PseudoStokes_Vis.ipynb
@@ -18,13 +18,15 @@
    "outputs": [],
    "source": [
     "%matplotlib inline\n",
-    "import matplotlib.pyplot as plt\n",
-    "from pathlib import Path\n",
-    "import hera_pspec as hp\n",
-    "from hera_pspec.data import DATA_PATH\n",
     "import os\n",
+    "from pathlib import Path\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
     "from pyuvdata import UVData\n",
-    "import numpy as np"
+    "\n",
+    "import hera_pspec as hp\n",
+    "from hera_pspec.data import DATA_PATH"
    ]
   },
   {

--- a/examples/Inverse_sinc_weighting_example.ipynb
+++ b/examples/Inverse_sinc_weighting_example.ipynb
@@ -19,18 +19,20 @@
    "outputs": [],
    "source": [
     "%matplotlib inline\n",
-    "from pyuvdata import UVData\n",
-    "import hera_pspec as hp\n",
-    "import numpy as np\n",
-    "import matplotlib.pyplot as plt\n",
     "import copy\n",
-    "import os\n",
-    "import itertools\n",
     "import inspect\n",
-    "from hera_pspec.data import DATA_PATH\n",
-    "from hera_sim.simulate import Simulator\n",
+    "import itertools\n",
+    "import os\n",
+    "\n",
     "import hera_sim\n",
-    "from hera_sim import noise"
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "from hera_sim import noise\n",
+    "from hera_sim.simulate import Simulator\n",
+    "from pyuvdata import UVData\n",
+    "\n",
+    "import hera_pspec as hp\n",
+    "from hera_pspec.data import DATA_PATH"
    ]
   },
   {

--- a/examples/Overview_Core_Pspec_functions.ipynb
+++ b/examples/Overview_Core_Pspec_functions.ipynb
@@ -58,18 +58,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from pyuvdata import UVData, UVFlag\n",
-    "import hera_pspec as hp\n",
+    "import copy\n",
+    "import inspect\n",
+    "import itertools\n",
+    "import os\n",
+    "\n",
     "import hera_qm as hq\n",
+    "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
     "from astropy import units\n",
-    "import matplotlib.pyplot as plt\n",
-    "import copy\n",
-    "import os\n",
-    "import itertools\n",
-    "import inspect\n",
-    "from hera_pspec.data import DATA_PATH\n",
+    "from pyuvdata import UVData, UVFlag\n",
     "from pyuvdata import utils as uvutils\n",
+    "\n",
+    "import hera_pspec as hp\n",
+    "from hera_pspec.data import DATA_PATH\n",
     "\n",
     "colorlist = [\n",
     "    \"#1f77b4\",\n",
@@ -1818,7 +1820,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from matplotlib import colors, cm"
+    "from matplotlib import cm, colors"
    ]
   },
   {
@@ -3049,7 +3051,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from hera_pspec import UVWindow, FTBeam"
+    "from hera_pspec import FTBeam, UVWindow"
    ]
   },
   {

--- a/examples/PS_estimation_example.ipynb
+++ b/examples/PS_estimation_example.ipynb
@@ -15,14 +15,16 @@
    "outputs": [],
    "source": [
     "%matplotlib inline\n",
-    "from pyuvdata import UVData\n",
-    "import hera_pspec as hp\n",
-    "import numpy as np\n",
-    "import matplotlib.pyplot as plt\n",
     "import copy\n",
-    "import os\n",
-    "import itertools\n",
     "import inspect\n",
+    "import itertools\n",
+    "import os\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "from pyuvdata import UVData\n",
+    "\n",
+    "import hera_pspec as hp\n",
     "from hera_pspec.data import DATA_PATH"
    ]
   },

--- a/examples/PSpecBeam_tutorial.ipynb
+++ b/examples/PSpecBeam_tutorial.ipynb
@@ -25,8 +25,9 @@
    "outputs": [],
    "source": [
     "%matplotlib inline\n",
-    "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "\n",
     "import hera_pspec as hp"
    ]
   },
@@ -212,8 +213,9 @@
     }
    ],
    "source": [
-    "from pyuvdata import UVData\n",
     "import os\n",
+    "\n",
+    "from pyuvdata import UVData\n",
     "\n",
     "# Create a UVData object and fill it with data\n",
     "datafile = os.path.join(\"../src/hera_pspec/data/\", \"zen.2458042.12552.xx.HH.uvXAA\")\n",

--- a/examples/Plotting_examples.ipynb
+++ b/examples/Plotting_examples.ipynb
@@ -15,10 +15,11 @@
    "outputs": [],
    "source": [
     "%matplotlib inline\n",
-    "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
-    "import hera_pspec as hp\n",
-    "from pyuvdata import UVData"
+    "import numpy as np\n",
+    "from pyuvdata import UVData\n",
+    "\n",
+    "import hera_pspec as hp"
    ]
   },
   {

--- a/examples/UVWindow_tutorial.ipynb
+++ b/examples/UVWindow_tutorial.ipynb
@@ -112,13 +112,14 @@
    },
    "outputs": [],
    "source": [
-    "from pyuvdata import UVData, UVBeam\n",
-    "from pyuvdata import utils as uvutils\n",
-    "import hera_pspec as hp\n",
-    "from hera_pspec.data import DATA_PATH\n",
     "from hera_cal import redcal\n",
+    "from pyuvdata import UVBeam, UVData\n",
+    "from pyuvdata import utils as uvutils\n",
+    "\n",
+    "import hera_pspec as hp\n",
     "from hera_pspec import utils\n",
-    "from hera_pspec import uvpspec_utils as uvputils"
+    "from hera_pspec import uvpspec_utils as uvputils\n",
+    "from hera_pspec.data import DATA_PATH"
    ]
   },
   {
@@ -135,13 +136,14 @@
    },
    "outputs": [],
    "source": [
-    "from astropy import units\n",
-    "import numpy as np\n",
-    "from multiprocessing import Pool\n",
     "import time\n",
+    "from multiprocessing import Pool\n",
+    "\n",
     "import h5py\n",
     "import matplotlib.pyplot as plt\n",
-    "from matplotlib import colors, cm\n",
+    "import numpy as np\n",
+    "from astropy import units\n",
+    "from matplotlib import cm, colors\n",
     "\n",
     "%matplotlib inline"
    ]
@@ -160,7 +162,7 @@
    },
    "outputs": [],
    "source": [
-    "from hera_pspec import UVWindow, FTBeam"
+    "from hera_pspec import FTBeam, UVWindow"
    ]
   },
   {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,6 +118,7 @@ select = [
     "E",      # pycodestyle errors
     "W",      # pycodestyle warnings
     "F",      # pyflakes
+    "I",      # isort
     "FA",     # flake8-future-annotations
     "Q",      # flake8-quotes
     "A",      # flake8-builtins

--- a/scripts/auto_noise_run.py
+++ b/scripts/auto_noise_run.py
@@ -3,10 +3,11 @@
 Pipeline script to obtain error bars from autocorrelations.
 """
 
+from hera_cal._cli_tools import parse_args, run_with_profiling
+from pyuvdata import UVData
+
 from hera_pspec import utils
 from hera_pspec.container import PSpecContainer
-from pyuvdata import UVData
-from hera_cal._cli_tools import parse_args, run_with_profiling
 
 
 def main(args):

--- a/scripts/bootstrap_run.py
+++ b/scripts/bootstrap_run.py
@@ -4,8 +4,9 @@ Pipeline script to load a PSpecContainer and bootstrap over redundant baseline-
 pair groups to produce errorbars.
 """
 
-from hera_pspec import grouping
 from hera_cal._cli_tools import parse_args, run_with_profiling
+
+from hera_pspec import grouping
 
 # Parse commandline args
 args = grouping.get_bootstrap_run_argparser()

--- a/scripts/generate_pstokes_run.py
+++ b/scripts/generate_pstokes_run.py
@@ -5,9 +5,10 @@ Pipeline script for generating pstokes visibility.
 
 import copy
 
-from hera_pspec import pstokes
-from pyuvdata import UVData
 import pyuvdata
+from pyuvdata import UVData
+
+from hera_pspec import pstokes
 
 ap = pstokes.generate_pstokes_argparser()
 args = ap.parse_args()

--- a/scripts/psc_merge_spectra.py
+++ b/scripts/psc_merge_spectra.py
@@ -4,8 +4,9 @@ Command-line script for merging UVPSpec power spectra
 within a PSpecContainer.
 """
 
-from hera_pspec import container
 from hera_cal._cli_tools import parse_args, run_with_profiling
+
+from hera_pspec import container
 
 # Parse commandline args
 args = container.get_combine_psc_argparser()

--- a/scripts/pspec_red.py
+++ b/scripts/pspec_red.py
@@ -3,14 +3,16 @@
 Run HERA OQE power spectrum estimation code on sets of redundant baselines.
 """
 
-import hera_pspec as hp
-from hera_pspec.utils import log, load_config
-from hera_cal import redcal
-import pyuvdata as uv
+import glob
 import os
 import sys
-import glob
 import time
+
+import pyuvdata as uv
+from hera_cal import redcal
+
+import hera_pspec as hp
+from hera_pspec.utils import load_config, log
 
 # Default settings for pspec calculation
 pspec_defaults = {

--- a/scripts/pspec_run.py
+++ b/scripts/pspec_run.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python
 import sys
+
+from hera_cal._cli_tools import filter_kwargs, parse_args, run_with_profiling
+
 from hera_pspec import pspecdata
-from hera_cal._cli_tools import parse_args, run_with_profiling, filter_kwargs
 
 # parse args
 args = pspecdata.get_pspec_run_argparser()

--- a/src/hera_pspec/__init__.py
+++ b/src/hera_pspec/__init__.py
@@ -3,9 +3,9 @@ __init__.py file for hera_pspec
 """
 
 try:
-    from importlib.metadata import version, PackageNotFoundError
+    from importlib.metadata import PackageNotFoundError, version
 except ImportError:
-    from importlib_metadata import version, PackageNotFoundError
+    from importlib_metadata import PackageNotFoundError, version
 
 try:
     from ._version import version as __version__
@@ -16,16 +16,14 @@ except ModuleNotFoundError:  # pragma: no cover
         # package is not installed
         __version__ = "unknown"
 
-from . import conversions, grouping, pspecbeam, plot, pstokes, testing, utils, loss
+from . import conversions, grouping, loss, plot, pspecbeam, pstokes, testing, utils
 from . import uvpspec_utils as uvputils
-
-from .uvpspec import UVPSpec
-from .uvwindow import UVWindow, FTBeam
-from .pspecdata import PSpecData
 from .container import PSpecContainer
 from .parameter import PSpecParam
-from .pspecbeam import PSpecBeamUV, PSpecBeamGauss, PSpecBeamFromArray
-
+from .pspecbeam import PSpecBeamFromArray, PSpecBeamGauss, PSpecBeamUV
+from .pspecdata import PSpecData
+from .uvpspec import UVPSpec
+from .uvwindow import FTBeam, UVWindow
 
 del version
 del PackageNotFoundError

--- a/src/hera_pspec/cli.py
+++ b/src/hera_pspec/cli.py
@@ -1,17 +1,19 @@
 """A CLI interface for hera_pspec."""
 
-import typer
-from pathlib import Path
-from rich.console import Console
-import h5py
-import pickle
 import glob
+import pickle
+from pathlib import Path
+
+import h5py
+import typer
+from rich.console import Console
 from tqdm import tqdm
 
 cns = Console()
 
 app = typer.Typer()
-from . import container  # noqa: E402  (typer pattern: register subcommands after app is constructed)
+# typer pattern: register subcommands after app is constructed
+from . import container  # noqa: E402
 from .uvpspec import recursive_combine_uvpspec  # noqa: E402
 
 

--- a/src/hera_pspec/container.py
+++ b/src/hera_pspec/container.py
@@ -1,11 +1,12 @@
-import numpy as np
-import h5py
 import argparse
 import time
-from functools import wraps
 import warnings
+from functools import wraps
 
-from . import uvpspec, __version__, utils
+import h5py
+import numpy as np
+
+from . import __version__, utils, uvpspec
 
 
 def transactional(fn):

--- a/src/hera_pspec/grouping.py
+++ b/src/hera_pspec/grouping.py
@@ -1,13 +1,15 @@
-import numpy as np
-from collections import OrderedDict as odict
-import random
-import copy
-import warnings
 import argparse
-from astropy import stats as astats
+import copy
 import os
+import random
+import warnings
+from collections import OrderedDict as odict
 
-from . import utils, __version__, uvpspec_utils as uvputils
+import numpy as np
+from astropy import stats as astats
+
+from . import __version__, utils
+from . import uvpspec_utils as uvputils
 from .uvpspec import _ordered_unique
 
 

--- a/src/hera_pspec/loss.py
+++ b/src/hera_pspec/loss.py
@@ -1,7 +1,8 @@
 """Functions to apply and estimate losses/biases in the power spectrum estimates."""
 
-from .uvpspec import UVPSpec
 import copy
+
+from .uvpspec import UVPSpec
 
 
 def apply_bias_correction(

--- a/src/hera_pspec/noise.py
+++ b/src/hera_pspec/noise.py
@@ -1,9 +1,11 @@
-import numpy as np
 import ast
 from collections import OrderedDict as odict
-from uvtools import dspec
-from . import conversions
+
+import numpy as np
 from scipy.linalg import circulant
+from uvtools import dspec
+
+from . import conversions
 
 
 def calc_P_N(

--- a/src/hera_pspec/plot.py
+++ b/src/hera_pspec/plot.py
@@ -1,10 +1,11 @@
-import numpy as np
 import copy
 from collections import OrderedDict as odict
-from pyuvdata import UVData
-import uvtools
 
-from . import conversions, uvpspec, utils
+import numpy as np
+import uvtools
+from pyuvdata import UVData
+
+from . import conversions, utils, uvpspec
 
 
 def delay_spectrum(
@@ -455,8 +456,8 @@ def delay_waterfall(
         Matplotlib Figure instance if input ax is None.
     """
     import matplotlib
-    import matplotlib.pyplot as plt
     import matplotlib.axes
+    import matplotlib.pyplot as plt
 
     # assert component
     assert component in ["real", "abs", "imag", "abs-real", "abs-imag"], (

--- a/src/hera_pspec/pspecbeam.py
+++ b/src/hera_pspec/pspecbeam.py
@@ -8,7 +8,7 @@ from pyuvdata import UVBeam
 from pyuvdata import utils as uvutils
 from scipy.interpolate import interp1d
 
-from . import conversions as conversions
+from . import conversions
 from . import uvpspec_utils as uvputils
 
 

--- a/src/hera_pspec/pspecbeam.py
+++ b/src/hera_pspec/pspecbeam.py
@@ -1,12 +1,15 @@
-import numpy as np
-import scipy.integrate as integrate
-from scipy.interpolate import interp1d
-from pyuvdata import UVBeam, utils as uvutils
-import uvtools.dspec as dspec
 from collections import OrderedDict as odict
 from pathlib import Path
 
-from . import conversions as conversions, uvpspec_utils as uvputils
+import numpy as np
+import scipy.integrate as integrate
+import uvtools.dspec as dspec
+from pyuvdata import UVBeam
+from pyuvdata import utils as uvutils
+from scipy.interpolate import interp1d
+
+from . import conversions as conversions
+from . import uvpspec_utils as uvputils
 
 
 def _compute_pspec_scalar(

--- a/src/hera_pspec/pspecdata.py
+++ b/src/hera_pspec/pspecdata.py
@@ -1,27 +1,31 @@
-import numpy as np
-from pyuvdata import UVData, UVCal
-import copy
-import itertools
-from collections import OrderedDict as odict
-import hera_cal as hc
-from pyuvdata import utils as uvutils
-import datetime
-import time
 import argparse
+import copy
+import datetime
 import glob
-import warnings
+import itertools
 import json
-import uvtools.dspec as dspec
 import logging
+import time
+import warnings
+from collections import OrderedDict as odict
+from functools import lru_cache
+
+import hera_cal as hc
+import numpy as np
+import uvtools.dspec as dspec
+from pyuvdata import UVCal, UVData
+from pyuvdata import utils as uvutils
+
 from . import (
-    uvpspec,
-    utils,
     __version__,
-    pspecbeam,
     container,
+    pspecbeam,
+    utils,
+    uvpspec,
+)
+from . import (
     uvpspec_utils as uvputils,
 )
-from functools import lru_cache
 
 logger = logging.getLogger(__name__)
 

--- a/src/hera_pspec/pspecdata.py
+++ b/src/hera_pspec/pspecdata.py
@@ -16,16 +16,8 @@ import uvtools.dspec as dspec
 from pyuvdata import UVCal, UVData
 from pyuvdata import utils as uvutils
 
-from . import (
-    __version__,
-    container,
-    pspecbeam,
-    utils,
-    uvpspec,
-)
-from . import (
-    uvpspec_utils as uvputils,
-)
+from . import __version__, container, pspecbeam, utils, uvpspec
+from . import uvpspec_utils as uvputils
 
 logger = logging.getLogger(__name__)
 

--- a/src/hera_pspec/pstokes.py
+++ b/src/hera_pspec/pstokes.py
@@ -2,13 +2,14 @@
 Module to construct pseudo-Stokes (I,Q,U,V) visibilities from miriad files or UVData objects
 """
 
-import numpy as np
-import pyuvdata
+import argparse
 import copy
+import warnings
 from collections import OrderedDict as odict
 from collections.abc import Iterable
-import argparse
-import warnings
+
+import numpy as np
+import pyuvdata
 
 from . import __version__
 

--- a/src/hera_pspec/testing.py
+++ b/src/hera_pspec/testing.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python2
-import numpy as np
 import copy
-from pyuvdata import UVData
-from hera_cal.utils import JD2LST
-from scipy import stats, interpolate
 
-from . import uvpspec, pspecdata, conversions, pspecbeam, utils
+import numpy as np
+from hera_cal.utils import JD2LST
+from pyuvdata import UVData
+from scipy import interpolate, stats
+
+from . import conversions, pspecbeam, pspecdata, utils, uvpspec
 
 
 def build_vanilla_uvpspec(

--- a/src/hera_pspec/utils.py
+++ b/src/hera_pspec/utils.py
@@ -1,20 +1,23 @@
-import numpy as np
-import time
-import yaml
-import itertools
-import glob
-import traceback
-from hera_cal import redcal
-from collections import OrderedDict as odict
-from pyuvdata import UVData, utils as uvutils
-from datetime import datetime
-import copy
-from scipy.interpolate import interp1d
-import uvtools as uvt
 import argparse
-from .conversions import Cosmo_Conversions
+import copy
+import glob
 import inspect
+import itertools
+import time
+import traceback
+from collections import OrderedDict as odict
+from datetime import datetime
+
+import numpy as np
+import uvtools as uvt
+import yaml
+from hera_cal import redcal
+from pyuvdata import UVData
+from pyuvdata import utils as uvutils
+from scipy.interpolate import interp1d
+
 from . import __version__
+from .conversions import Cosmo_Conversions
 
 
 def circular_average(angles, axis=0):
@@ -1463,8 +1466,7 @@ def uvd_to_Tsys(uvd, beam, Tsys_outfile=None):
     uvd.select(bls=autobls, polarizations=pols)
 
     # construct beam
-    from hera_pspec import pspecbeam
-    from hera_pspec import uvpspec
+    from hera_pspec import pspecbeam, uvpspec
 
     if isinstance(beam, str):
         beam = pspecbeam.PSpecBeamUV(beam)

--- a/src/hera_pspec/uvpspec.py
+++ b/src/hera_pspec/uvpspec.py
@@ -1,12 +1,13 @@
-import numpy as np
-from collections import OrderedDict as odict
-import os
-import copy
 import ast
+import copy
 import fnmatch
-from pyuvdata import utils as uvutils
-import h5py
+import os
 import warnings
+from collections import OrderedDict as odict
+
+import h5py
+import numpy as np
+from pyuvdata import utils as uvutils
 
 try:
     from typing import Self
@@ -14,13 +15,15 @@ except ImportError:
     from typing_extensions import Self
 
 from . import (
-    conversions,
-    noise,
-    version,
     __version__,
-    pspecbeam,
+    conversions,
     grouping,
+    noise,
+    pspecbeam,
     utils,
+    version,
+)
+from . import (
     uvpspec_utils as uvputils,
 )
 from .parameter import PSpecParam

--- a/src/hera_pspec/uvpspec.py
+++ b/src/hera_pspec/uvpspec.py
@@ -14,18 +14,8 @@ try:
 except ImportError:
     from typing_extensions import Self
 
-from . import (
-    __version__,
-    conversions,
-    grouping,
-    noise,
-    pspecbeam,
-    utils,
-    version,
-)
-from . import (
-    uvpspec_utils as uvputils,
-)
+from . import __version__, conversions, grouping, noise, pspecbeam, utils, version
+from . import uvpspec_utils as uvputils
 from .parameter import PSpecParam
 from .uvwindow import UVWindow
 

--- a/src/hera_pspec/uvpspec_utils.py
+++ b/src/hera_pspec/uvpspec_utils.py
@@ -1,9 +1,10 @@
-import numpy as np
 import copy
-from collections import OrderedDict as odict
-from pyuvdata.utils import polstr2num, polnum2str
 import json
 import warnings
+from collections import OrderedDict as odict
+
+import numpy as np
+from pyuvdata.utils import polnum2str, polstr2num
 
 from . import utils
 

--- a/src/hera_pspec/uvwindow.py
+++ b/src/hera_pspec/uvwindow.py
@@ -1,14 +1,15 @@
-from pyuvdata import utils as uvutils
-import uvtools.dspec as dspec
-import h5py
-import warnings
-import numpy as np
-import sys
-import os
 import copy
-from scipy.interpolate import RegularGridInterpolator
-from astropy import units
+import os
+import sys
+import warnings
 from pathlib import Path
+
+import h5py
+import numpy as np
+import uvtools.dspec as dspec
+from astropy import units
+from pyuvdata import utils as uvutils
+from scipy.interpolate import RegularGridInterpolator
 
 from . import conversions, utils
 from . import uvpspec_utils as uvputils

--- a/src/hera_pspec/version.py
+++ b/src/hera_pspec/version.py
@@ -1,4 +1,5 @@
 import warnings
+
 from . import utils
 
 

--- a/tests/compare_legacy_oqe.py
+++ b/tests/compare_legacy_oqe.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 from __future__ import print_function
-import numpy as np
+
 import matplotlib.pyplot as plt
+import numpy as np
 
 
 def run_old_oqe(fname, key1, key2, freqrange):
@@ -62,6 +63,7 @@ def run_new_oqe(fname, key1, key2, freqrange):
     Run new OQE algorithm using hera_pspec.
     """
     from pyuvdata import UVData
+
     import hera_pspec as pspec
 
     # (1) Read data from file

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,15 +3,16 @@
 This adds several mock UVPSpec objects that can be used throughout the tests.
 """
 
-import pytest
-from hera_pspec.testing import build_vanilla_uvpspec
-from hera_pspec import UVPSpec, PSpecData, utils, grouping
-from hera_pspec import PSpecBeamUV
-from pathlib import Path
-from hera_pspec.data import DATA_PATH
-from pyuvdata import UVData
 import copy
+from pathlib import Path
+
 import numpy as np
+import pytest
+from pyuvdata import UVData
+
+from hera_pspec import PSpecBeamUV, PSpecData, UVPSpec, grouping, utils
+from hera_pspec.data import DATA_PATH
+from hera_pspec.testing import build_vanilla_uvpspec
 
 DATA_PATH = Path(DATA_PATH)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,11 +1,13 @@
+import pickle
+from pathlib import Path
+
+import h5py
+import pytest
 from typer.testing import CliRunner
+
 from hera_pspec import cli, testing
 from hera_pspec.container import PSpecContainer
 from hera_pspec.uvpspec import UVPSpec
-import pytest
-import h5py
-import pickle
-from pathlib import Path
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -1,9 +1,11 @@
-import unittest
-import pytest
-import numpy as np
 import os
+import unittest
+
+import numpy as np
+import pytest
+
+from hera_pspec import PSpecContainer, UVPSpec, container, testing
 from hera_pspec.data import DATA_PATH
-from hera_pspec import container, PSpecContainer, UVPSpec, testing
 
 
 class Test_PSpecContainer(unittest.TestCase):

--- a/tests/test_conversions.py
+++ b/tests/test_conversions.py
@@ -1,5 +1,7 @@
 import unittest
+
 import numpy as np
+
 from hera_pspec import conversions
 
 

--- a/tests/test_grouping.py
+++ b/tests/test_grouping.py
@@ -1,22 +1,25 @@
-import pytest
-import numpy as np
+import copy
 import os
-from hera_pspec.data import DATA_PATH
+
+import numpy as np
+import pytest
+from hera_cal import redcal
+from pytest_cases import parametrize_with_cases
+from pyuvdata import UVData
+
 from hera_pspec import (
-    uvpspec,
+    UVPSpec,
+    container,
     conversions,
+    grouping,
     pspecbeam,
     pspecdata,
     testing,
     utils,
+    uvpspec,
     uvwindow,
 )
-from hera_pspec import grouping, container
-from pyuvdata import UVData
-from hera_cal import redcal
-import copy
-from pytest_cases import parametrize_with_cases
-from hera_pspec import UVPSpec
+from hera_pspec.data import DATA_PATH
 
 
 def case_vanilla_uvp(vanilla_uvp: UVPSpec):

--- a/tests/test_loss.py
+++ b/tests/test_loss.py
@@ -1,9 +1,11 @@
 """Tests for loss functions in hera_pspec."""
 
 import os
-from hera_pspec import pspecbeam, testing, loss
-from hera_pspec.data import DATA_PATH
+
 import numpy as np
+
+from hera_pspec import loss, pspecbeam, testing
+from hera_pspec.data import DATA_PATH
 
 
 class TestApplyBiasCorrection:

--- a/tests/test_noise.py
+++ b/tests/test_noise.py
@@ -1,12 +1,13 @@
-import unittest
-import pytest
-import numpy as np
-import os
 import copy
+import os
+import unittest
+
+import numpy as np
+import pytest
 from pyuvdata import UVData
 
+from hera_pspec import conversions, noise, pspecbeam, pspecdata, testing, utils
 from hera_pspec.data import DATA_PATH
-from hera_pspec import conversions, pspecdata, pspecbeam, noise, testing, utils
 
 
 class Test_Sensitivity(unittest.TestCase):

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -1,14 +1,16 @@
+import copy
+import glob
+import os
 import unittest
-import pytest
+
 import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
-import os
-import copy
-from hera_pspec import pspecdata, pspecbeam, conversions, plot, utils, grouping
-from hera_pspec.data import DATA_PATH
+import pytest
 from pyuvdata import UVData
-import glob
+
+from hera_pspec import conversions, grouping, plot, pspecbeam, pspecdata, utils
+from hera_pspec.data import DATA_PATH
 
 # Data files to use in tests
 dfiles = ["zen.all.xx.LST.1.06964.uvA"]

--- a/tests/test_pspecbeam.py
+++ b/tests/test_pspecbeam.py
@@ -1,10 +1,12 @@
-import unittest
 import os
-import pytest
+import unittest
+
 import numpy as np
-from hera_pspec import pspecbeam, conversions
-from hera_pspec.data import DATA_PATH
+import pytest
 from pyuvdata import UVBeam
+
+from hera_pspec import conversions, pspecbeam
+from hera_pspec.data import DATA_PATH
 
 
 class Test_DataSet(unittest.TestCase):

--- a/tests/test_pspecdata.py
+++ b/tests/test_pspecdata.py
@@ -1,28 +1,31 @@
-import unittest
-import pytest
-import numpy as np
-import pyuvdata as uv
-import os
 import copy
+import glob
+import os
+import unittest
+import warnings
+
+import numpy as np
+import pytest
+import pyuvdata as uv
+from astropy.time import Time
+from hera_cal import redcal
+from pyuvdata import UVCal, UVData
+from pyuvdata import utils as uvutils
 from scipy.integrate import trapezoid
+from scipy.interpolate import interp1d
+from scipy.signal import windows
+from uvtools import dspec
+
 from hera_pspec import (
-    pspecdata,
-    pspecbeam,
-    conversions,
     container,
-    utils,
+    conversions,
+    pspecbeam,
+    pspecdata,
     testing,
+    utils,
     uvwindow,
 )
 from hera_pspec.data import DATA_PATH
-from pyuvdata import UVData, UVCal, utils as uvutils
-from hera_cal import redcal
-from scipy.signal import windows
-from scipy.interpolate import interp1d
-from astropy.time import Time
-import warnings
-import glob
-from uvtools import dspec
 
 # Data files to use in tests
 dfiles = ["zen.2458042.12552.xx.HH.uvXAA", "zen.2458042.12552.xx.HH.uvXAA"]

--- a/tests/test_pstokes.py
+++ b/tests/test_pstokes.py
@@ -1,12 +1,14 @@
-import unittest
-import pytest
+import copy
 import os
-from hera_pspec.data import DATA_PATH
-from hera_pspec import pstokes
+import unittest
+
+import numpy as np
+import pytest
 import pyuvdata
 import pyuvdata.utils as uvutils
-import copy
-import numpy as np
+
+from hera_pspec import pstokes
+from hera_pspec.data import DATA_PATH
 
 dset1 = os.path.join(DATA_PATH, "zen.all.xx.LST.1.06964.uvA")
 dset2 = os.path.join(DATA_PATH, "zen.all.yy.LST.1.06964.uvA")

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -1,11 +1,13 @@
-import pytest
-from hera_pspec.data import DATA_PATH
-from hera_pspec import testing, uvpspec, conversions, pspecbeam
-import os
-from pyuvdata import UVData
-import numpy as np
-from hera_cal import redcal
 import copy
+import os
+
+import numpy as np
+import pytest
+from hera_cal import redcal
+from pyuvdata import UVData
+
+from hera_pspec import conversions, pspecbeam, testing, uvpspec
+from hera_pspec.data import DATA_PATH
 
 
 def test_build_vanilla_uvpspec():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,12 +1,14 @@
-import pytest
-import numpy as np
+import copy
 import os
 import sys
-import copy
-from hera_pspec.data import DATA_PATH
-from hera_pspec import utils, testing, pspecbeam
-from pyuvdata import UVData
+
+import numpy as np
+import pytest
 from hera_cal import redcal
+from pyuvdata import UVData
+
+from hera_pspec import pspecbeam, testing, utils
+from hera_pspec.data import DATA_PATH
 
 
 def test_circular_average():

--- a/tests/test_uvpspec.py
+++ b/tests/test_uvpspec.py
@@ -1,26 +1,28 @@
-import pytest
-import numpy as np
+import copy
 import os
-from hera_pspec.data import DATA_PATH
+from collections import OrderedDict as odict
+from pathlib import Path
+
+import numpy as np
+import pytest
+from hera_cal import redcal
+from pytest_cases import parametrize_with_cases
+from pyuvdata import UVData
+
 from hera_pspec import (
-    uvpspec,
+    UVPSpec,
     conversions,
+    grouping,
     parameter,
     pspecbeam,
     pspecdata,
     testing,
     utils,
+    uvpspec,
     uvwindow,
-    grouping,
 )
 from hera_pspec import uvpspec_utils as uvputils
-import copy
-from collections import OrderedDict as odict
-from pyuvdata import UVData
-from hera_cal import redcal
-from pytest_cases import parametrize_with_cases
-from hera_pspec import UVPSpec
-from pathlib import Path
+from hera_pspec.data import DATA_PATH
 
 
 # Setup Test Cases for this module

--- a/tests/test_uvpspec_utils.py
+++ b/tests/test_uvpspec_utils.py
@@ -1,11 +1,13 @@
-import pytest
-import numpy as np
-from hera_pspec import uvpspec_utils as uvputils
-from hera_pspec import testing, grouping, pspecbeam, UVPSpec
-from hera_pspec.data import DATA_PATH
-import os
 import copy
 import json
+import os
+
+import numpy as np
+import pytest
+
+from hera_pspec import UVPSpec, grouping, pspecbeam, testing
+from hera_pspec import uvpspec_utils as uvputils
+from hera_pspec.data import DATA_PATH
 
 
 def test_select_common():

--- a/tests/test_uvwindow.py
+++ b/tests/test_uvwindow.py
@@ -1,14 +1,14 @@
-import unittest
-import pytest
-import numpy as np
-import os
 import copy
+import os
+import unittest
+
+import numpy as np
+import pytest
 from astropy import units
 from pyuvdata import UVData
-from hera_pspec.data import DATA_PATH
 
-from hera_pspec import conversions, pspecbeam, utils
-from hera_pspec import uvwindow, PSpecData
+from hera_pspec import PSpecData, conversions, pspecbeam, utils, uvwindow
+from hera_pspec.data import DATA_PATH
 
 # Data files to use in tests
 dfile = "zen.2458116.31939.HH.uvh5"


### PR DESCRIPTION
Enables `I` (isort). Autofixes 62 `I001` violations; import-order-only.

`__init__.py` re-exports alphabetized. One touch-up in `cli.py`: moved a long inline comment off a `# noqa: E402` import so isort didn't wrap it onto a continuation line.

Tests pass locally.