### PR TITLE
chore: enable ruff E711 and E712 checks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,8 +139,6 @@ ignore = [
     "E501",   # line-too-long (1116) — defer to ruff format
     "E701",   # multi-statement on one line, colon (105)
     "E702",   # multi-statement on one line, semicolon (11)
-    "E711",   # none-comparison (13)
-    "E712",   # true-false-comparison (31)
     "E722",   # bare-except (12)
     "E741",   # ambiguous-variable-name (19) — `l`, `I`, `O` are scientific idioms
     "F401",   # unused-import (18) — includes legitimate __init__ re-exports

--- a/src/hera_pspec/container.py
+++ b/src/hera_pspec/container.py
@@ -596,7 +596,7 @@ def combine_psc_spectra(
         # Iterate over each unique spectra, and merge all spectra extensions
         for spc in unique_spectra:
             # check for overwrite
-            if spc in spectra and overwrite == False:
+            if spc in spectra and not overwrite:
                 if verbose:
                     print(
                         f"spectra {grp}/{spc} already exists and overwrite == False, "

--- a/src/hera_pspec/grouping.py
+++ b/src/hera_pspec/grouping.py
@@ -703,7 +703,7 @@ def average_spectra(
     uvp.check()
 
     # Return
-    if inplace == False:
+    if not inplace:
         return uvp
 
 

--- a/src/hera_pspec/plot.py
+++ b/src/hera_pspec/plot.py
@@ -156,7 +156,7 @@ def delay_spectrum(
             uvp_plt.average_spectra(time_avg=True, inplace=True)
 
     # Check plot size
-    if uvp_plt.Ntimes * len(blpairs) > 100 and force_plot == False:
+    if uvp_plt.Ntimes * len(blpairs) > 100 and not force_plot:
         raise ValueError(
             "Trying to plot > 100 spectra... Set force_plot=True to continue."
         )
@@ -553,7 +553,7 @@ def delay_waterfall(
 
     # check for reasonable number of blpairs to plot...
     Nkeys = len(waterfall)
-    if Nkeys > 20 and force_plot == False:
+    if Nkeys > 20 and not force_plot:
         raise ValueError("Nblps > 20 and force_plot == False, quitting...")
 
     # Take logarithm of data if requested

--- a/src/hera_pspec/pspecdata.py
+++ b/src/hera_pspec/pspecdata.py
@@ -2583,7 +2583,7 @@ class PSpecData:
             W = (W.T / W_norm).T
 
         elif mode == "V^-1/2":
-            if np.sum(band_covar) is None:
+            if band_covar is None:
                 raise ValueError("Covariance not supplied for V^-1/2 normalization")
             # First find the eigenvectors and eigenvalues of the unnormalizd covariance
             # Then use it to compute V^-1/2

--- a/src/hera_pspec/pspecdata.py
+++ b/src/hera_pspec/pspecdata.py
@@ -441,7 +441,7 @@ class PSpecData:
             key = (key,)
 
         # check key is a tuple
-        if isinstance(key, tuple) == False or len(key) not in (1, 2, 3):
+        if not isinstance(key, tuple) or len(key) not in (1, 2, 3):
             raise KeyError(f"key {key} must be a length 1, 2 or 3 tuple")
 
         try:
@@ -1642,7 +1642,7 @@ class PSpecData:
         G : array_like, complex
             Fisher matrix, with dimensions (Nfreqs, Nfreqs).
         """
-        if self.spw_Ndlys == None:
+        if self.spw_Ndlys is None:
             raise ValueError(
                 "Number of delay bins should have been set"
                 "by now! Cannot be equal to None"
@@ -1743,7 +1743,7 @@ class PSpecData:
         H : array_like, complex
             Dimensions (Nfreqs, Nfreqs).
         """
-        if self.spw_Ndlys == None:
+        if self.spw_Ndlys is None:
             raise ValueError(
                 "Number of delay bins should have been set"
                 "by now! Cannot be equal to None."
@@ -1837,7 +1837,7 @@ class PSpecData:
             Set of E matrices, with dimensions (Ndlys, Nfreqs, Nfreqs).
 
         """
-        if self.spw_Ndlys == None:
+        if self.spw_Ndlys is None:
             raise ValueError(
                 "Number of delay bins should have been set"
                 "by now! Cannot be equal to None"
@@ -2583,7 +2583,7 @@ class PSpecData:
             W = (W.T / W_norm).T
 
         elif mode == "V^-1/2":
-            if np.sum(band_covar) == None:
+            if np.sum(band_covar) is None:
                 raise ValueError("Covariance not supplied for V^-1/2 normalization")
             # First find the eigenvectors and eigenvalues of the unnormalizd covariance
             # Then use it to compute V^-1/2
@@ -2798,7 +2798,7 @@ class PSpecData:
         Q_alt : array_like
             Exponential part of Q (HERA memo #44, Eq. 11).
         """
-        if self.spw_Ndlys == None:
+        if self.spw_Ndlys is None:
             self.set_Ndlys()
         if mode >= self.spw_Ndlys:
             raise IndexError(
@@ -3634,7 +3634,7 @@ class PSpecData:
 
         # if using the whole band in the dataset, then there should just be
         # one n_dly parameter specified
-        if spw_ranges is None and n_dlys != None:
+        if spw_ranges is None and n_dlys is not None:
             assert len(n_dlys) == 1, (
                 "Only one spw, so cannot specify more than one n_dly value"
             )
@@ -3920,7 +3920,7 @@ class PSpecData:
                     pv = self.p_hat(Mv, qv)
 
                     # Multiply by scalar
-                    if self.primary_beam != None:
+                    if self.primary_beam is not None:
                         if nper_chunk == 1:
                             logger.info("  Computing and multiplying scalar...")
                         pv *= scalar
@@ -3950,7 +3950,7 @@ class PSpecData:
                             )
                         )
 
-                        if self.primary_beam != None:
+                        if self.primary_beam is not None:
                             cov_real = cov_real * (scalar) ** 2.0
                             cov_imag = cov_imag * (scalar) ** 2.0
 
@@ -5498,9 +5498,9 @@ def validate_blpairs(blpairs, uvd1, uvd2, baseline_tol=1.0, verbose=True):
         If True report feedback to stdout. Default: True.
     """
     # ensure uvd1 and uvd2 are UVData objects
-    if isinstance(uvd1, UVData) == False:
+    if not isinstance(uvd1, UVData):
         raise TypeError("uvd1 must be a UVData instance")
-    if isinstance(uvd2, UVData) == False:
+    if not isinstance(uvd2, UVData):
         raise TypeError("uvd2 must be a UVData instance")
 
     # get antenna position dictionary

--- a/src/hera_pspec/pstokes.py
+++ b/src/hera_pspec/pstokes.py
@@ -368,7 +368,7 @@ def construct_pstokes(
     uvdS : UVData object with pseudo-Stokes visibility
     """
     # convert dset1 and dset2 to UVData objects if they are miriad files
-    if isinstance(dset1, pyuvdata.UVData) == False:
+    if not isinstance(dset1, pyuvdata.UVData):
         assert isinstance(dset1, str), "dset1 must be fed as a string or UVData object"
         uvd1 = miriad2pyuvdata(
             dset1,
@@ -380,7 +380,7 @@ def construct_pstokes(
         )
     else:
         uvd1 = dset1
-    if isinstance(dset2, pyuvdata.UVData) == False:
+    if not isinstance(dset2, pyuvdata.UVData):
         assert isinstance(dset2, str), "dset2 must be fed as a string or UVData object"
         uvd2 = miriad2pyuvdata(
             dset2,
@@ -407,19 +407,19 @@ def construct_pstokes(
     # check if dset1 and dset2 have the same frequencies
     freqs1 = uvd1.freq_array
     freqs2 = uvd2.freq_array
-    if np.array_equal(freqs1, freqs2) == False:
+    if not np.array_equal(freqs1, freqs2):
         raise ValueError("dset1 and dset2 must have the same frequencies.")
 
     # check if dset1 and dset2 have the same timestamps
     times1 = uvd1.time_array
     times2 = uvd2.time_array
-    if np.array_equal(times1, times2) == False:
+    if not np.array_equal(times1, times2):
         raise ValueError("dset1 and dset2 must have the same timestamps.")
 
     # check if dset1 and dset2 have the same baselines
     bls1 = uvd1.baseline_array
     bls2 = uvd2.baseline_array
-    if np.array_equal(bls1, bls2) == False:
+    if not np.array_equal(bls1, bls2):
         raise ValueError("dset1 and dset2 must have the same baselines")
 
     # makes the Npol length==1 so that the UVData carries data for the

--- a/src/hera_pspec/utils.py
+++ b/src/hera_pspec/utils.py
@@ -562,7 +562,7 @@ def get_delays(freqs, n_dlys=None):
     Delta_nu = np.median(np.diff(freqs))
     n_freqs = freqs.size
 
-    if n_dlys == None:  # assume that n_dlys = n_freqs if not specified
+    if n_dlys is None:  # assume that n_dlys = n_freqs if not specified
         n_dlys = n_freqs
 
     # Calculate the delays

--- a/src/hera_pspec/uvpspec.py
+++ b/src/hera_pspec/uvpspec.py
@@ -1238,7 +1238,7 @@ class UVPSpec:
         # edit units
         uvp.norm_units += " k^3 / (2pi^2)"
 
-        if inplace == False:
+        if not inplace:
             return uvp
 
     def blpair_to_antnums(self, blpair):
@@ -1717,7 +1717,7 @@ class UVPSpec:
 
         if run_check:
             uvp.check()
-        if inplace == False:
+        if not inplace:
             return uvp
 
     def get_ENU_bl_vecs(self):
@@ -2126,7 +2126,7 @@ class UVPSpec:
         verbose : bool, optional
             If True, report feedback to stdout. Default: True.
         """
-        if hasattr(self, "cosmo") and overwrite == False:
+        if hasattr(self, "cosmo") and not overwrite:
             print("self.cosmo exists and overwrite == False, not overwriting...")
             return
         else:

--- a/tests/test_grouping.py
+++ b/tests/test_grouping.py
@@ -652,13 +652,11 @@ def test_bootstrap_run(tmp_path):
         assert uvp_avg.get_stats(
             stat, (0, ((37, 38), (38, 39)), ("xx", "xx"))
         ).shape == (1, 50)
-        assert (
-            np.any(
-                np.isnan(
-                    uvp_avg.get_stats(stat, (0, ((37, 38), (38, 39)), ("xx", "xx")))
-                )
+        assert not np.any(
+            np.isnan(
+                uvp_avg.get_stats(stat, (0, ((37, 38), (38, 39)), ("xx", "xx")))
             )
-        ) == False
+        )
         assert (
             uvp_avg.get_stats(stat, (0, ((37, 38), (38, 39)), ("xx", "xx"))).dtype
             == np.complex128

--- a/tests/test_grouping.py
+++ b/tests/test_grouping.py
@@ -653,9 +653,7 @@ def test_bootstrap_run(tmp_path):
             stat, (0, ((37, 38), (38, 39)), ("xx", "xx"))
         ).shape == (1, 50)
         assert not np.any(
-            np.isnan(
-                uvp_avg.get_stats(stat, (0, ((37, 38), (38, 39)), ("xx", "xx")))
-            )
+            np.isnan(uvp_avg.get_stats(stat, (0, ((37, 38), (38, 39)), ("xx", "xx"))))
         )
         assert (
             uvp_avg.get_stats(stat, (0, ((37, 38), (38, 39)), ("xx", "xx"))).dtype

--- a/tests/test_pspecdata.py
+++ b/tests/test_pspecdata.py
@@ -1471,9 +1471,9 @@ class Test_PSpecData(unittest.TestCase):
         assert ds.check_key_in_dset((24, 25, "xx"), 0)
 
         # check for non-existing key
-        assert ds.check_key_in_dset("yy", 0) == False
-        assert ds.check_key_in_dset((24, 26), 0) == False
-        assert ds.check_key_in_dset((24, 26, "yy"), 0) == False
+        assert not ds.check_key_in_dset("yy", 0)
+        assert not ds.check_key_in_dset((24, 26), 0)
+        assert not ds.check_key_in_dset((24, 26, "yy"), 0)
 
         # check exception
         pytest.raises(KeyError, ds.check_key_in_dset, (1, 2, 3, 4, 5), 0)
@@ -2409,7 +2409,7 @@ class Test_PSpecData(unittest.TestCase):
             dsets=[copy.deepcopy(uvd), copy.deepcopy(uvd)], wgts=[None, None]
         )
         ds.broadcast_dset_flags(spw_ranges=[(400, 800)], time_thresh=0.2)
-        assert ds.dsets[0].get_flags(24, 25)[:, 550:650].any() == False
+        assert not ds.dsets[0].get_flags(24, 25)[:, 550:650].any()
 
         # test w/ no spw selection
         ds = pspecdata.PSpecData(
@@ -2423,7 +2423,7 @@ class Test_PSpecData(unittest.TestCase):
             dsets=[copy.deepcopy(uvd), copy.deepcopy(uvd)], wgts=[None, None]
         )
         ds.broadcast_dset_flags(spw_ranges=None, time_thresh=0.2, unflag=True)
-        assert ds.dsets[0].get_flags(24, 25)[:, :].any() == False
+        assert not ds.dsets[0].get_flags(24, 25)[:, :].any()
 
         # test single integration being flagged within spw
         ds = pspecdata.PSpecData(
@@ -2434,7 +2434,7 @@ class Test_PSpecData(unittest.TestCase):
         ] = True
         ds.broadcast_dset_flags(spw_ranges=[(400, 800)], time_thresh=0.25, unflag=False)
         assert ds.dsets[0].get_flags(24, 25)[3, 400:800].all()
-        assert ds.dsets[0].get_flags(24, 25)[3, :].all() == False
+        assert not ds.dsets[0].get_flags(24, 25)[3, :].all()
 
         # test pspec run sets flagged integration to have zero weight
         uvd.flag_array[uvd.antpair2ind(24, 25, ordered=False), 400, :][3] = True
@@ -2755,10 +2755,9 @@ def test_pspec_run():
     assert ds.dsets[0].get_flags(37, 38)[0, 0:25].all()
 
     # assert first integration flagged *ONLY* across spw
-    assert (
+    assert not (
         ds.dsets[0].get_flags(37, 38)[0, :0].any()
         + ds.dsets[0].get_flags(37, 38)[0, 25:].any()
-        == False
     )
 
     # assert channel 15 flagged for all ints
@@ -2856,8 +2855,8 @@ def test_pspec_run():
             overwrite=True,
             blpairs=[((500, 501), (600, 601))],
         )  # blpairs that don't exist
-    assert ds == None
-    assert os.path.exists("./out.h5") == False
+    assert ds is None
+    assert not os.path.exists("./out.h5")
 
     # same test but with pre-loaded UVDatas
     uvds = []
@@ -2878,8 +2877,8 @@ def test_pspec_run():
             overwrite=True,
             blpairs=[((500, 501), (600, 601))],
         )
-    assert ds == None
-    assert os.path.exists("./out.h5") == False
+    assert ds is None
+    assert not os.path.exists("./out.h5")
 
     # test when data is loaded, but no blpairs match
     if os.path.exists("./out.h5"):
@@ -2897,7 +2896,7 @@ def test_pspec_run():
             blpairs=[((37, 38), (600, 601))],
         )
     assert isinstance(ds, pspecdata.PSpecData)
-    assert os.path.exists("./out.h5") == False
+    assert not os.path.exists("./out.h5")
 
     # test glob-parseable input dataset
     dsets = [

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -107,7 +107,7 @@ def test_load_config():
     assert "pspec" in cfg.keys()
 
     # Check that boolean values are read in correctly
-    assert cfg["pspec"]["overwrite"] == True
+    assert cfg["pspec"]["overwrite"]
 
     # Check that lists are read in as lists
     assert len(cfg["data"]["subdirs"]) == 1
@@ -118,9 +118,9 @@ def test_load_config():
     # Check 'None' and list of lists become Nones and list of tuples
     assert cfg["data"]["pairs"] == [("xx", "xx"), ("yy", "yy")]
     assert cfg["pspec"]["taper"] == "none"
-    assert cfg["pspec"]["groupname"] == None
+    assert cfg["pspec"]["groupname"] is None
     assert cfg["pspec"]["options"]["bar"] == [("foo", "bar")]
-    assert cfg["pspec"]["options"]["foo"] == None
+    assert cfg["pspec"]["options"]["foo"] is None
 
 
 class Test_Utils:

--- a/tests/test_uvpspec.py
+++ b/tests/test_uvpspec.py
@@ -269,7 +269,7 @@ class TestUVPSpec:
             inplace=False,
             error_field=["..............."],
         )
-        assert hasattr(u3, "stats_array") == False
+        assert not hasattr(u3, "stats_array")
 
         u.write_hdf5(tmp_path / "ex.hdf5")
         u.read_hdf5(tmp_path / "ex.hdf5")
@@ -549,8 +549,8 @@ class TestUVPSpec:
     def test_clear(self, vanilla_uvp: uvpspec.UVPSpec):
         uvp = copy.deepcopy(vanilla_uvp)
         uvp._clear()
-        assert hasattr(uvp, "Ntimes") == False
-        assert hasattr(uvp, "data_array") == False
+        assert not hasattr(uvp, "Ntimes")
+        assert not hasattr(uvp, "data_array")
 
     def test_get_r_params(self):
 
@@ -593,7 +593,7 @@ class TestUVPSpec:
         uvp2 = uvpspec.UVPSpec()
         uvp2.read_hdf5(out, just_meta=True)
         assert hasattr(uvp2, "Ntimes")
-        assert hasattr(uvp2, "data_array") == False
+        assert not hasattr(uvp2, "data_array")
 
         # test exception
         pytest.raises(IOError, uvp.write_hdf5, out, overwrite=False)


### PR DESCRIPTION
Enables `E711` (13 sites) and `E712` (31 sites). 44 mechanical rewrites across `src/` and `tests/`; ignore-list pruning in the second commit. Tests pass. Note: `pspecdata.py:2586` rewrite is behavior-preserving since `np.sum(None) is None`.