### PR TITLE
chore: enable additional ruff lint families

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,6 +124,15 @@ select = [
     "PIE",    # flake8-pie
     "PERF",   # perflint
     "UP",     # pyupgrade
+    "FLY",    # flynt
+    "LOG",    # flake8-logging
+    "ISC",    # flake8-implicit-str-concat
+    "RSE",    # flake8-raise
+    "TID",    # flake8-tidy-imports
+    "YTT",    # flake8-2020 (sys.version usage)
+    "ICN",    # flake8-import-conventions
+    "FURB",   # refurb
+    "RUF100", # unused-noqa (RUF100 only; rest of RUF deferred)
 ]
 ignore = [
     "UP031",  # printf-string-formatting (69) — manual conversion, deferred to follow-up PR

--- a/src/hera_pspec/plot.py
+++ b/src/hera_pspec/plot.py
@@ -453,8 +453,7 @@ def delay_waterfall(
     fig : matplotlib.pyplot.Figure
         Matplotlib Figure instance if input ax is None.
     """
-    import matplotlib
-    import matplotlib.axes
+    import matplotlib as mpl
     import matplotlib.pyplot as plt
 
     # assert component
@@ -576,7 +575,7 @@ def delay_waterfall(
         fig, axes = plt.subplots(Nside, Nside, figsize=figsize)
 
     # Ensure axes is an ndarray
-    if isinstance(axes, matplotlib.axes.Axes):
+    if isinstance(axes, mpl.axes.Axes):
         axes = np.array([[axes]])
     if isinstance(axes, list):
         axes = np.array(axes)
@@ -870,7 +869,7 @@ def delay_wedge(
     fig : matplotlib.pyplot.Figure
         Matplotlib Figure instance if ax is None.
     """
-    import matplotlib
+    import matplotlib as mpl
     import matplotlib.pyplot as plt
 
     # type checking
@@ -976,10 +975,10 @@ def delay_wedge(
     if loglog:
         ax.set_xscale("log")
         ax.set_yscale("log")
-        ax.yaxis.set_major_formatter(matplotlib.ticker.LogFormatterSciNotation())
-        ax.yaxis.set_minor_formatter(matplotlib.ticker.NullFormatter())
-        ax.xaxis.set_major_formatter(matplotlib.ticker.LogFormatterSciNotation())
-        ax.xaxis.set_minor_formatter(matplotlib.ticker.NullFormatter())
+        ax.yaxis.set_major_formatter(mpl.ticker.LogFormatterSciNotation())
+        ax.yaxis.set_minor_formatter(mpl.ticker.NullFormatter())
+        ax.xaxis.set_major_formatter(mpl.ticker.LogFormatterSciNotation())
+        ax.xaxis.set_minor_formatter(mpl.ticker.NullFormatter())
 
     # rotate
     if rotate:

--- a/src/hera_pspec/uvpspec_utils.py
+++ b/src/hera_pspec/uvpspec_utils.py
@@ -460,7 +460,7 @@ def polpair_tuple2int(polpair, x_orientation=None):
         return [polpair_tuple2int(p) for p in polpair]
 
     # Check types
-    assert type(polpair) in (tuple,), "pol must be a tuple"
+    assert type(polpair) is tuple, "pol must be a tuple"
     assert len(polpair) == 2, "polpair tuple must have 2 elements"
 
     # Convert strings to ints if necessary

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -3,7 +3,7 @@ import glob
 import os
 import unittest
 
-import matplotlib
+import matplotlib as mpl
 import matplotlib.pyplot as plt
 import numpy as np
 import pytest
@@ -119,7 +119,7 @@ class Test_Plot(unittest.TestCase):
             average_blpairs=True,
             average_times=True,
         )
-        elements = [(matplotlib.lines.Line2D, 1)]
+        elements = [(mpl.lines.Line2D, 1)]
         assert axes_contains(f1.axes[0], elements)
         plt.close(f1)
 
@@ -132,7 +132,7 @@ class Test_Plot(unittest.TestCase):
             average_blpairs=True,
             average_times=False,
         )
-        elements = [(matplotlib.lines.Line2D, self.uvp.Ntpairs)]
+        elements = [(mpl.lines.Line2D, self.uvp.Ntpairs)]
         assert axes_contains(f2.axes[0], elements)
         plt.close(f2)
 
@@ -145,7 +145,7 @@ class Test_Plot(unittest.TestCase):
             average_blpairs=False,
             average_times=True,
         )
-        elements = [(matplotlib.lines.Line2D, self.uvp.Nblpairs)]
+        elements = [(mpl.lines.Line2D, self.uvp.Nblpairs)]
         assert axes_contains(f3.axes[0], elements)
         plt.close(f3)
 
@@ -160,7 +160,7 @@ class Test_Plot(unittest.TestCase):
             average_times=True,
             fold=True,
         )
-        elements = [(matplotlib.lines.Line2D, 1)]
+        elements = [(mpl.lines.Line2D, 1)]
         assert axes_contains(f4.axes[0], elements)
         plt.close(f4)
 
@@ -174,7 +174,7 @@ class Test_Plot(unittest.TestCase):
             average_times=True,
             component="imag",
         )
-        elements = [(matplotlib.lines.Line2D, self.uvp.Nblpairs)]
+        elements = [(mpl.lines.Line2D, self.uvp.Nblpairs)]
         assert axes_contains(f4.axes[0], elements)
         plt.close(f4)
 
@@ -188,7 +188,7 @@ class Test_Plot(unittest.TestCase):
             average_times=True,
             component="abs",
         )
-        elements = [(matplotlib.lines.Line2D, self.uvp.Nblpairs)]
+        elements = [(mpl.lines.Line2D, self.uvp.Nblpairs)]
         assert axes_contains(f4.axes[0], elements)
         plt.close(f5)
 
@@ -252,7 +252,7 @@ class Test_Plot(unittest.TestCase):
             average_times=True,
             delay=False,
         )
-        elements = [(matplotlib.lines.Line2D, 1), (matplotlib.legend.Legend, 0)]
+        elements = [(mpl.lines.Line2D, 1), (mpl.legend.Legend, 0)]
         self.assertTrue(axes_contains(f1.axes[0], elements))
         plt.close(f1)
 
@@ -270,7 +270,7 @@ class Test_Plot(unittest.TestCase):
             label_type="blpair",
         )
         # Should contain 1 line and 1 legend
-        elements = [(matplotlib.lines.Line2D, 1), (matplotlib.legend.Legend, 1)]
+        elements = [(mpl.lines.Line2D, 1), (mpl.legend.Legend, 1)]
         self.assertTrue(axes_contains(f2.axes[0], elements))
         plt.close(f2)
 


### PR DESCRIPTION
Enables `FLY, LOG, ISC, RSE, TID, YTT, ICN, FURB, RUF100`. Six are zero-violation locks; three small fixes:

- 4× ICN001: `matplotlib` aliased to `mpl` in `plot.py` and `test_plot.py`
- 1× FURB171: `type(x) in (tuple,)` → `type(x) is tuple`

Only `RUF100` is selected from `RUF`; the rest is deferred.

Tests pass; docs build locally.