### PR TITLE
chore: enable ruff DTZ and NPY (defer NPY002)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,10 +132,13 @@ select = [
     "YTT",    # flake8-2020 (sys.version usage)
     "ICN",    # flake8-import-conventions
     "FURB",   # refurb
+    "DTZ",    # flake8-datetimez
+    "NPY",    # numpy-specific rules
     "RUF100", # unused-noqa (RUF100 only; rest of RUF deferred)
 ]
 ignore = [
     "UP031",  # printf-string-formatting (69) — manual conversion, deferred to follow-up PR
+    "NPY002", # legacy np.random (31) — RNG-algorithm change, deferred to follow-up PR
     "E501",   # line-too-long (1116) — defer to ruff format
     "E701",   # multi-statement on one line, colon (105)
     "E702",   # multi-statement on one line, semicolon (11)

--- a/src/hera_pspec/pspecdata.py
+++ b/src/hera_pspec/pspecdata.py
@@ -2916,7 +2916,7 @@ class PSpecData:
                     ubl = np.unique(dset.baseline_array)
                     for bl in ubl:
                         # get baseline-times indices
-                        bl_inds = np.where(np.in1d(dset.baseline_array, bl))[0]
+                        bl_inds = np.where(np.isin(dset.baseline_array, bl))[0]
                         # get flag waterfall
                         flags = dset.flag_array[bl_inds, :, i].copy()
                         Ntimes = float(flags.shape[0])
@@ -4211,7 +4211,7 @@ class PSpecData:
             "dataset1: filename: {}, label: {}, cal: {}, history:\n{}\n{}\n"
             "dataset2: filename: {}, label: {}, cal: {}, history:\n{}\n{}\n"
             "".format(
-                datetime.datetime.utcnow(),
+                datetime.datetime.now(datetime.UTC),
                 __version__,
                 "-" * 20,
                 filename1,

--- a/src/hera_pspec/utils.py
+++ b/src/hera_pspec/utils.py
@@ -5,7 +5,7 @@ import inspect
 import itertools
 import time
 import traceback
-from datetime import datetime
+from datetime import UTC, datetime
 
 import numpy as np
 import uvtools as uvt
@@ -1132,7 +1132,7 @@ def job_monitor(
 
     # run function over jobs
     exit_codes = np.array(list(M(run_func, iterator)))
-    tnow = datetime.utcnow()
+    tnow = datetime.now(UTC)
 
     # check for len-0
     if len(exit_codes) == 0:


### PR DESCRIPTION
- enable `DTZ` (2 fixes) and `NPY` (1 fix, `np.in1d` → `np.isin`) in `[tool.ruff.lint] select`
- defer `NPY002` (legacy `np.random`) — RNG-algorithm change, follow-up PR will migrate fixtures
- `ruff check` clean; `pytest` 254 passed