### PR TITLE
fix: warn when pspec_run produces no output

### DIFF
--- a/src/hera_pspec/pspecdata.py
+++ b/src/hera_pspec/pspecdata.py
@@ -4830,6 +4830,11 @@ def pspec_run(
         The PSpecData object used for OQE of power spectrum, with cached
         weighting matrices.
     """
+    no_output_warning = (
+        "pspec_run produced no output because the selected data contains no "
+        "matching baseline-pairs."
+    )
+
     # type check
     assert isinstance(dsets, (list, tuple, np.ndarray)), (
         "dsets must be fed as a list of dataset string paths or UVData objects."
@@ -4892,11 +4897,7 @@ def pspec_run(
             )
         except ValueError:
             # at least one of the dset loads failed due to no data being present
-            utils.log(
-                "One of the dset loads failed due to no data overlap given "
-                "the bls and pols selection",
-                verbose=verbose,
-            )
+            warnings.warn(no_output_warning, stacklevel=2)
             return None
 
     assert np.all([isinstance(d, UVData) for d in dsets]), (
@@ -4928,11 +4929,7 @@ def pspec_run(
             except ValueError:
                 # at least one of the dsets_std loads failed due to no data
                 # being present
-                utils.log(
-                    "One of the dsets_std loads failed due to no data overlap given "
-                    "the bls and pols selection",
-                    verbose=verbose,
-                )
+                warnings.warn(no_output_warning, stacklevel=2)
                 return None
 
         assert np.all([isinstance(d, UVData) for d in dsets_std]), err_msg
@@ -5127,6 +5124,7 @@ def pspec_run(
         groupname = "_".join(dset_labels)
 
     # Loop over dataset combinations
+    stored_pspec = False
     for i, dset_idxs in enumerate(dset_pairs):
         # check bls lists aren't empty
         if len(bls1_list[i]) == 0 or len(bls2_list[i]) == 0:
@@ -5167,6 +5165,10 @@ def pspec_run(
         # write in transactional mode
         logger.info(f"Storing {psname}")
         psc.set_pspec(group=groupname, psname=psname, pspec=uvp, overwrite=overwrite)
+        stored_pspec = True
+
+    if not stored_pspec:
+        warnings.warn(no_output_warning, stacklevel=2)
 
     return ds
 

--- a/tests/test_pspecdata.py
+++ b/tests/test_pspecdata.py
@@ -2844,14 +2844,18 @@ def test_pspec_run():
     # test when no data is loaded in dset
     if os.path.exists("./out.h5"):
         os.remove("./out.h5")
-    ds = pspecdata.pspec_run(
-        fnames,
-        "./out.h5",
-        Jy2mK=False,
-        verbose=False,
-        overwrite=True,
-        blpairs=[((500, 501), (600, 601))],
-    )  # blpairs that don't exist
+    with pytest.warns(
+        UserWarning,
+        match="pspec_run produced no output because the selected data contains no matching baseline-pairs.",
+    ):
+        ds = pspecdata.pspec_run(
+            fnames,
+            "./out.h5",
+            Jy2mK=False,
+            verbose=False,
+            overwrite=True,
+            blpairs=[((500, 501), (600, 601))],
+        )  # blpairs that don't exist
     assert ds == None
     assert os.path.exists("./out.h5") == False
 
@@ -2861,29 +2865,37 @@ def test_pspec_run():
         uvd = UVData()
         uvd.read_miriad(f)
         uvds.append(uvd)
-    ds = pspecdata.pspec_run(
-        uvds,
-        "./out.h5",
-        dsets_std=fnames_std,
-        Jy2mK=False,
-        verbose=False,
-        overwrite=True,
-        blpairs=[((500, 501), (600, 601))],
-    )
+    with pytest.warns(
+        UserWarning,
+        match="pspec_run produced no output because the selected data contains no matching baseline-pairs.",
+    ):
+        ds = pspecdata.pspec_run(
+            uvds,
+            "./out.h5",
+            dsets_std=fnames_std,
+            Jy2mK=False,
+            verbose=False,
+            overwrite=True,
+            blpairs=[((500, 501), (600, 601))],
+        )
     assert ds == None
     assert os.path.exists("./out.h5") == False
 
     # test when data is loaded, but no blpairs match
     if os.path.exists("./out.h5"):
         os.remove("./out.h5")
-    ds = pspecdata.pspec_run(
-        fnames,
-        "./out.h5",
-        Jy2mK=False,
-        verbose=False,
-        overwrite=True,
-        blpairs=[((37, 38), (600, 601))],
-    )
+    with pytest.warns(
+        UserWarning,
+        match="pspec_run produced no output because the selected data contains no matching baseline-pairs.",
+    ):
+        ds = pspecdata.pspec_run(
+            fnames,
+            "./out.h5",
+            Jy2mK=False,
+            verbose=False,
+            overwrite=True,
+            blpairs=[((37, 38), (600, 601))],
+        )
     assert isinstance(ds, pspecdata.PSpecData)
     assert os.path.exists("./out.h5") == False
 


### PR DESCRIPTION
## Summary

- emit a `UserWarning` when `pspec_run` produces no output because the selected data contains no matching baseline-pairs
- cover both the early no-data load path and the later no-output path after baseline-pair validation
- extend the existing `test_pspec_run` cases to assert the warning

## Testing

- `uv run --with ruff ruff check src/hera_pspec/pspecdata.py tests/test_pspecdata.py`
- `MPLBACKEND=agg uv run pytest tests/test_pspecdata.py::test_pspec_run tests/test_pspecdata.py::test_get_argparser tests/test_pspecdata.py::test_get_argparser_backwards_compatibility`

Closes #244

Merge #479 first before reviewing