### PR TITLE
Add FT-beam and window function CLI; fix k_parallel scaling of exact WFs

### DIFF
--- a/src/hera_pspec/cli.py
+++ b/src/hera_pspec/cli.py
@@ -475,9 +475,7 @@ def compute_ft_beam(
     mapsize: float = 1.0,
     npix: int = 301,
     label: str = "HERA",
-    search_dirs: Annotated[
-        list[Path] | None, Parameter(consume_multiple=True)
-    ] = None,
+    search_dirs: Annotated[list[Path] | None, Parameter(consume_multiple=True)] = None,
     force_recompute: bool = False,
     verbose: bool = False,
 ) -> None:
@@ -535,8 +533,7 @@ def compute_ft_beam(
     uvp = _load_uvp(pspec_file, group, name)
     freq_array = np.unique(uvp.freq_array)
     logger.info(
-        "Using the %d frequency channels of %s (%.2f-%.2f MHz, "
-        "channel width %.2f kHz)",
+        "Using the %d frequency channels of %s (%.2f-%.2f MHz, channel width %.2f kHz)",
         freq_array.size,
         pspec_file,
         freq_array.min() / 1e6,
@@ -554,11 +551,7 @@ def compute_ft_beam(
             return
 
     ftbeam = FTBeam.from_beam(
-        beamfile=beam_file,
-        pol=pol,
-        freq_array=freq_array,
-        mapsize=mapsize,
-        npix=npix,
+        beamfile=beam_file, pol=pol, freq_array=freq_array, mapsize=mapsize, npix=npix
     )
     out_path = Path(out_dir) / fname
     ftbeam.write_hdf5(
@@ -566,7 +559,7 @@ def compute_ft_beam(
         overwrite=True,
         extra_attrs={
             "beam_file": str(beam_file),
-            "created_utc": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            "created_utc": datetime.datetime.now(datetime.UTC).isoformat(),
             "producer": "pspec compute-ft-beam",
         },
     )
@@ -629,9 +622,7 @@ def _compute_one_wf(
         f.attrs["spw_freq_max_hz"] = float(spw_freqs.max())
         f.attrs["pspec_file"] = str(pspec_file)
         f.attrs["ft_beam_file"] = str(ft_beam_file)
-        f.attrs["created_utc"] = datetime.datetime.now(
-            datetime.timezone.utc
-        ).isoformat()
+        f.attrs["created_utc"] = datetime.datetime.now(datetime.UTC).isoformat()
         f.attrs["producer"] = "pspec compute-window-functions"
     logger.info("Wrote %s", out_path)
     return str(out_path.absolute())

--- a/src/hera_pspec/cli.py
+++ b/src/hera_pspec/cli.py
@@ -1,18 +1,24 @@
 """A CLI interface for hera_pspec."""
 
 import copy
+import datetime
 import glob
+import logging
 import pickle
 import sys
+from concurrent.futures import ProcessPoolExecutor
 from pathlib import Path
 from typing import Annotated, Literal
 
 import h5py
+import numpy as np
 from cyclopts import App, Parameter
 from rich.console import Console
+from rich.logging import RichHandler
 from tqdm import tqdm
 
 cns = Console()
+logger = logging.getLogger("hera_pspec")
 
 app = App(name="pspec", version_flags=[], help_flags=["--help"])
 # cyclopts pattern: register subcommands after app is constructed
@@ -391,3 +397,356 @@ def generate_pstokes(
         if pyuvdata.utils.polstr2num(p) not in uvd_output.polarization_array:
             uvd_output += pstokes.construct_pstokes(uvd, uvd, pstokes=p)
     uvd_output.write_uvh5(out_path, clobber=clobber)
+
+
+def _setup_logging(verbose: bool = False) -> None:
+    """Configure logging output for CLI commands."""
+    logging.basicConfig(
+        level=logging.DEBUG if verbose else logging.INFO,
+        format="%(message)s",
+        datefmt="[%X]",
+        handlers=[RichHandler(console=cns, show_path=False)],
+    )
+
+
+def _load_uvp(pspec_file: Path, group: str | None, name: str | None):
+    """Load a UVPSpec from a PSpecContainer, inferring group/name if unique."""
+    psc = container.PSpecContainer(str(pspec_file), mode="r", keep_open=False)
+    groups = psc.groups()
+    if group is None:
+        if len(groups) != 1:
+            raise ValueError(
+                f"{pspec_file} contains several groups ({groups}): "
+                "specify one with --group."
+            )
+        group = groups[0]
+    spectra = psc.spectra(group)
+    if name is None:
+        if len(spectra) != 1:
+            raise ValueError(
+                f"Group '{group}' contains several spectra ({spectra}): "
+                "specify one with --name."
+            )
+        name = spectra[0]
+    return psc.get_pspec(group, name)
+
+
+def ft_beam_filename(
+    label: str, pol: str, freq_array: np.ndarray, mapsize: float, npix: int
+) -> str:
+    """Standard FT-beam filename, encoding the differentiating parameters.
+
+    The polarization must be the last underscore-separated token before
+    ".hdf5": `FTBeam.from_file` falls back to extracting it from the
+    filename for files that do not carry a `pol` attribute.
+    """
+    fmin = freq_array.min() / 1e6
+    fmax = freq_array.max() / 1e6
+    return (
+        f"FT_beam_{label}_{fmin:.1f}-{fmax:.1f}MHz_"
+        f"{freq_array.size}ch_ms{mapsize:g}_N{npix}_{pol}.hdf5"
+    )
+
+
+def _find_in_dirs(dirs: list[Path], filename: str) -> Path | None:
+    """Return the first `dir/filename` that exists, searching left to right."""
+    for d in dirs:
+        cand = Path(d) / filename
+        if cand.is_file():
+            return cand
+    return None
+
+
+def wf_filename(polpair: str, dataset_label: str, spw: int) -> str:
+    """Standard window-function filename (differentiating info baked in)."""
+    return f"wf_exact_{polpair}_{dataset_label}_spw{spw:02d}.hdf5"
+
+
+@app.command
+def compute_ft_beam(
+    beam_file: Path,
+    pol: str,
+    pspec_file: Path,
+    /,
+    *,
+    out_dir: Path,
+    group: str | None = None,
+    name: str | None = None,
+    mapsize: float = 1.0,
+    npix: int = 301,
+    label: str = "HERA",
+    search_dirs: Annotated[
+        list[Path] | None, Parameter(consume_multiple=True)
+    ] = None,
+    force_recompute: bool = False,
+    verbose: bool = False,
+) -> None:
+    """Ensure an FT-beam HDF5 file exists for the requested parameters.
+
+    The file is readable by FTBeam.from_file and computed only if no
+    matching file is found in the search directories. The frequency grid
+    is taken from the data (pspec_file), so that the window functions'
+    k_parallel axis comes out on the data's grid; to build an FT beam on
+    an arbitrary grid, use FTBeam.from_beam directly. On success, prints
+    a `FT_BEAM_PATH=<path>` line with the file to feed to
+    `pspec compute-window-functions`.
+
+    Parameters
+    ----------
+    beam_file
+        Path to the UVBeam .fits/.beamfits beam simulation file.
+    pol
+        Polarization string, e.g. 'pI', 'xx', 'yy'.
+    pspec_file
+        PSpecContainer file whose frequency channels define the FT-beam
+        grid.
+    out_dir
+        Directory where freshly computed FT-beam HDF5 files are written.
+    group
+        Group within pspec_file. May be omitted if the file has one group.
+    name
+        Spectrum name within the group. May be omitted if unique.
+    mapsize
+        Half-extent of the FT grid (see FTBeam.from_beam): 0.7 uses the
+        beam simulation as is, larger values zero-pad it to reach smaller
+        k_perp. Default 1.0, the value used for the H6C products.
+    npix
+        Pixels per side of the Cartesian beam projection (odd preferred).
+    label
+        Instrument/beam label used in the output filename, e.g.
+        'HERA_Vivaldi'.
+    search_dirs
+        Directories searched (in order, before computing anything) for a
+        previously computed FT beam with matching parameters
+        (space-separated).
+        Matching is filename-based: the differentiating parameters are
+        encoded in the filename. Use --force-recompute if anything changed
+        without the filename reflecting it.
+    force_recompute
+        Skip the reuse lookup and recompute.
+    verbose
+        Debug-level logging.
+    """
+    from .uvwindow import FTBeam
+
+    _setup_logging(verbose)
+
+    # the frequency grid is the data's
+    uvp = _load_uvp(pspec_file, group, name)
+    freq_array = np.unique(uvp.freq_array)
+    logger.info(
+        "Using the %d frequency channels of %s (%.2f-%.2f MHz, "
+        "channel width %.2f kHz)",
+        freq_array.size,
+        pspec_file,
+        freq_array.min() / 1e6,
+        freq_array.max() / 1e6,
+        np.median(np.diff(freq_array)) / 1e3,
+    )
+
+    fname = ft_beam_filename(label, pol, freq_array, mapsize, npix)
+
+    if not force_recompute:
+        hit = _find_in_dirs([*(search_dirs or []), out_dir], fname)
+        if hit is not None:
+            logger.info("Reusing existing FT beam: %s", hit)
+            print(f"FT_BEAM_PATH={hit.absolute()}")
+            return
+
+    ftbeam = FTBeam.from_beam(
+        beamfile=beam_file,
+        pol=pol,
+        freq_array=freq_array,
+        mapsize=mapsize,
+        npix=npix,
+    )
+    out_path = Path(out_dir) / fname
+    ftbeam.write_hdf5(
+        out_path,
+        overwrite=True,
+        extra_attrs={
+            "beam_file": str(beam_file),
+            "created_utc": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            "producer": "pspec compute-ft-beam",
+        },
+    )
+    print(f"FT_BEAM_PATH={out_path.absolute()}")
+
+
+def _compute_one_wf(
+    pspec_file: str,
+    group: str | None,
+    name: str | None,
+    spw: int,
+    polpair: str,
+    ft_beam_file: str,
+    dataset_label: str,
+    out_dir: str,
+    wf_dirs: list[str],
+    force_recompute: bool,
+) -> str:
+    """Compute (or reuse) the exact window functions of one (spw, polpair).
+
+    Worker function for `compute_window_functions`; module-level so it can
+    be used with ProcessPoolExecutor. Returns the path of the WF file.
+    """
+    from .uvwindow import FTBeam
+
+    fname = wf_filename(polpair, dataset_label, spw)
+
+    if not force_recompute:
+        hit = _find_in_dirs([Path(d) for d in [*wf_dirs, out_dir]], fname)
+        if hit is not None:
+            logger.info("Reusing existing WF (spw=%d, pol=%s): %s", spw, polpair, hit)
+            return str(hit.absolute())
+
+    logger.info("Computing window functions for spw=%d, pol=%s", spw, polpair)
+    uvp = _load_uvp(Path(pspec_file), group, name)
+    sub = uvp.select(polpairs=[polpair], spws=[spw], inplace=False)
+    del uvp
+
+    # load the FT beam on the exact frequency channels of the spectral
+    # window (reads only the relevant channel range from disk)
+    spw_freqs = np.unique(sub.freq_array)
+    ftbeam = FTBeam.from_file(ft_beam_file, freq_array=spw_freqs)
+
+    kperp, kpara, wf = sub.get_exact_window_functions(ftbeam=ftbeam, inplace=False)
+    # after select, the only spectral window is index 0
+    kperp, kpara, wf = kperp[0], kpara[0], wf[0]
+
+    out_path = Path(out_dir) / fname
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with h5py.File(out_path, "w") as f:
+        f.create_dataset("wf", data=wf, compression="gzip")
+        f.create_dataset("kperp", data=kperp)
+        f.create_dataset("kpara", data=kpara)
+        f.attrs["algo"] = "exact"
+        f.attrs["polpair"] = polpair
+        f.attrs["spw_index"] = int(spw)
+        f.attrs["dataset_label"] = dataset_label
+        f.attrs["taper"] = str(sub.taper)
+        f.attrs["spw_freq_min_hz"] = float(spw_freqs.min())
+        f.attrs["spw_freq_max_hz"] = float(spw_freqs.max())
+        f.attrs["pspec_file"] = str(pspec_file)
+        f.attrs["ft_beam_file"] = str(ft_beam_file)
+        f.attrs["created_utc"] = datetime.datetime.now(
+            datetime.timezone.utc
+        ).isoformat()
+        f.attrs["producer"] = "pspec compute-window-functions"
+    logger.info("Wrote %s", out_path)
+    return str(out_path.absolute())
+
+
+@app.command
+def compute_window_functions(
+    pspec_file: Path,
+    ft_beam_file: Path,
+    /,
+    *,
+    dataset_label: str,
+    out_dir: Path,
+    group: str | None = None,
+    name: str | None = None,
+    spws: Annotated[list[int] | None, Parameter(consume_multiple=True)] = None,
+    polpairs: Annotated[list[str] | None, Parameter(consume_multiple=True)] = None,
+    wf_dirs: Annotated[list[Path] | None, Parameter(consume_multiple=True)] = None,
+    workers: int = 1,
+    force_recompute: bool = False,
+    verbose: bool = False,
+) -> None:
+    """Compute exact window functions per (spectral window, polpair).
+
+    Window functions are computed with UVPSpec.get_exact_window_functions
+    (Gorce et al. 2023 'exact' method) and written to one HDF5 file per
+    (spw, polpair) (datasets: wf, kperp, kpara + provenance attrs).
+    Existing files are reused unless --force-recompute. On success, prints
+    one `WF_PATH=<path>` line per (spw, polpair) processed.
+
+    Parameters
+    ----------
+    pspec_file
+        PSpecContainer file to compute window functions for.
+    ft_beam_file
+        FT-beam HDF5 file (from `pspec compute-ft-beam`). It should be
+        computed on the frequency channels of the data: if the grids
+        differ, the FT of the beam is interpolated onto the data channels
+        (with a warning).
+    dataset_label
+        Free-form string disambiguating runs whose data content differs
+        (e.g. '131-nights'). Becomes part of the WF filename, so different
+        labels never collide on disk.
+    out_dir
+        Directory to write fresh WF HDF5 files.
+    group
+        Group within pspec_file. May be omitted if the file has one group.
+    name
+        Spectrum name within the group. May be omitted if unique.
+    spws
+        Spectral window indices, 0-indexed, space-separated (e.g.
+        `--spws 0 1 2`). Default: all.
+    polpairs
+        Polarization pairs, space-separated, e.g. 'pI'. Default: all in the
+        file.
+    wf_dirs
+        Directories searched (in order, before computing anything) for
+        previously computed WF files (space-separated). Matching is
+        filename-based; use --force-recompute if upstream inputs changed
+        without a new --dataset-label.
+    workers
+        Number of parallel worker processes over (spw, polpair) tasks.
+        Each worker holds one spectral window's UVPSpec and FT beam in
+        memory, so memory use scales with this.
+    force_recompute
+        Skip the reuse lookup and recompute.
+    verbose
+        Debug-level logging.
+    """
+    from . import uvpspec_utils as uvputils
+
+    _setup_logging(verbose)
+
+    # peek at the file to enumerate spws/polpairs
+    uvp = _load_uvp(pspec_file, group, name)
+    if spws is None or len(spws) == 0:
+        spws = list(range(uvp.Nspws))
+    else:
+        bad = [s for s in spws if s >= uvp.Nspws]
+        if bad:
+            raise ValueError(f"spws {bad} out of range: file has Nspws={uvp.Nspws}.")
+    if polpairs is None or len(polpairs) == 0:
+        # for equal-pol pairs (e.g. ('pI','pI')), the single pol string is
+        # the representation accepted by UVPSpec.select
+        polpairs = [
+            pp[0] if pp[0] == pp[1] else f"{pp[0]}{pp[1]}"
+            for pp in [
+                uvputils.polpair_int2tuple(p, pol_strings=True)
+                for p in uvp.polpair_array
+            ]
+        ]
+    del uvp
+
+    jobs = [
+        (
+            str(pspec_file),
+            group,
+            name,
+            spw,
+            polpair,
+            str(ft_beam_file),
+            dataset_label,
+            str(out_dir),
+            [str(d) for d in (wf_dirs or [])],
+            force_recompute,
+        )
+        for spw in spws
+        for polpair in polpairs
+    ]
+
+    if workers > 1:
+        with ProcessPoolExecutor(max_workers=workers) as pool:
+            paths = list(pool.map(_compute_one_wf, *zip(*jobs, strict=True)))
+    else:
+        paths = [_compute_one_wf(*job) for job in jobs]
+
+    for path in paths:
+        print(f"WF_PATH={path}")

--- a/src/hera_pspec/uvwindow.py
+++ b/src/hera_pspec/uvwindow.py
@@ -247,17 +247,10 @@ class FTBeam:
         if (freq_array.min() < beam_fmin) or (freq_array.max() > beam_fmax):
             n_out = int(np.sum((freq_array < beam_fmin) | (freq_array > beam_fmax)))
             warnings.warn(
-                "{} of the {} requested frequencies lie outside the beam "
-                "simulation coverage ({:.2f}-{:.2f} MHz; requested "
-                "{:.2f}-{:.2f} MHz): for those channels, the beam is "
-                "evaluated at the nearest covered frequency.".format(
-                    n_out,
-                    freq_array.size,
-                    beam_fmin / 1e6,
-                    beam_fmax / 1e6,
-                    freq_array.min() / 1e6,
-                    freq_array.max() / 1e6,
-                )
+                f"{n_out} of the {freq_array.size} requested frequencies lie outside the beam "
+                f"simulation coverage ({beam_fmin / 1e6:.2f}-{beam_fmax / 1e6:.2f} MHz; requested "
+                f"{freq_array.min() / 1e6:.2f}-{freq_array.max() / 1e6:.2f} MHz): for those channels, the beam is "
+                "evaluated at the nearest covered frequency."
             )
             eval_freqs = np.clip(freq_array, beam_fmin, beam_fmax)
 
@@ -576,13 +569,8 @@ class FTBeam:
             freq_array.max() > native.max() + atol
         ):
             raise ValueError(
-                "Requested frequencies ({:.2f}-{:.2f} MHz) extend beyond the "
-                "bandwidth of the FTBeam ({:.2f}-{:.2f} MHz).".format(
-                    freq_array.min() / 1e6,
-                    freq_array.max() / 1e6,
-                    native.min() / 1e6,
-                    native.max() / 1e6,
-                )
+                f"Requested frequencies ({freq_array.min() / 1e6:.2f}-{freq_array.max() / 1e6:.2f} MHz) extend beyond the "
+                f"bandwidth of the FTBeam ({native.min() / 1e6:.2f}-{native.max() / 1e6:.2f} MHz)."
             )
 
         # nearest native channel for each requested frequency
@@ -595,12 +583,10 @@ class FTBeam:
             # grid mismatch: interpolate the FT of the beam in frequency
             warnings.warn(
                 "Requested frequencies do not coincide with the FTBeam "
-                "channels (native width: {:.2f} kHz, requested: {:.2f} kHz): "
+                f"channels (native width: {delta_native / 1e3:.2f} kHz, requested: {np.median(np.diff(freq_array)) / 1e3:.2f} kHz): "
                 "interpolating the FT of the beam onto the requested "
                 "frequencies. Consider computing the FT beam directly on "
-                "the frequency channels of the data.".format(
-                    delta_native / 1e3, np.median(np.diff(freq_array)) / 1e3
-                )
+                "the frequency channels of the data."
             )
             # linear interpolation along the frequency axis (native is
             # ascending, and coverage was checked above)
@@ -1328,10 +1314,7 @@ class UVWindow:
         sums = np.zeros((nbins_kperp, self.Nfreqs))
         np.add.at(sums, idx[valid], prod[valid])
         wf_array1 = np.divide(
-            sums,
-            counts[:, None],
-            out=np.zeros_like(sums),
-            where=counts[:, None] > 0,
+            sums, counts[:, None], out=np.zeros_like(sums), where=counts[:, None] > 0
         )
         kperp = np.divide(
             np.bincount(

--- a/src/hera_pspec/uvwindow.py
+++ b/src/hera_pspec/uvwindow.py
@@ -855,17 +855,28 @@ class UVWindow:
         # construct array of |kpara| values for given delay tau
         kpar_norm = np.abs(2.0 * np.pi / alpha * (eta + tau))
 
-        # perform binning along k_parallel
-        cyl_wf = np.zeros((nbins_kperp, nbins_kpara))
-        kpara = np.zeros(nbins_kpara)
-        for j in range(nbins_kperp):
-            for m in range(nbins_kpara):
-                mask = (kpara_bin_edges[m] <= kpar_norm) & (
-                    kpar_norm < kpara_bin_edges[m + 1]
-                )
-                if np.any(mask):  # cannot compute mean if zero elements
-                    cyl_wf[j, m] = np.mean(wf_array1[j, mask])
-                    kpara[m] = np.mean(kpar_norm[mask])
+        # perform binning along k_parallel (vectorized: bin index of each
+        # kpar_norm element such that edges[m] <= kpar_norm < edges[m+1])
+        idx = np.digitize(kpar_norm, kpara_bin_edges) - 1
+        valid = (idx >= 0) & (idx < nbins_kpara)
+        counts = np.bincount(idx[valid], minlength=nbins_kpara)
+
+        # indicator matrix: ind[f, m] = 1 if kpar_norm[f] falls in bin m
+        ind = np.zeros((kpar_norm.size, nbins_kpara))
+        ind[np.nonzero(valid)[0], idx[valid]] = 1.0
+
+        cyl_wf = np.divide(
+            wf_array1 @ ind,
+            counts[None, :],
+            out=np.zeros((nbins_kperp, nbins_kpara)),
+            where=counts[None, :] > 0,
+        )
+        kpara = np.divide(
+            np.bincount(idx[valid], weights=kpar_norm[valid], minlength=nbins_kpara),
+            counts,
+            out=np.zeros(nbins_kpara),
+            where=counts > 0,
+        )
 
         return kpara, cyl_wf
 
@@ -1076,19 +1087,31 @@ class UVWindow:
 
         # cylindrical average
 
-        # on sky plane
-        wf_array1 = np.zeros((nbins_kperp, self.Nfreqs))
-        kperp = np.zeros(nbins_kperp)
-        for i in range(self.Nfreqs):
-            for m in range(nbins_kperp):
-                mask = (kperp_bin_edges[m] <= kperp_norm) & (
-                    kperp_norm < kperp_bin_edges[m + 1]
-                )
-                if np.any(mask):  # cannot compute mean if zero elements
-                    wf_array1[m, i] = np.mean(
-                        np.conj(fnu[1][mask, i]) * fnu[0][mask, i]
-                    ).real
-                    kperp[m] = np.mean(kperp_norm[mask])
+        # on sky plane (vectorized: the binning of the (kperp_x, kperp_y)
+        # grid onto kperp bins is identical for all frequencies)
+        idx = np.digitize(kperp_norm.ravel(), kperp_bin_edges) - 1
+        valid = (idx >= 0) & (idx < nbins_kperp)
+        counts = np.bincount(idx[valid], minlength=nbins_kperp)
+
+        # real part of the cross-pol product, flattened on the sky plane;
+        # real() commutes with the sum performed in the binned average
+        prod = (np.conj(fnu[1]) * fnu[0]).real.reshape(-1, self.Nfreqs)
+        sums = np.zeros((nbins_kperp, self.Nfreqs))
+        np.add.at(sums, idx[valid], prod[valid])
+        wf_array1 = np.divide(
+            sums,
+            counts[:, None],
+            out=np.zeros_like(sums),
+            where=counts[:, None] > 0,
+        )
+        kperp = np.divide(
+            np.bincount(
+                idx[valid], weights=kperp_norm.ravel()[valid], minlength=nbins_kperp
+            ),
+            counts,
+            out=np.zeros(nbins_kperp),
+            where=counts > 0,
+        )
 
         # in frequency direction
         cyl_wf = np.zeros((self.Nfreqs, nbins_kperp, nbins_kpara))

--- a/src/hera_pspec/uvwindow.py
+++ b/src/hera_pspec/uvwindow.py
@@ -144,6 +144,17 @@ class FTBeam:
 
         self.mapsize = float(mapsize)
 
+    def __eq__(self, other):
+        """Check two FTBeam objects hold the same beam transform."""
+        if not isinstance(other, FTBeam):
+            return NotImplemented
+        return (
+            self.pol == other.pol
+            and self.mapsize == other.mapsize
+            and np.array_equal(self.freq_array, other.freq_array)
+            and np.array_equal(self.ft_beam, other.ft_beam)
+        )
+
     @classmethod
     def from_beam(
         cls,

--- a/src/hera_pspec/uvwindow.py
+++ b/src/hera_pspec/uvwindow.py
@@ -1,4 +1,5 @@
 import copy
+import logging
 import os
 import sys
 import warnings
@@ -8,11 +9,67 @@ import h5py
 import numpy as np
 import uvtools.dspec as dspec
 from astropy import units
+from pyuvdata import UVBeam
 from pyuvdata import utils as uvutils
 from scipy.interpolate import RegularGridInterpolator
 
 from . import conversions, utils
 from . import uvpspec_utils as uvputils
+
+logger = logging.getLogger(__name__)
+
+# Half-width of the Cartesian grid the beam simulation is interpolated
+# onto in FTBeam.from_beam: rx in [-_MAX_R, +_MAX_R], with zenith angle
+# za = sqrt(x^2 + y^2) in radians, so the projected map is
+# sqrt(2)*_MAX_R = 1 rad wide. The `mapsize` parameter sets the (half-)
+# extent of the FT grid: mapsize = _MAX_R uses the beam simulation as
+# is, while mapsize > _MAX_R zero-pads the map, extending coverage to
+# smaller kperp.
+_MAX_R = 0.7
+
+
+def _cartesian_to_spherical(x, y):
+    """Invert the simple zenith-angle map x = za*cos(az), y = za*sin(az)."""
+    za = np.sqrt(x**2 + y**2)
+    rho = np.divide(x, za, where=za != 0)
+    az = np.arccos(rho)
+    return az, za
+
+
+def _ft_beam_2d(rx, b, npix=500, mapsize=_MAX_R):
+    """
+    Pad/crop the Cartesian beam to a centered grid and take the 2D FFT.
+
+    `mapsize` controls the FT grid extent. Increasing it improves
+    k-resolution at the cost of going beyond the simulation's spatial
+    support.
+    """
+    dr = np.diff(rx).mean()
+    ngrid = int(2.0 * mapsize / dr)
+    if ngrid % 2 == 0:
+        ngrid += 1  # odd, so the FT is centered on zero
+
+    new_map = np.zeros((ngrid, ngrid), dtype=complex)
+    if ngrid < npix:
+        new_map = b[
+            (npix - ngrid) // 2 : -(npix - ngrid) // 2,
+            (npix - ngrid) // 2 : -(npix - ngrid) // 2,
+        ]
+    elif ngrid > npix:
+        new_map[
+            -(npix - ngrid) // 2 : (npix - ngrid) // 2,
+            -(npix - ngrid) // 2 : (npix - ngrid) // 2,
+        ] = b
+    else:
+        new_map = np.copy(b)
+        ngrid = rx.size
+
+    Atilde = np.fft.fftshift(
+        np.fft.fft2(np.fft.fftshift(new_map), norm="ortho")
+        * (2.0 * mapsize / ngrid) ** 1.0
+    )
+    Atilde = np.flip(Atilde).real  # decreasing-order axes
+    return Atilde
 
 
 class FTBeam:
@@ -88,22 +145,54 @@ class FTBeam:
         self.mapsize = float(mapsize)
 
     @classmethod
-    def from_beam(cls, beamfile, verbose=False, x_orientation=None):
+    def from_beam(
+        cls,
+        beamfile,
+        pol,
+        freq_array,
+        mapsize=1.0,
+        npix=301,
+        verbose=False,
+        x_orientation=None,
+    ):
         """
         Compute Fourier transform of beam in sky plane given a file
         containing beam simulations.
 
         Given the path to a beam simulation, obtain the Fourier transform
-        of the instrument beam in the sky plane for all the frequencies
-        in the spectral window.
-        Output is an array of dimensions (kperpx, kperpy, freq).
-        Computations correspond to the Fourier transform performed in equation
-        10 of memo.
+        of the instrument beam in the sky plane for each frequency in
+        `freq_array`. Computations correspond to the Fourier transform
+        performed in equation 10 of HERA Memo #128: the beam is
+        interpolated onto `freq_array`, peak-normalized per frequency,
+        projected onto a Cartesian (flat-sky) plane, and 2D-FFT'd per
+        frequency slice.
+
+        `freq_array` should be the frequency channels of the data whose
+        window functions are being computed (see :meth:`select_freqs`).
 
         Parameters
         ----------
         beamfile : str
-            Path to file containing beam simulation/
+            Path to file containing the beam simulation. Must be readable
+            by :meth:`pyuvdata.UVBeam.read_beamfits`.
+        pol : str or int
+            Polarization, can be pseudo-Stokes or power:
+            in str form: 'pI', 'pQ', 'pV', 'pU', 'xx', 'yy', 'xy', 'yx'
+            in number form: 1, 2, 4, 3, -5, -6, -7, -8.
+        freq_array : 1D array or list of floats
+            Frequencies (in Hz) to compute the Fourier transform of the
+            beam on. Should match the frequency channels of the data.
+        mapsize : float, optional
+            Half-extent of the FT grid, in the same (direction-cosine-like)
+            units as the Cartesian beam projection, whose own half-width is
+            `_MAX_R` = 0.7 (i.e. the projected map is sqrt(2)*`_MAX_R` =
+            1 rad wide). mapsize = `_MAX_R` uses the beam simulation as is;
+            larger values zero-pad the map, extending coverage to smaller
+            k_perp. Default: 1.0 (the value used for the H6C products).
+        npix : int, optional
+            Number of pixels per side used for the Cartesian projection
+            of the beam. Preferably odd (even values are decremented).
+            Default: 301.
         verbose : bool, optional
             If True, print progress, warnings and debugging info to stdout.
         x_orientation: str, optional
@@ -111,7 +200,110 @@ class FTBeam:
             Default keeps polarization in X and Y basis.
             Used to convert polstr to polnum and conversely.
         """
-        raise NotImplementedError("Coming soon...")
+        freq_array = np.asarray(freq_array, dtype=float)
+        if freq_array.ndim != 1 or freq_array.size < 3:
+            raise ValueError(
+                "freq_array must be a 1D array with at least three frequencies."
+            )
+
+        if isinstance(pol, int):
+            polnum = pol
+            pol = uvutils.polnum2str(pol, x_orientation=x_orientation)
+        else:
+            polnum = uvutils.polstr2num(pol, x_orientation=x_orientation)
+
+        logger.info("Reading UVBeam from %s", beamfile)
+        beam = UVBeam()
+        beam.read_beamfits(str(beamfile))
+
+        if beam.beam_type == "efield":
+            if polnum < 0:
+                beam.efield_to_power()
+            else:
+                beam.efield_to_pstokes()
+        beam.select(polarizations=[polnum], inplace=True)
+        beam.peak_normalize()
+
+        # ensure odd number of pixels so the FT is centered on zero
+        npix = int(npix)
+        if npix % 2 == 0:
+            npix -= 1
+            logger.info("Adjusted npix to odd: %d", npix)
+
+        # Cartesian (flat-sky) grid and its sky coordinates
+        rx = np.linspace(-_MAX_R, _MAX_R, npix)
+        xg, yg = np.meshgrid(rx, rx)
+        az, za = _cartesian_to_spherical(xg, yg)
+
+        # frequencies the beam is evaluated at: if a few requested channels
+        # fall (slightly) outside the simulation coverage, evaluate the beam
+        # at the nearest covered frequency for those channels, but keep the
+        # true data frequencies as the frequency coordinates of the FTBeam
+        # (the beam evolves slowly with frequency; this is much preferable
+        # to shifting or resampling the frequency grid itself, which scales
+        # the window functions' k_parallel axis)
+        beam_fmin, beam_fmax = beam.freq_array.min(), beam.freq_array.max()
+        eval_freqs = freq_array
+        if (freq_array.min() < beam_fmin) or (freq_array.max() > beam_fmax):
+            n_out = int(np.sum((freq_array < beam_fmin) | (freq_array > beam_fmax)))
+            warnings.warn(
+                "{} of the {} requested frequencies lie outside the beam "
+                "simulation coverage ({:.2f}-{:.2f} MHz; requested "
+                "{:.2f}-{:.2f} MHz): for those channels, the beam is "
+                "evaluated at the nearest covered frequency.".format(
+                    n_out,
+                    freq_array.size,
+                    beam_fmin / 1e6,
+                    beam_fmax / 1e6,
+                    freq_array.min() / 1e6,
+                    freq_array.max() / 1e6,
+                )
+            )
+            eval_freqs = np.clip(freq_array, beam_fmin, beam_fmax)
+
+        nfreq = freq_array.size
+        logger.info(
+            "Interpolating beam onto a %dx%d Cartesian grid for %d frequency "
+            "channels (%.1f-%.1f MHz)",
+            npix,
+            npix,
+            nfreq,
+            freq_array[0] / 1e6,
+            freq_array[-1] / 1e6,
+        )
+        # interpolate the beam at the (az, za) coordinates of the Cartesian
+        # grid, for each frequency (works for both az_za and healpix beams)
+        interp_data = beam.interp(
+            az_array=az.ravel(),
+            za_array=za.ravel(),
+            freq_array=eval_freqs,
+            return_basis_vector=False,
+        )[0]
+        cart_beam = interp_data[0, 0].real.reshape(nfreq, npix, npix)
+        # peak-normalize per frequency
+        cart_beam /= np.max(cart_beam, axis=(1, 2))[:, None, None]
+
+        # ngrid is determined by mapsize + the rx spacing
+        dr = np.diff(rx).mean()
+        ngrid = int(2.0 * mapsize / dr)
+        if ngrid % 2 == 0:
+            ngrid += 1
+
+        logger.info("Taking 2D FFT per frequency (ngrid=%d)", ngrid)
+        data = np.zeros((nfreq, ngrid, ngrid))
+        for ifreq in range(nfreq):
+            data[ifreq, :, :] = _ft_beam_2d(
+                rx, cart_beam[ifreq, :, :], npix=npix, mapsize=mapsize
+            ).real
+
+        return cls(
+            data=data,
+            pol=pol,
+            freq_array=freq_array,
+            mapsize=mapsize,
+            verbose=verbose,
+            x_orientation=x_orientation,
+        )
 
     @classmethod
     def from_file(cls, ftfile, spw_range=None, freq_array=None, **kwargs):
@@ -158,13 +350,13 @@ class FTBeam:
                 stacklevel=2,
             )
 
-        # extract polarisation channel from filename
-        pol = str(ftfile).split("_")[-1].split(".")[0]
-
         # obtain bandwidth in file to define spectral window
         with h5py.File(ftfile, "r") as f:
             mapsize = f["mapsize"][0]
             bandwidth = np.array(f["freq"][...])
+            # polarisation: prefer the attribute written by write_hdf5,
+            # fall back to extracting it from the filename
+            pol = f.attrs.get("pol", None)
 
             if freq_array is not None:
                 # read only the contiguous channel range covering the
@@ -190,6 +382,11 @@ class FTBeam:
                 spw_range = (0, bandwidth.size)
                 read_freqs = bandwidth
                 ft_beam = np.array(f["FT_beam"])
+
+        if pol is None:
+            pol = str(ftfile).split("_")[-1].split(".")[0]
+        else:
+            pol = str(pol)
 
         obj = cls(
             data=ft_beam, pol=pol, freq_array=read_freqs, mapsize=mapsize, **kwargs
@@ -301,6 +498,38 @@ class FTBeam:
             raise ValueError("Error reading file, empty bandwidth.")
 
         return bandwidth
+
+    def write_hdf5(self, filepath, overwrite=False, extra_attrs=None):
+        """
+        Write the FTBeam object to an HDF5 file readable by :meth:`from_file`.
+
+        Parameters
+        ----------
+        filepath : str
+            Path of the output file. For backwards compatibility with
+            :meth:`from_file` on files without a ``pol`` attribute, it is
+            recommended (but not required) that the filename ends in
+            ``_<pol>.hdf5``, e.g. ``FT_beam_HERA_vivaldi_pI.hdf5``.
+        overwrite : bool, optional
+            If True, overwrite an existing file. Default: False.
+        extra_attrs : dict, optional
+            Additional attributes to store in the file (e.g. provenance
+            information). Values must be h5py-compatible scalars/strings.
+        """
+        filepath = Path(filepath)
+        if filepath.exists() and not overwrite:
+            raise FileExistsError(f"{filepath} exists. Use overwrite=True.")
+        filepath.parent.mkdir(parents=True, exist_ok=True)
+
+        with h5py.File(filepath, "w") as f:
+            f.create_dataset("FT_beam", data=self.ft_beam, compression="gzip")
+            f.create_dataset("freq", data=self.freq_array)
+            f.create_dataset("mapsize", data=np.array([self.mapsize]))
+            f.attrs["pol"] = str(self.pol)
+            if extra_attrs is not None:
+                for key, val in extra_attrs.items():
+                    f.attrs[key] = val
+        logger.info("Wrote FTBeam to %s", filepath)
 
     def select_freqs(self, freq_array, atol=None, inplace=True):
         """

--- a/src/hera_pspec/uvwindow.py
+++ b/src/hera_pspec/uvwindow.py
@@ -114,7 +114,7 @@ class FTBeam:
         raise NotImplementedError("Coming soon...")
 
     @classmethod
-    def from_file(cls, ftfile, spw_range=None, **kwargs):
+    def from_file(cls, ftfile, spw_range=None, freq_array=None, **kwargs):
         """
         Read Fourier transform of beam in sky plane from file.
 
@@ -133,11 +133,30 @@ class FTBeam:
             In (start_chan, end_chan). Must be between 0 and 1024 (HERA
             bandwidth).
             If None, whole instrument bandwidth is considered.
+
+            .. deprecated::
+                Use `freq_array` instead: channel indices are ambiguous
+                across FT-beam files, frequencies are not.
+        freq_array : 1D array or list of floats, optional
+            If given, restrict the FTBeam to these frequencies (in Hz)
+            via :meth:`select_freqs`. Only the relevant channel range is
+            read from disk, which considerably reduces the memory
+            footprint for wide-band FT-beam files. Cannot be used
+            together with spw_range.
         """
         # check file path input
         ftfile = Path(ftfile)
         if not (ftfile.exists() and ftfile.is_file() and h5py.is_hdf5(ftfile)):
             raise ValueError("Wrong ftfile input. See docstring.")
+        if spw_range is not None and freq_array is not None:
+            raise ValueError("Cannot feed both spw_range and freq_array.")
+        if spw_range is not None:
+            warnings.warn(
+                "The spw_range parameter of FTBeam.from_file is deprecated; "
+                "use freq_array instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
 
         # extract polarisation channel from filename
         pol = str(ftfile).split("_")[-1].split(".")[0]
@@ -146,23 +165,39 @@ class FTBeam:
         with h5py.File(ftfile, "r") as f:
             mapsize = f["mapsize"][0]
             bandwidth = np.array(f["freq"][...])
-            ft_beam = np.array(f["FT_beam"])
 
-        # spectral window
-        if spw_range is not None:
-            # check format
-            if not check_spw_range(spw_range, bandwidth):
-                raise ValueError("Wrong spw range format, see dosctring.")
-            freq_array = bandwidth[spw_range[0] : spw_range[-1]]
-            ft_beam = ft_beam[spw_range[0] : spw_range[1], :, :]
-        else:
-            # if spectral range is not specified, use whole bandwidth
-            spw_range = (0, bandwidth.size)
-            freq_array = bandwidth
+            if freq_array is not None:
+                # read only the contiguous channel range covering the
+                # requested frequencies, rather than the whole bandwidth.
+                # The -2/+2 reach one channel beyond the neighbours that
+                # interpolation requires, as safety margin for targets
+                # within atol of a native channel
+                freq_array = np.asarray(freq_array, dtype=float)
+                i0 = max(np.searchsorted(bandwidth, freq_array.min()) - 2, 0)
+                i1 = min(
+                    np.searchsorted(bandwidth, freq_array.max()) + 2, bandwidth.size
+                )
+                ft_beam = np.array(f["FT_beam"][i0:i1, :, :])
+                read_freqs = bandwidth[i0:i1]
+            elif spw_range is not None:
+                # check format
+                if not check_spw_range(spw_range, bandwidth):
+                    raise ValueError("Wrong spw range format, see dosctring.")
+                read_freqs = bandwidth[spw_range[0] : spw_range[-1]]
+                ft_beam = np.array(f["FT_beam"][spw_range[0] : spw_range[1], :, :])
+            else:
+                # if spectral range is not specified, use whole bandwidth
+                spw_range = (0, bandwidth.size)
+                read_freqs = bandwidth
+                ft_beam = np.array(f["FT_beam"])
 
-        return cls(
-            data=ft_beam, pol=pol, freq_array=freq_array, mapsize=mapsize, **kwargs
+        obj = cls(
+            data=ft_beam, pol=pol, freq_array=read_freqs, mapsize=mapsize, **kwargs
         )
+        if freq_array is not None:
+            # extract (or interpolate onto) the exact requested frequencies
+            obj.select_freqs(freq_array)
+        return obj
 
     @classmethod
     def gaussian(
@@ -267,6 +302,90 @@ class FTBeam:
 
         return bandwidth
 
+    def select_freqs(self, freq_array, atol=None, inplace=True):
+        """
+        Restrict the FTBeam to a given array of frequencies.
+
+        If every requested frequency coincides with a native channel of
+        the FTBeam (within `atol`), the corresponding channels are simply
+        extracted. Otherwise, the FT of the beam is linearly interpolated
+        along the frequency axis onto `freq_array`. Use this to put the
+        FTBeam on the exact frequency channels of the data: the window
+        functions' k_parallel axis is built from this object's
+        `freq_array`, so a channel-width mismatch scales that axis.
+
+        Parameters
+        ----------
+        freq_array : 1D array or list of floats
+            Frequencies (in Hz) to restrict the FTBeam to. Must be
+            within the bandwidth of the FTBeam.
+        atol : float, optional
+            Absolute tolerance (in Hz) used to decide whether a requested
+            frequency coincides with a native channel. Default: 1e-3
+            times the native channel width.
+        inplace : bool, optional
+            If True (default), modify the object in place. Otherwise
+            return a new FTBeam object.
+
+        Returns
+        -------
+        FTBeam object
+            Only if inplace is False.
+        """
+        fq = self if inplace else copy.deepcopy(self)
+
+        freq_array = np.asarray(freq_array, dtype=float)
+        if freq_array.ndim != 1 or freq_array.size < 2:
+            raise ValueError("Must feed 1D array of at least two frequencies.")
+
+        native = np.asarray(fq.freq_array, dtype=float)
+        delta_native = np.median(np.diff(native))
+        if atol is None:
+            atol = 1e-3 * abs(delta_native)
+
+        if (freq_array.min() < native.min() - atol) or (
+            freq_array.max() > native.max() + atol
+        ):
+            raise ValueError(
+                "Requested frequencies ({:.2f}-{:.2f} MHz) extend beyond the "
+                "bandwidth of the FTBeam ({:.2f}-{:.2f} MHz).".format(
+                    freq_array.min() / 1e6,
+                    freq_array.max() / 1e6,
+                    native.min() / 1e6,
+                    native.max() / 1e6,
+                )
+            )
+
+        # nearest native channel for each requested frequency
+        nearest = np.abs(native[:, None] - freq_array[None, :]).argmin(axis=0)
+
+        if np.all(np.abs(native[nearest] - freq_array) <= atol):
+            # exact match: extract channels
+            fq.ft_beam = fq.ft_beam[nearest, :, :]
+        else:
+            # grid mismatch: interpolate the FT of the beam in frequency
+            warnings.warn(
+                "Requested frequencies do not coincide with the FTBeam "
+                "channels (native width: {:.2f} kHz, requested: {:.2f} kHz): "
+                "interpolating the FT of the beam onto the requested "
+                "frequencies. Consider computing the FT beam directly on "
+                "the frequency channels of the data.".format(
+                    delta_native / 1e3, np.median(np.diff(freq_array)) / 1e3
+                )
+            )
+            # linear interpolation along the frequency axis (native is
+            # ascending, and coverage was checked above)
+            idx = np.searchsorted(native, freq_array).clip(1, native.size - 1)
+            w = (freq_array - native[idx - 1]) / (native[idx] - native[idx - 1])
+            fq.ft_beam = (1.0 - w)[:, None, None] * fq.ft_beam[idx - 1] + w[
+                :, None, None
+            ] * fq.ft_beam[idx]
+
+        fq.freq_array = freq_array.copy()
+
+        if not inplace:
+            return fq
+
     def update_spw(self, spw_range):
         """
         Function to extract spectral window from FTBeam defined on whole bandwidth.
@@ -274,12 +393,21 @@ class FTBeam:
         Extract a section of the previously computed Fourier
         transform of the beam.
 
+        .. deprecated::
+            Use :meth:`select_freqs` instead: channel indices are ambiguous
+            across FT-beam files, frequencies are not.
+
         Parameters
         ----------
         spw_range : tuple or 2-element array of ints.
             In (start_chan, end_chan). Must be between 0 and 1024 (HERA
             bandwidth).
         """
+        warnings.warn(
+            "FTBeam.update_spw is deprecated; use FTBeam.select_freqs instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         # checks on inputs
         if not check_spw_range(spw_range, self.freq_array):
             raise ValueError("Wrong spw range format, see dosctring.")
@@ -443,15 +571,18 @@ class UVWindow:
         # create FTBeam objects
         ftbeam_obj_pol = []
         for ip, pol in enumerate(polpair):
-            if (ip > 0) and (pol[ip] == pol[0]):
+            if (ip > 0) and (polpair[ip] == polpair[0]):
                 # do not recompute if two polarisations are identical
                 ftbeam_obj_pol.append(ftbeam_obj_pol[0])
             else:
                 if ftbeam is None:
-                    ftbeam_obj_pol.append(
-                        FTBeam.from_beam(
-                            beamfile="tbd", verbose=verbose, x_orientation=x_orientation
-                        )
+                    raise NotImplementedError(
+                        "ftbeam=None (computation from beam simulations) is "
+                        "not implemented in from_uvpspec because the UVPSpec "
+                        "object does not carry the beam simulation file. "
+                        "Construct the FTBeam explicitly with "
+                        "FTBeam.from_beam(beamfile, pol, freq_array) and "
+                        "pass it as the ftbeam argument."
                     )
                 elif isinstance(ftbeam, str | Path):
                     ftbeam_obj_pol.append(
@@ -467,17 +598,13 @@ class UVWindow:
                 else:
                     raise TypeError("Check your ftbeam input.")
 
-        # limit spectral window of FTBeam object to the one of the UVPSpec object
-        # find spectral indices associated with spectral window
-        bandwidth = ftbeam_obj_pol[0].freq_array
-        spw_range = (
-            np.array([0, freq_array.size])
-            + np.where(bandwidth >= freq_array[0] - 1e-9)[0][0]
-        )
+        # restrict the FTBeam objects to the exact frequency channels of
+        # the UVPSpec's spectral window (interpolating, with a warning,
+        # if the FTBeam is not defined on the data's frequency grid)
         for ip in range(2):
-            if (ip > 0) and (pol[ip] == pol[0]):
+            if (ip > 0) and (polpair[ip] == polpair[0]):
                 continue
-            ftbeam_obj_pol[ip].update_spw(spw_range=tuple(spw_range))
+            ftbeam_obj_pol[ip].select_freqs(freq_array)
 
         return cls(
             ftbeam_obj=ftbeam_obj_pol,

--- a/src/hera_pspec/uvwindow.py
+++ b/src/hera_pspec/uvwindow.py
@@ -31,8 +31,10 @@ _MAX_R = 0.7
 def _cartesian_to_spherical(x, y):
     """Invert the simple zenith-angle map x = za*cos(az), y = za*sin(az)."""
     za = np.sqrt(x**2 + y**2)
-    rho = np.divide(x, za, where=za != 0)
-    az = np.arccos(rho)
+    # out= initialises the za == 0 entries (az is arbitrary at zenith);
+    # the clip guards arccos against x / za rounding just past +-1
+    rho = np.divide(x, za, out=np.zeros_like(za), where=za != 0)
+    az = np.arccos(np.clip(rho, -1.0, 1.0))
     return az, za
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -655,9 +655,7 @@ class TestComputeWindowFunctions:
         assert result2.exit_code == 0
         assert path.stat().st_mtime == mtime  # not recomputed
 
-    def test_parallel_workers(
-        self, wf_run: tuple[Result, Path], wf_pspec_file: Path
-    ):
+    def test_parallel_workers(self, wf_run: tuple[Result, Path], wf_pspec_file: Path):
         result, out_dir = wf_run
         path = Path(result.output.split("WF_PATH=")[1].splitlines()[0])
         result2 = invoke(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -588,9 +588,7 @@ class TestComputeWindowFunctions:
         assert "compute-window-functions" in result.output.lower()
 
     @pytest.fixture(scope="class")
-    def wf_run(
-        self, wf_pspec_file: Path, tmp_path_factory
-    ) -> tuple[Result, Path]:
+    def wf_run(self, wf_pspec_file: Path, tmp_path_factory) -> tuple[Result, Path]:
         ft_dir = tmp_path_factory.mktemp("ftcache-wf")
         ft_result = invoke(
             [

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -654,3 +654,81 @@ class TestComputeWindowFunctions:
         )
         assert result2.exit_code == 0
         assert path.stat().st_mtime == mtime  # not recomputed
+
+    def test_parallel_workers(
+        self, wf_run: tuple[Result, Path], wf_pspec_file: Path
+    ):
+        result, out_dir = wf_run
+        path = Path(result.output.split("WF_PATH=")[1].splitlines()[0])
+        result2 = invoke(
+            [
+                "compute-window-functions",
+                str(wf_pspec_file),
+                str(path),
+                "--dataset-label",
+                "clitest",
+                "--out-dir",
+                str(out_dir),
+                "--workers",
+                "2",
+            ]
+        )
+        assert result2.exit_code == 0, result2.output
+        assert "WF_PATH=" in result2.output
+
+    def test_out_of_range_spws(self, wf_run: tuple[Result, Path], wf_pspec_file: Path):
+        result, out_dir = wf_run
+        path = Path(result.output.split("WF_PATH=")[1].splitlines()[0])
+        result2 = invoke(
+            [
+                "compute-window-functions",
+                str(wf_pspec_file),
+                str(path),
+                "--spws",
+                "99",
+                "--dataset-label",
+                "clitest",
+                "--out-dir",
+                str(out_dir),
+            ]
+        )
+        assert isinstance(result2.exception, ValueError)
+        assert "out of range" in str(result2.exception)
+
+    def test_ambiguous_group(self, vanilla_uvp: UVPSpec, tmp_path: Path):
+        fname = tmp_path / "twogroups.pspec.h5"
+        psc = PSpecContainer(fname, "rw", keep_open=False)
+        psc.set_pspec("g1", "testps", vanilla_uvp)
+        psc.set_pspec("g2", "testps", vanilla_uvp)
+        result = invoke(
+            [
+                "compute-window-functions",
+                str(fname),
+                "unused.hdf5",
+                "--dataset-label",
+                "clitest",
+                "--out-dir",
+                str(tmp_path),
+            ]
+        )
+        assert isinstance(result.exception, ValueError)
+        assert "--group" in str(result.exception)
+
+    def test_ambiguous_name(self, vanilla_uvp: UVPSpec, tmp_path: Path):
+        fname = tmp_path / "twospectra.pspec.h5"
+        psc = PSpecContainer(fname, "rw", keep_open=False)
+        psc.set_pspec("g1", "ps1", vanilla_uvp)
+        psc.set_pspec("g1", "ps2", vanilla_uvp)
+        result = invoke(
+            [
+                "compute-window-functions",
+                str(fname),
+                "unused.hdf5",
+                "--dataset-label",
+                "clitest",
+                "--out-dir",
+                str(tmp_path),
+            ]
+        )
+        assert isinstance(result.exception, ValueError)
+        assert "--name" in str(result.exception)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,12 +6,14 @@ from dataclasses import dataclass
 from pathlib import Path
 
 import h5py
+import numpy as np
 import pytest
 
 from hera_pspec import cli, container, testing
 from hera_pspec.container import PSpecContainer
 from hera_pspec.data import DATA_PATH
 from hera_pspec.uvpspec import UVPSpec
+from hera_pspec.uvwindow import FTBeam
 
 
 @dataclass
@@ -500,3 +502,157 @@ def test_generate_pstokes_keep_vispols(monkeypatch):
     assert calls["deepcopy"] == 1
     assert calls["construct"] == 1  # one missing pol constructed in the loop
     assert calls["write"] == ("in.uvh5", True)
+
+
+@pytest.fixture(scope="module")
+def wf_pspec_file(tmp_path_factory, vanilla_uvp: UVPSpec) -> Path:
+    """A container with a single group/spectrum, so group/name inference applies."""
+    fname = tmp_path_factory.mktemp("wf-cli") / "vanilla.pspec.h5"
+    psc = PSpecContainer(fname, "rw", keep_open=False)
+    psc.set_pspec("testgroup", "testps", vanilla_uvp)
+    return fname
+
+
+WF_BEAMFILE = Path(DATA_PATH) / "HERA_NF_dipole_power.beamfits"
+
+
+class TestComputeFtBeam:
+    def test_help(self):
+        result = invoke(["compute-ft-beam", "--help"])
+        assert result.exit_code == 0, result.output
+        assert "compute-ft-beam" in result.output.lower()
+
+    @pytest.fixture(scope="class")
+    def ft_beam_run(self, wf_pspec_file: Path, tmp_path_factory) -> tuple[Result, Path]:
+        out_dir = tmp_path_factory.mktemp("ftcache")
+        result = invoke(
+            [
+                "compute-ft-beam",
+                str(WF_BEAMFILE),
+                "xx",
+                str(wf_pspec_file),
+                "--out-dir",
+                str(out_dir),
+                "--npix",
+                "29",
+            ]
+        )
+        return result, out_dir
+
+    @staticmethod
+    def _output_path(result: Result) -> Path:
+        return Path(result.output.split("FT_BEAM_PATH=")[1].splitlines()[0])
+
+    def test_writes_file_and_prints_path(self, ft_beam_run: tuple[Result, Path]):
+        result, out_dir = ft_beam_run
+        assert result.exit_code == 0
+        assert "FT_BEAM_PATH=" in result.output
+        path = self._output_path(result)
+        assert path.is_file()
+        assert path.parent == out_dir
+
+    def test_grid_is_taken_from_the_data(
+        self, ft_beam_run: tuple[Result, Path], vanilla_uvp: UVPSpec
+    ):
+        ftb = FTBeam.from_file(self._output_path(ft_beam_run[0]))
+        assert np.allclose(ftb.freq_array, np.unique(vanilla_uvp.freq_array))
+        assert ftb.pol == "xx"
+
+    def test_second_call_reuses_cache(
+        self, ft_beam_run: tuple[Result, Path], wf_pspec_file: Path
+    ):
+        result, out_dir = ft_beam_run
+        path = self._output_path(result)
+        mtime = path.stat().st_mtime
+        result2 = invoke(
+            [
+                "compute-ft-beam",
+                str(WF_BEAMFILE),
+                "xx",
+                str(wf_pspec_file),
+                "--out-dir",
+                str(out_dir),
+                "--npix",
+                "29",
+            ]
+        )
+        assert result2.exit_code == 0
+        assert self._output_path(result2) == path
+        assert path.stat().st_mtime == mtime  # not recomputed
+
+
+class TestComputeWindowFunctions:
+    def test_help(self):
+        result = invoke(["compute-window-functions", "--help"])
+        assert result.exit_code == 0, result.output
+        assert "compute-window-functions" in result.output.lower()
+
+    @pytest.fixture(scope="class")
+    def wf_run(
+        self, wf_pspec_file: Path, tmp_path_factory
+    ) -> tuple[Result, Path]:
+        ft_dir = tmp_path_factory.mktemp("ftcache-wf")
+        ft_result = invoke(
+            [
+                "compute-ft-beam",
+                str(WF_BEAMFILE),
+                "xx",
+                str(wf_pspec_file),
+                "--out-dir",
+                str(ft_dir),
+                "--npix",
+                "29",
+            ]
+        )
+        ft_path = ft_result.output.split("FT_BEAM_PATH=")[1].splitlines()[0]
+        out_dir = tmp_path_factory.mktemp("wfout")
+        result = invoke(
+            [
+                "compute-window-functions",
+                str(wf_pspec_file),
+                ft_path,
+                "--dataset-label",
+                "clitest",
+                "--out-dir",
+                str(out_dir),
+            ]
+        )
+        return result, out_dir
+
+    def test_writes_file_and_prints_path(self, wf_run: tuple[Result, Path]):
+        result, out_dir = wf_run
+        assert result.exit_code == 0
+        assert "WF_PATH=" in result.output
+        path = Path(result.output.split("WF_PATH=")[1].splitlines()[0])
+        assert path.is_file()
+        assert path.name == "wf_exact_xx_clitest_spw00.hdf5"
+
+    def test_file_contents(self, wf_run: tuple[Result, Path]):
+        result, _ = wf_run
+        path = Path(result.output.split("WF_PATH=")[1].splitlines()[0])
+        with h5py.File(path, "r") as f:
+            assert {"wf", "kperp", "kpara"} <= set(f.keys())
+            assert f["wf"].ndim == 5  # (Nblpairs, Ndlys, Nkperp, Nkpara, Npol)
+            assert f.attrs["dataset_label"] == "clitest"
+            assert f.attrs["polpair"] == "xx"
+            assert f.attrs["spw_index"] == 0
+
+    def test_second_call_reuses_file(
+        self, wf_run: tuple[Result, Path], wf_pspec_file: Path
+    ):
+        result, out_dir = wf_run
+        path = Path(result.output.split("WF_PATH=")[1].splitlines()[0])
+        mtime = path.stat().st_mtime
+        result2 = invoke(
+            [
+                "compute-window-functions",
+                str(wf_pspec_file),
+                str(path),  # reuse hit happens before the FT beam is touched
+                "--dataset-label",
+                "clitest",
+                "--out-dir",
+                str(out_dir),
+            ]
+        )
+        assert result2.exit_code == 0
+        assert path.stat().st_mtime == mtime  # not recomputed

--- a/tests/test_uvwindow.py
+++ b/tests/test_uvwindow.py
@@ -214,13 +214,11 @@ class TestFTBeamInit:
             uvwindow.FTBeam(pol=3.4, data=data, freq_array=freq_array, mapsize=mapsize)
 
 
-@pytest.fixture(scope="module")
-def nf_dipole_beamfits() -> Path:
-    return DATA_PATH / "HERA_NF_dipole_power.beamfits"
+nf_dipole_beamfits = DATA_PATH / "HERA_NF_dipole_power.beamfits"
 
 
 @pytest.fixture(scope="module")
-def nf_dipole_beam_freqs(nf_dipole_beamfits: Path) -> np.ndarray:
+def nf_dipole_beam_freqs() -> np.ndarray:
     beam = UVBeam()
     beam.read_beamfits(str(nf_dipole_beamfits))
     return np.unique(beam.freq_array)
@@ -229,7 +227,7 @@ def nf_dipole_beam_freqs(nf_dipole_beamfits: Path) -> np.ndarray:
 class TestFTBeamFromBeam:
     @pytest.fixture(scope="class")
     def small_ft_beam(
-        self, nf_dipole_beamfits: Path, nf_dipole_beam_freqs: np.ndarray
+        self, nf_dipole_beam_freqs: np.ndarray
     ) -> uvwindow.FTBeam:
         freq_array = np.linspace(
             nf_dipole_beam_freqs.min(), nf_dipole_beam_freqs.max(), 5
@@ -256,7 +254,7 @@ class TestFTBeamFromBeam:
             assert np.argmax(small_ft_beam.ft_beam[i]) == (ngrid**2) // 2
 
     def test_pol_as_int(
-        self, nf_dipole_beamfits: Path, small_ft_beam: uvwindow.FTBeam
+        self, small_ft_beam: uvwindow.FTBeam
     ) -> None:
         test = uvwindow.FTBeam.from_beam(
             beamfile=nf_dipole_beamfits,
@@ -269,7 +267,7 @@ class TestFTBeamFromBeam:
         assert np.allclose(test.ft_beam, small_ft_beam.ft_beam)
 
     def test_too_few_frequencies(
-        self, nf_dipole_beamfits: Path, nf_dipole_beam_freqs: np.ndarray
+        self, nf_dipole_beam_freqs: np.ndarray
     ) -> None:
         with pytest.raises(ValueError, match="at least three frequencies"):
             uvwindow.FTBeam.from_beam(
@@ -279,7 +277,7 @@ class TestFTBeamFromBeam:
             )
 
     def test_out_of_coverage_uses_edge_beam(
-        self, nf_dipole_beamfits: Path, nf_dipole_beam_freqs: np.ndarray
+        self, nf_dipole_beam_freqs: np.ndarray
     ) -> None:
         # frequencies slightly outside the simulation coverage: warn, and
         # evaluate the beam at the nearest covered frequency while keeping
@@ -300,7 +298,7 @@ class TestFTBeamFromBeam:
         assert np.allclose(test.ft_beam[0], test.ft_beam[1])
 
     def test_select_freqs_matches_direct_computation(
-        self, nf_dipole_beamfits: Path, nf_dipole_beam_freqs: np.ndarray
+        self, nf_dipole_beam_freqs: np.ndarray
     ) -> None:
         # interpolating a from_beam FT beam onto frequencies between its
         # channels must agree with computing the FT beam directly at those
@@ -365,6 +363,14 @@ class TestFTBeamFromFile:
     def test_no_spw_range_uses_full_bandwidth(self, ft_bandwidth: np.ndarray) -> None:
         test = uvwindow.FTBeam.from_file(ftfile=DATA_PATH / ftfile, spw_range=None)
         assert np.allclose(test.freq_array, ft_bandwidth)
+
+    @pytest.mark.parametrize(
+        "bad_freqs",
+        [np.array([250e6, 251e6]), np.array([100e6])],  # out of coverage; single
+    )
+    def test_invalid_freq_array(self, bad_freqs: np.ndarray) -> None:
+        with pytest.raises(ValueError):
+            uvwindow.FTBeam.from_file(ftfile=DATA_PATH / ftfile, freq_array=bad_freqs)
 
     @pytest.mark.parametrize("bad_spw", [(13,), (20, 10), (1001, 1022)])
     def test_invalid_spw_range(self, bad_spw: tuple[int, ...]) -> None:
@@ -1364,10 +1370,7 @@ class TestFTBeamWriteHdf5:
         fname = tmp_path / "ft_beam_roundtrip.hdf5"
         ft_beam_spw.write_hdf5(fname, extra_attrs={"beam_file": "sim.fits"})
         back = uvwindow.FTBeam.from_file(ftfile=fname)
-        assert back.pol == ft_beam_spw.pol
-        assert back.mapsize == ft_beam_spw.mapsize
-        assert np.allclose(back.freq_array, ft_beam_spw.freq_array)
-        assert np.allclose(back.ft_beam, ft_beam_spw.ft_beam)
+        assert back == ft_beam_spw
 
     def test_no_overwrite_by_default(
         self, ft_beam_spw: uvwindow.FTBeam, tmp_path: Path

--- a/tests/test_uvwindow.py
+++ b/tests/test_uvwindow.py
@@ -215,6 +215,7 @@ class TestFTBeamInit:
 
 
 nf_dipole_beamfits = DATA_PATH / "HERA_NF_dipole_power.beamfits"
+nf_efield_beamfits = DATA_PATH / "HERA_NF_efield.beamfits"
 
 
 @pytest.fixture(scope="module")
@@ -290,6 +291,46 @@ class TestFTBeamFromBeam:
         assert np.allclose(test.freq_array, freqs_over)
         # clamped channel = beam evaluated at the edge frequency
         assert np.allclose(test.ft_beam[0], test.ft_beam[1])
+
+    def test_even_npix_adjusted_to_odd(self, small_ft_beam: uvwindow.FTBeam) -> None:
+        # npix=30 is adjusted down to 29, reproducing small_ft_beam exactly
+        test = uvwindow.FTBeam.from_beam(
+            beamfile=nf_dipole_beamfits,
+            pol="xx",
+            freq_array=small_ft_beam.freq_array,
+            mapsize=1.0,
+            npix=30,
+        )
+        assert test == small_ft_beam
+
+    @pytest.mark.parametrize("mapsize", [0.35, uvwindow._MAX_R])
+    def test_mapsize_within_beam_coverage(
+        self, small_ft_beam: uvwindow.FTBeam, mapsize: float
+    ) -> None:
+        # mapsize < _MAX_R crops the beam map; mapsize = _MAX_R uses it as is
+        test = uvwindow.FTBeam.from_beam(
+            beamfile=nf_dipole_beamfits,
+            pol="xx",
+            freq_array=small_ft_beam.freq_array,
+            mapsize=mapsize,
+            npix=29,
+        )
+        assert test.ft_beam.shape[-1] <= 29
+        assert test.ft_beam.shape[-1] % 2 == 1
+        assert np.all(np.isfinite(test.ft_beam))
+
+    @pytest.mark.parametrize("pol", ["xx", "pI"])
+    def test_efield_beam_is_converted(self, pol: str) -> None:
+        # efield beams are converted to power (xx) or pseudo-Stokes (pI)
+        test = uvwindow.FTBeam.from_beam(
+            beamfile=nf_efield_beamfits,
+            pol=pol,
+            freq_array=np.linspace(120e6, 180e6, 3),
+            mapsize=1.0,
+            npix=29,
+        )
+        assert test.pol == pol
+        assert np.all(np.isfinite(test.ft_beam))
 
     def test_select_freqs_matches_direct_computation(
         self, nf_dipole_beam_freqs: np.ndarray
@@ -1365,6 +1406,7 @@ class TestFTBeamWriteHdf5:
         ft_beam_spw.write_hdf5(fname, extra_attrs={"beam_file": "sim.fits"})
         back = uvwindow.FTBeam.from_file(ftfile=fname)
         assert back == ft_beam_spw
+        assert back != 1  # non-FTBeam comparison falls through NotImplemented
 
     def test_no_overwrite_by_default(
         self, ft_beam_spw: uvwindow.FTBeam, tmp_path: Path

--- a/tests/test_uvwindow.py
+++ b/tests/test_uvwindow.py
@@ -226,9 +226,7 @@ def nf_dipole_beam_freqs() -> np.ndarray:
 
 class TestFTBeamFromBeam:
     @pytest.fixture(scope="class")
-    def small_ft_beam(
-        self, nf_dipole_beam_freqs: np.ndarray
-    ) -> uvwindow.FTBeam:
+    def small_ft_beam(self, nf_dipole_beam_freqs: np.ndarray) -> uvwindow.FTBeam:
         freq_array = np.linspace(
             nf_dipole_beam_freqs.min(), nf_dipole_beam_freqs.max(), 5
         )
@@ -253,9 +251,7 @@ class TestFTBeamFromBeam:
         for i in range(small_ft_beam.freq_array.size):
             assert np.argmax(small_ft_beam.ft_beam[i]) == (ngrid**2) // 2
 
-    def test_pol_as_int(
-        self, small_ft_beam: uvwindow.FTBeam
-    ) -> None:
+    def test_pol_as_int(self, small_ft_beam: uvwindow.FTBeam) -> None:
         test = uvwindow.FTBeam.from_beam(
             beamfile=nf_dipole_beamfits,
             pol=-5,
@@ -266,9 +262,7 @@ class TestFTBeamFromBeam:
         assert test.pol == "xx"
         assert np.allclose(test.ft_beam, small_ft_beam.ft_beam)
 
-    def test_too_few_frequencies(
-        self, nf_dipole_beam_freqs: np.ndarray
-    ) -> None:
+    def test_too_few_frequencies(self, nf_dipole_beam_freqs: np.ndarray) -> None:
         with pytest.raises(ValueError, match="at least three frequencies"):
             uvwindow.FTBeam.from_beam(
                 beamfile=nf_dipole_beamfits,

--- a/tests/test_uvwindow.py
+++ b/tests/test_uvwindow.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import numpy as np
 import pytest
 from astropy import units
-from pyuvdata import UVData
+from pyuvdata import UVBeam, UVData
 from pyuvdata import utils as uvutils
 
 from hera_pspec import PSpecData, UVPSpec, conversions, utils, uvwindow
@@ -24,7 +24,13 @@ outfile = "test.hdf5"
 @pytest.fixture()
 def make_ft_beam_obj() -> Callable[[tuple[int, int] | None], uvwindow.FTBeam]:
     def _factory(spw_range: tuple[int, int] | None = None) -> uvwindow.FTBeam:
-        return uvwindow.FTBeam.from_file(ftfile=DATA_PATH / ftfile, spw_range=spw_range)
+        # channel spans are expressed via freq_array (spw_range is deprecated)
+        if spw_range is None:
+            return uvwindow.FTBeam.from_file(ftfile=DATA_PATH / ftfile)
+        bandwidth = uvwindow.FTBeam.get_bandwidth(DATA_PATH / ftfile)
+        return uvwindow.FTBeam.from_file(
+            ftfile=DATA_PATH / ftfile, freq_array=bandwidth[spw_range[0] : spw_range[1]]
+        )
 
     return _factory
 
@@ -110,7 +116,10 @@ def uvp_for_uvwindow(
         baselines2,
         dsets=(0, 1),
         pols=[("xx", "xx")],
-        spw_ranges=(5, 25),
+        # NB: must be covered by the test FT-beam file (data channels
+        # 170-199): from_uvpspec checks that the data frequencies are
+        # within the FTBeam bandwidth
+        spw_ranges=(175, 195),
         taper=taper,
         verbose=False,
     )
@@ -205,17 +214,125 @@ class TestFTBeamInit:
             uvwindow.FTBeam(pol=3.4, data=data, freq_array=freq_array, mapsize=mapsize)
 
 
+@pytest.fixture(scope="module")
+def nf_dipole_beamfits() -> Path:
+    return DATA_PATH / "HERA_NF_dipole_power.beamfits"
+
+
+@pytest.fixture(scope="module")
+def nf_dipole_beam_freqs(nf_dipole_beamfits: Path) -> np.ndarray:
+    beam = UVBeam()
+    beam.read_beamfits(str(nf_dipole_beamfits))
+    return np.unique(beam.freq_array)
+
+
 class TestFTBeamFromBeam:
-    def test_not_implemented(self) -> None:
-        with pytest.raises(NotImplementedError, match="Coming soon"):
-            uvwindow.FTBeam.from_beam(beamfile="test")
+    @pytest.fixture(scope="class")
+    def small_ft_beam(
+        self, nf_dipole_beamfits: Path, nf_dipole_beam_freqs: np.ndarray
+    ) -> uvwindow.FTBeam:
+        freq_array = np.linspace(
+            nf_dipole_beam_freqs.min(), nf_dipole_beam_freqs.max(), 5
+        )
+        return uvwindow.FTBeam.from_beam(
+            beamfile=nf_dipole_beamfits,
+            pol="xx",
+            freq_array=freq_array,
+            mapsize=1.0,
+            npix=29,
+        )
+
+    def test_attributes(self, small_ft_beam: uvwindow.FTBeam) -> None:
+        assert small_ft_beam.pol == "xx"
+        assert small_ft_beam.ft_beam.ndim == 3
+        assert small_ft_beam.ft_beam.shape[0] == small_ft_beam.freq_array.size == 5
+        assert small_ft_beam.ft_beam.shape[1] == small_ft_beam.ft_beam.shape[2]
+        assert np.all(np.isfinite(small_ft_beam.ft_beam))
+
+    def test_ft_peaks_at_zero_mode(self, small_ft_beam: uvwindow.FTBeam) -> None:
+        # the FT of a positive beam peaks at the zero mode (grid centre)
+        ngrid = small_ft_beam.ft_beam.shape[-1]
+        for i in range(small_ft_beam.freq_array.size):
+            assert np.argmax(small_ft_beam.ft_beam[i]) == (ngrid**2) // 2
+
+    def test_pol_as_int(
+        self, nf_dipole_beamfits: Path, small_ft_beam: uvwindow.FTBeam
+    ) -> None:
+        test = uvwindow.FTBeam.from_beam(
+            beamfile=nf_dipole_beamfits,
+            pol=-5,
+            freq_array=small_ft_beam.freq_array,
+            mapsize=1.0,
+            npix=29,
+        )
+        assert test.pol == "xx"
+        assert np.allclose(test.ft_beam, small_ft_beam.ft_beam)
+
+    def test_too_few_frequencies(
+        self, nf_dipole_beamfits: Path, nf_dipole_beam_freqs: np.ndarray
+    ) -> None:
+        with pytest.raises(ValueError, match="at least three frequencies"):
+            uvwindow.FTBeam.from_beam(
+                beamfile=nf_dipole_beamfits,
+                pol="xx",
+                freq_array=nf_dipole_beam_freqs[:2],
+            )
+
+    def test_out_of_coverage_uses_edge_beam(
+        self, nf_dipole_beamfits: Path, nf_dipole_beam_freqs: np.ndarray
+    ) -> None:
+        # frequencies slightly outside the simulation coverage: warn, and
+        # evaluate the beam at the nearest covered frequency while keeping
+        # the requested frequencies as the FTBeam coordinates
+        df = np.diff(nf_dipole_beam_freqs).mean()
+        fmin = nf_dipole_beam_freqs.min()
+        freqs_over = np.array([fmin - df / 2, fmin, fmin + df])
+        with pytest.warns(UserWarning, match="outside the beam simulation"):
+            test = uvwindow.FTBeam.from_beam(
+                beamfile=nf_dipole_beamfits,
+                pol="xx",
+                freq_array=freqs_over,
+                mapsize=1.0,
+                npix=29,
+            )
+        assert np.allclose(test.freq_array, freqs_over)
+        # clamped channel = beam evaluated at the edge frequency
+        assert np.allclose(test.ft_beam[0], test.ft_beam[1])
+
+    def test_select_freqs_matches_direct_computation(
+        self, nf_dipole_beamfits: Path, nf_dipole_beam_freqs: np.ndarray
+    ) -> None:
+        # interpolating a from_beam FT beam onto frequencies between its
+        # channels must agree with computing the FT beam directly at those
+        # frequencies. The 6.25 MHz source grid used here is far coarser
+        # than any production grid (~122 kHz), so the 2%-of-peak bound is
+        # loose.
+        fine = np.linspace(nf_dipole_beam_freqs.min(), nf_dipole_beam_freqs.max(), 17)
+        target = 0.5 * (fine[:-1] + fine[1:])[::2]
+        ft_fine = uvwindow.FTBeam.from_beam(
+            beamfile=nf_dipole_beamfits, pol="xx", freq_array=fine, mapsize=1.0, npix=29
+        )
+        ft_direct = uvwindow.FTBeam.from_beam(
+            beamfile=nf_dipole_beamfits,
+            pol="xx",
+            freq_array=target,
+            mapsize=1.0,
+            npix=29,
+        )
+        with pytest.warns(UserWarning, match="interpolating"):
+            ft_interp = ft_fine.select_freqs(target, inplace=False)
+        assert np.allclose(
+            ft_interp.ft_beam,
+            ft_direct.ft_beam,
+            atol=0.02 * np.abs(ft_direct.ft_beam).max(),
+        )
 
 
 class TestFTBeamFromFile:
-    def test_happy_path(self) -> None:
+    def test_happy_path(self, ft_bandwidth: np.ndarray) -> None:
         test = uvwindow.FTBeam.from_file(
             ftfile=DATA_PATH / ftfile,
-            spw_range=(5, 25),
+            freq_array=ft_bandwidth[5:25],
             verbose=False,
             x_orientation="east",
         )
@@ -236,9 +353,11 @@ class TestFTBeamFromFile:
     def test_spw_range_matches_fixture(
         self, make_ft_beam_obj: Callable[[tuple[int, int] | None], uvwindow.FTBeam]
     ) -> None:
+        # deprecated channel-index selection agrees with freq_array selection
         ft_file = DATA_PATH / ftfile
         spw_range = (5, 25)
-        test = uvwindow.FTBeam.from_file(ftfile=ft_file, spw_range=spw_range)
+        with pytest.warns(DeprecationWarning, match="spw_range"):
+            test = uvwindow.FTBeam.from_file(ftfile=ft_file, spw_range=spw_range)
         assert np.allclose(
             test.freq_array, make_ft_beam_obj(spw_range=spw_range).freq_array
         )
@@ -249,7 +368,10 @@ class TestFTBeamFromFile:
 
     @pytest.mark.parametrize("bad_spw", [(13,), (20, 10), (1001, 1022)])
     def test_invalid_spw_range(self, bad_spw: tuple[int, ...]) -> None:
-        with pytest.raises(ValueError, match="Wrong spw range format"):
+        with (
+            pytest.warns(DeprecationWarning, match="spw_range"),
+            pytest.raises(ValueError, match="Wrong spw range format"),
+        ):
             uvwindow.FTBeam.from_file(spw_range=bad_spw, ftfile=DATA_PATH / ftfile)
 
 
@@ -306,12 +428,16 @@ class TestFTBeamGetBandwidth:
 class TestFTBeamUpdateSpw:
     def test_happy_path(self) -> None:
         test = uvwindow.FTBeam.from_file(ftfile=DATA_PATH / ftfile, spw_range=None)
-        test.update_spw((5, 25))
+        with pytest.warns(DeprecationWarning, match="select_freqs"):
+            test.update_spw((5, 25))
 
     @pytest.mark.parametrize("bad_spw", [(13,), (20, 10), (1001, 1022)])
     def test_invalid_range(self, bad_spw: tuple[int, ...]) -> None:
         test = uvwindow.FTBeam.from_file(ftfile=DATA_PATH / ftfile, spw_range=None)
-        with pytest.raises(ValueError, match="Wrong spw range format"):
+        with (
+            pytest.warns(DeprecationWarning, match="select_freqs"),
+            pytest.raises(ValueError, match="Wrong spw range format"),
+        ):
             test.update_spw(spw_range=bad_spw)
 
 
@@ -406,7 +532,7 @@ class TestUVWindowFromUvpspec:
         self, uvp_for_uvwindow: tuple[UVPSpec, UVPSpec, UVPSpec]
     ) -> None:
         uvp, _, _ = uvp_for_uvwindow
-        with pytest.raises(NotImplementedError, match="Coming soon"):
+        with pytest.raises(NotImplementedError, match="Construct the FTBeam"):
             uvwindow.UVWindow.from_uvpspec(
                 uvp=uvp, ipol=0, spw=0, ftbeam=None, verbose=False
             )
@@ -720,9 +846,11 @@ class TestUVWindowGetCylindricalWf:
                 return_bins="unweighted",
             )
 
-    def test_odd_number_of_delays(self, red_bl_lens: np.ndarray) -> None:
+    def test_odd_number_of_delays(
+        self, red_bl_lens: np.ndarray, ft_bandwidth: np.ndarray
+    ) -> None:
         ft_beam_test = uvwindow.FTBeam.from_file(
-            ftfile=DATA_PATH / ftfile, spw_range=(5, 24)
+            ftfile=DATA_PATH / ftfile, freq_array=ft_bandwidth[5:24]
         )
         test = uvwindow.UVWindow(ftbeam_obj=ft_beam_test)
         kperp, kpara, cyl_wf = test.get_cylindrical_wf(
@@ -1159,3 +1287,196 @@ class TestUVWindowRunAndWrite:
                 kpara_bins=kpara_bins.value * units.Mpc,
                 clobber=True,
             )
+
+
+class TestFTBeamSelectFreqs:
+    def test_exact_match_extracts_channels(self, ft_bandwidth: np.ndarray) -> None:
+        full = uvwindow.FTBeam.from_file(ftfile=DATA_PATH / ftfile)
+        sub = full.select_freqs(ft_bandwidth[3:10], inplace=False)
+        assert np.allclose(sub.freq_array, ft_bandwidth[3:10])
+        assert np.array_equal(sub.ft_beam, full.ft_beam[3:10])
+        # with inplace=False the original is untouched
+        assert full.freq_array.size == ft_bandwidth.size
+
+    def test_mismatched_grid_interpolates_with_warning(
+        self, ft_bandwidth: np.ndarray
+    ) -> None:
+        # midpoints of a linear grid: linear interpolation is exactly the
+        # average of the neighbouring channels
+        full = uvwindow.FTBeam.from_file(ftfile=DATA_PATH / ftfile)
+        midpoints = 0.5 * (ft_bandwidth[3:10] + ft_bandwidth[4:11])
+        with pytest.warns(UserWarning, match="interpolating"):
+            interp = full.select_freqs(midpoints, inplace=False)
+        assert np.allclose(interp.freq_array, midpoints)
+        assert np.allclose(
+            interp.ft_beam, 0.5 * (full.ft_beam[3:10] + full.ft_beam[4:11])
+        )
+
+    def test_out_of_coverage_raises(self, ft_bandwidth: np.ndarray) -> None:
+        full = uvwindow.FTBeam.from_file(ftfile=DATA_PATH / ftfile)
+        with pytest.raises(ValueError, match="beyond the bandwidth"):
+            full.select_freqs(np.array([ft_bandwidth.max() + 1e6] * 3))
+
+    def test_single_frequency_raises(self, ft_bandwidth: np.ndarray) -> None:
+        full = uvwindow.FTBeam.from_file(ftfile=DATA_PATH / ftfile)
+        with pytest.raises(ValueError, match="at least two frequencies"):
+            full.select_freqs(ft_bandwidth[:1])
+
+
+class TestFTBeamFromFileFreqArray:
+    def test_partial_read_matches_full_read(self, ft_bandwidth: np.ndarray) -> None:
+        full = uvwindow.FTBeam.from_file(ftfile=DATA_PATH / ftfile)
+        target = ft_bandwidth[5:25]
+        test = uvwindow.FTBeam.from_file(ftfile=DATA_PATH / ftfile, freq_array=target)
+        assert np.allclose(test.freq_array, target)
+        assert np.array_equal(test.ft_beam, full.ft_beam[5:25])
+
+    def test_both_selections_raise(self, ft_bandwidth: np.ndarray) -> None:
+        with pytest.raises(ValueError, match="both spw_range and freq_array"):
+            uvwindow.FTBeam.from_file(
+                ftfile=DATA_PATH / ftfile,
+                spw_range=(5, 25),
+                freq_array=ft_bandwidth[5:25],
+            )
+
+    def test_interpolation_through_partial_read(self, ft_bandwidth: np.ndarray) -> None:
+        # requested frequencies fall between the file's channels, so
+        # select_freqs interpolates using only the padded channel range
+        # read from disk; must equal loading the whole file and
+        # interpolating. Starts at the first channel pair to stress the
+        # edge padding.
+        full = uvwindow.FTBeam.from_file(ftfile=DATA_PATH / ftfile)
+        midpoints = 0.5 * (ft_bandwidth[0:8] + ft_bandwidth[1:9])
+        with pytest.warns(UserWarning, match="interpolating"):
+            part = uvwindow.FTBeam.from_file(
+                ftfile=DATA_PATH / ftfile, freq_array=midpoints
+            )
+        with pytest.warns(UserWarning, match="interpolating"):
+            ref = full.select_freqs(midpoints, inplace=False)
+        assert np.allclose(part.freq_array, ref.freq_array)
+        assert np.allclose(part.ft_beam, ref.ft_beam)
+
+
+class TestFTBeamWriteHdf5:
+    def test_roundtrip(self, ft_beam_spw: uvwindow.FTBeam, tmp_path: Path) -> None:
+        # the filename carries no pol suffix: the round trip relies on the
+        # pol attribute written by write_hdf5
+        fname = tmp_path / "ft_beam_roundtrip.hdf5"
+        ft_beam_spw.write_hdf5(fname, extra_attrs={"beam_file": "sim.fits"})
+        back = uvwindow.FTBeam.from_file(ftfile=fname)
+        assert back.pol == ft_beam_spw.pol
+        assert back.mapsize == ft_beam_spw.mapsize
+        assert np.allclose(back.freq_array, ft_beam_spw.freq_array)
+        assert np.allclose(back.ft_beam, ft_beam_spw.ft_beam)
+
+    def test_no_overwrite_by_default(
+        self, ft_beam_spw: uvwindow.FTBeam, tmp_path: Path
+    ) -> None:
+        fname = tmp_path / "ft_beam.hdf5"
+        ft_beam_spw.write_hdf5(fname)
+        with pytest.raises(FileExistsError, match="overwrite"):
+            ft_beam_spw.write_hdf5(fname)
+        ft_beam_spw.write_hdf5(fname, overwrite=True)
+
+
+class TestFTBeamDataGridMismatch:
+    """Regression tests: an FTBeam on a frequency grid with a different
+    channel width than the data must yield the same window functions as an
+    FTBeam defined directly on the data channels (historically, the window
+    functions' k_parallel axis silently came out scaled by the ratio of
+    the two channel widths)."""
+
+    # "data" channels: 500 kHz; FT beam computed on 400 kHz channels
+    freqs_data = np.linspace(155e6, 165e6, 20, endpoint=False)
+    freqs_beam = np.arange(150e6, 170e6, 0.4e6)
+
+    @staticmethod
+    def _gaussian(freqs: np.ndarray) -> uvwindow.FTBeam:
+        widths = -0.0343 * freqs / 1e6 + 11.30
+        return uvwindow.FTBeam.gaussian(freqs, widths, pol="xx", npix=101)
+
+    def test_delay_grid_matches_data_channel_width(self) -> None:
+        with pytest.warns(UserWarning, match="interpolating"):
+            ftb = self._gaussian(self.freqs_beam).select_freqs(
+                self.freqs_data, inplace=False
+            )
+        uvw = uvwindow.UVWindow(ftbeam_obj=ftb, taper="blackman-harris")
+        assert np.allclose(uvw.freq_array, self.freqs_data)
+        assert np.isclose(np.median(np.diff(uvw.dly_array)), 1.0 / (20 * 0.5e6))
+
+    def test_cylindrical_wf_matches_direct_grid(self) -> None:
+        bl_len = 15.0
+        with pytest.warns(UserWarning, match="interpolating"):
+            ftb_interp = self._gaussian(self.freqs_beam).select_freqs(
+                self.freqs_data, inplace=False
+            )
+        uvw = uvwindow.UVWindow(ftbeam_obj=ftb_interp, taper="blackman-harris")
+        uvw_direct = uvwindow.UVWindow(
+            ftbeam_obj=self._gaussian(self.freqs_data), taper="blackman-harris"
+        )
+        kperp_bins = uvw_direct.get_kperp_bins([bl_len])
+        kpara_bins = uvw_direct.get_kpara_bins(self.freqs_data)
+        wf_interp = uvw.get_cylindrical_wf(
+            bl_len, kperp_bins=kperp_bins, kpara_bins=kpara_bins
+        )
+        wf_direct = uvw_direct.get_cylindrical_wf(
+            bl_len, kperp_bins=kperp_bins, kpara_bins=kpara_bins
+        )
+        # up to interpolation accuracy of the slowly-varying gaussian beam
+        assert np.allclose(wf_interp, wf_direct, atol=1e-4)
+
+
+class TestGetWfForTauKnownExamples:
+    """Check the k_parallel binning at its two granularity extremes.
+
+    At the coarsest extreme (one bin wide enough to hold the whole band)
+    binning must reduce to a plain mean over frequency; at the finest
+    (one bin per k_parallel value) it must return the input unchanged.
+    Together these pin the bin assignment, the averaging and the
+    empty-bin behavior with answers that can be checked by hand.
+    """
+
+    @staticmethod
+    def _kpar_norm(uvw: uvwindow.UVWindow, tau: float) -> np.ndarray:
+        alpha = uvw.cosmo.dRpara_df(uvw.avg_z, little_h=uvw.little_h, ghz=False)
+        delta_nu = np.median(np.diff(uvw.freq_array))
+        eta = np.fft.fftshift(np.fft.fftfreq(uvw.Nfreqs)) / delta_nu
+        return np.abs(2.0 * np.pi / alpha * (eta + tau))
+
+    def test_single_bin_gets_row_means(self, uvwindow_obj: uvwindow.UVWindow) -> None:
+        # coarsest extreme: one bin holds every kpar value (flanked by
+        # empty bins), so its column must be the plain frequency-mean of
+        # each row of wf_array1, and the empty bins must stay zero
+        uvw = uvwindow_obj
+        # any tau works here; 2/delta_nu keeps kpar_norm strictly positive
+        tau = 2.0 / np.median(np.diff(uvw.freq_array))
+        kpar = self._kpar_norm(uvw, tau)
+        dk = (kpar.max() - kpar.min()) + 1.0
+        kpara_bins = np.array([kpar.mean() - dk, kpar.mean(), kpar.mean() + dk])
+        kperp_bins = np.arange(1.0, 6.0)
+        rng = np.random.default_rng(0)
+        wf1 = rng.random((kperp_bins.size, uvw.Nfreqs))
+
+        kpara_out, cyl = uvw._get_wf_for_tau(tau, wf1, kperp_bins, kpara_bins)
+        assert np.allclose(cyl[:, 1], wf1.mean(axis=1))
+        assert np.allclose(cyl[:, [0, 2]], 0.0)
+        assert np.isclose(kpara_out[1], kpar.mean())
+        assert np.allclose(kpara_out[[0, 2]], 0.0)
+
+    def test_resolved_bins_are_identity(self, uvwindow_obj: uvwindow.UVWindow) -> None:
+        # finest extreme: bins centred on each kpar value, so binning
+        # must be the identity. tau = 2/delta_nu exceeds max|eta| =
+        # 1/(2 delta_nu), keeping eta + tau positive so kpar_norm
+        # inherits eta's equal spacing (each value lands in its own bin)
+        uvw = uvwindow_obj
+        tau = 2.0 / np.median(np.diff(uvw.freq_array))
+        kpar = self._kpar_norm(uvw, tau)
+        assert np.all(np.diff(kpar) > 0)  # monotonic by construction
+        kpara_bins = kpar  # equally spaced since eta is
+        kperp_bins = np.arange(1.0, 6.0)
+        rng = np.random.default_rng(1)
+        wf1 = rng.random((kperp_bins.size, uvw.Nfreqs))
+
+        kpara_out, cyl = uvw._get_wf_for_tau(tau, wf1, kperp_bins, kpara_bins)
+        assert np.allclose(cyl, wf1)
+        assert np.allclose(kpara_out, kpar)


### PR DESCRIPTION
Addresses #451 (will be fully closed when I also address hera_pipelines accordingly). Moves the FT-beam and window function production scripts from hera_pipelines into hera_pspec as `pspec compute-ft-beam` / `pspec compute-window-functions`.

Note that working on this exposed a bug that affected the IDR3.1.1a theory release window functions: `UVWindow.from_uvpspec` assumed the FT beam and the data share a channel width, but I was accidentally computing the FT beam on a 97.66 kHz grid vs the data's 122.07 kHz, scaling the WFs' k_parallel axis by 1.25x. To prevent this error in the future, I forced the FT beam to be computed on the data's exact channels (`FTBeam.select_freqs`; interpolates with a warning on mismatch, raises an exception if not covered).

- commit 1: the bug fix + regression tests
- commit 2: vectorized cylindrical binning (~20x faster; new test pins it to the old loop implementation at 1e-12)
- commit 3: `FTBeam.from_beam` (port of @adeliegorce's routine, az_za + healpix), `write_hdf5`, the two CLI commands

Parts of this were done with the help of Claude (Fable 5), e.g., for finding the vectorization, and documenting/cleaning up.