### PR TITLE
ci: cap pytest below 9.1 to unbreak pytest-cases

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,10 @@ docs = [
 ]
 tests = [
     "coverage>=7.0",
-    "pytest>=8.0",
+    # Upper bound: pytest 9.1 removed a parameter from the internal IdMaker
+    # class, which pytest-cases (<=3.10.1, the latest release) calls with the
+    # old signature, breaking collection. Relax once pytest-cases supports 9.1.
+    "pytest>=8.0,<9.1",
     "pytest-cov>=5.0",
     "pytest-cases>=3.8.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -786,7 +786,7 @@ dev = [
     { name = "nbsphinx", specifier = ">=0.9.0" },
     { name = "numpydoc", specifier = ">=0.8" },
     { name = "prek", specifier = ">=0.3.11" },
-    { name = "pytest", specifier = ">=8.0" },
+    { name = "pytest", specifier = ">=8.0,<9.1" },
     { name = "pytest-cases", specifier = ">=3.8.0" },
     { name = "pytest-cov", specifier = ">=5.0" },
     { name = "readthedocs-sphinx-search", specifier = ">=0.1.1" },
@@ -805,7 +805,7 @@ docs = [
 ]
 tests = [
     { name = "coverage", specifier = ">=7.0" },
-    { name = "pytest", specifier = ">=8.0" },
+    { name = "pytest", specifier = ">=8.0,<9.1" },
     { name = "pytest-cases", specifier = ">=3.8.0" },
     { name = "pytest-cov", specifier = ">=5.0" },
 ]


### PR DESCRIPTION
Closes #503.

pytest 9.1 changed pytest's internal `IdMaker` signature, and
`pytest-cases` 3.10.1 still calls the old signature at import time. This breaks
the `lowest-direct` and `upgraded` dependency-resolution jobs.

Temporarily cap pytest at `<9.1` until `pytest-cases` supports pytest 9.1+.

Verified:
- `uv lock --upgrade-package pytest --dry-run` keeps pytest at 9.0.3.
- `uv run pytest --co -q tests/test_grouping.py tests/test_uvpspec.py` collects
  111 tests successfully.