### PR TITLE
Remove any mention to hera_sim

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -50,7 +50,6 @@ MOCK_MODULES = [
     "pylab",
     "yaml",
     "pyuvdata.utils",
-    "hera_sim",
 ]
 
 for mod_name in MOCK_MODULES:


### PR DESCRIPTION
`hera_sim` was previously used in tests but is not used anymore: I have removed it from the list of mock-import modules. This addresses and closes #280 