### PR TITLE
Add click to test dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,7 @@ tests = [
     "pytest>=8.0,<9.1",
     "pytest-cov>=5.0",
     "pytest-cases>=3.8.0",
+    "click>=8.0.0",
 ]
 dev = [
     {include-group = "docs"},


### PR DESCRIPTION
Fixes test collection failure by adding click as an explicit test dependency.

The test_cli.py module imports from click.testing, but click was not
explicitly listed as a test dependency. While typer depends on click,
it's better to be explicit about direct dependencies.

Fixes: Test collection error - ModuleNotFoundError: No module named 'click'